### PR TITLE
fix: Bad object-property transformation

### DIFF
--- a/packages/swc-plugin/src/shared/regex.rs
+++ b/packages/swc-plugin/src/shared/regex.rs
@@ -21,9 +21,6 @@ pub(crate) static DASHIFY_REGEX: Lazy<Regex> =
 pub(crate) static SANITIZE_CLASS_NAME_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"[^.a-zA-Z0-9_-]").unwrap());
 
-pub(crate) static IDENT_PROP_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^[a-zA-Z\d$_]*$").unwrap());
-
 pub(crate) static WHITESPACE_NORMALIZER_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r#"(\))(\S)|(\")(\")"#).unwrap());
 

--- a/packages/swc-plugin/src/shared/utils/ast/convertors.rs
+++ b/packages/swc-plugin/src/shared/utils/ast/convertors.rs
@@ -10,7 +10,6 @@ use swc_core::{
 use crate::shared::{
   constants::messages::{ILLEGAL_PROP_VALUE, NON_STATIC_VALUE},
   enums::misc::VarDeclAction,
-  regex::IDENT_PROP_REGEX,
   structures::{functions::FunctionMap, state::EvaluationState, state_manager::StateManager},
   utils::{
     common::{
@@ -511,14 +510,13 @@ pub(crate) fn null_to_expression() -> Expr {
 }
 
 pub(crate) fn string_to_prop_name(value: &str) -> Option<PropName> {
-  if IDENT_PROP_REGEX.is_match(value) && value.parse::<i64>().is_err() {
-    Some(PropName::Ident(ident_name_factory(value)))
-  } else {
-    Some(PropName::Str(Str {
+  match Ident::verify_symbol(value) {
+    Ok(_) => Some(PropName::Ident(ident_name_factory(value))),
+    Err(_) => Some(PropName::Str(Str {
       span: DUMMY_SP,
       value: value.into(),
       raw: None,
-    }))
+    })),
   }
 }
 

--- a/packages/swc-plugin/tests/__swc_snapshots__/tests/stylex_number_property_test/stylex_number_property_test.rs/stylex_number_property_is_supported.js
+++ b/packages/swc-plugin/tests/__swc_snapshots__/tests/stylex_number_property_test/stylex_number_property_test.rs/stylex_number_property_is_supported.js
@@ -1,0 +1,7 @@
+//__stylex_metadata_start__[{"class_name":"xm1nzai","style":{"rtl":null,"ltr":":root{--x1rcl4l6:4;--x1eptlkq:8;}"},"priority":0}]__stylex_metadata_end__
+import stylex from 'stylex';
+export const vars = {
+    xl: "var(--x1rcl4l6)",
+    "2xl": "var(--x1eptlkq)",
+    __themeName__: "xm1nzai"
+};

--- a/packages/swc-plugin/tests/stylex_number_property_test/mod.rs
+++ b/packages/swc-plugin/tests/stylex_number_property_test/mod.rs
@@ -1,0 +1,1 @@
+mod stylex_number_property_test;

--- a/packages/swc-plugin/tests/stylex_number_property_test/stylex_number_property_test.rs
+++ b/packages/swc-plugin/tests/stylex_number_property_test/stylex_number_property_test.rs
@@ -1,0 +1,33 @@
+use stylex_swc_plugin::{shared::structures::plugin_pass::PluginPass, ModuleTransformVisitor};
+use swc_core::{
+  common::FileName,
+  ecma::{
+    parser::{Syntax, TsSyntax},
+    transforms::testing::test,
+  },
+};
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| {
+    ModuleTransformVisitor::new_test(
+      tr.comments.clone(),
+      &PluginPass {
+        cwd: None,
+        filename: FileName::Real("/stylex/packages/TestTheme.stylex.js".into()),
+      },
+      None,
+    )
+  },
+  stylex_number_property_is_supported,
+  r#"
+        import stylex from 'stylex';
+        export const vars = stylex.defineVars({
+          xl: 4,
+          "2xl": 8,
+        });
+    "#
+);


### PR DESCRIPTION
The current property name validation is too simple and doesn't catch cases like:

```json
{ "2xl": ... } 
```

We can leverage `Ident::verify_symbol` to check this.