### PR TITLE
feat(ast convertors): wrap object key in quotes when starting with a number

### DIFF
--- a/.changeset/perfect-days-talk.md
+++ b/.changeset/perfect-days-talk.md
@@ -1,0 +1,5 @@
+---
+'@stylexswc/swc-plugin': patch
+---
+
+wrap object key in quotes when starting with a number

--- a/packages/swc-plugin/Cargo.lock
+++ b/packages/swc-plugin/Cargo.lock
@@ -1552,6 +1552,7 @@ dependencies = [
  "serde_json",
  "stylex_path_resolver",
  "swc_core",
+ "swc_ecma_parser",
  "testing 0.38.1",
 ]
 
@@ -1838,6 +1839,7 @@ dependencies = [
  "swc_atoms",
  "swc_common 0.34.4",
  "swc_ecma_ast",
+ "swc_ecma_visit",
  "tracing",
  "typed-arena",
 ]

--- a/packages/swc-plugin/Cargo.toml
+++ b/packages/swc-plugin/Cargo.toml
@@ -50,6 +50,7 @@ node-resolve = { version = "2.2.0" }
 path-clean = { version = "1.0.1" }
 cssparser = { version = "0.34.0" }
 stylex_path_resolver = { path = "../path-resolver" }
+swc_ecma_parser = {version = "*", features = ["verify"]}
 
 [dev-dependencies]
 swc_core = { version = "0.96.9", features = [

--- a/packages/swc-plugin/src/shared/regex.rs
+++ b/packages/swc-plugin/src/shared/regex.rs
@@ -21,9 +21,6 @@ pub(crate) static DASHIFY_REGEX: Lazy<Regex> =
 pub(crate) static SANITIZE_CLASS_NAME_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"[^.a-zA-Z0-9_-]").unwrap());
 
-pub(crate) static IDENT_PROP_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^[a-zA-Z\d$_]*$").unwrap());
-
 pub(crate) static WHITESPACE_NORMALIZER_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r#"(\))(\S)|(\")(\")"#).unwrap());
 

--- a/packages/swc-plugin/src/shared/transformers/stylex_include.rs
+++ b/packages/swc-plugin/src/shared/transformers/stylex_include.rs
@@ -1,10 +1,12 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use swc_core::ecma::ast::{Expr, KeyValueProp, Prop, PropName, PropOrSpread};
+use swc_core::ecma::{
+  ast::{Expr, KeyValueProp, Prop, PropName, PropOrSpread},
+  utils::quote_ident,
+};
 
 use crate::shared::{
-  constants::messages::ILLEGAL_ARGUMENT_LENGTH,
-  utils::ast::factories::{ident_name_factory, object_expression_factory},
+  constants::messages::ILLEGAL_ARGUMENT_LENGTH, utils::ast::factories::object_expression_factory,
 };
 
 static NUMBER: AtomicUsize = AtomicUsize::new(1);
@@ -22,7 +24,7 @@ pub(crate) fn stylex_include(args: Vec<Expr>) -> Expr {
   let first_arg = &args[0];
 
   let prop = Prop::from(KeyValueProp {
-    key: PropName::Ident(ident_name_factory(uuid().as_str())),
+    key: PropName::Ident(quote_ident!(uuid().as_str())),
     value: Box::new(first_arg.clone()),
   });
 

--- a/packages/swc-plugin/src/shared/utils/ast/factories.rs
+++ b/packages/swc-plugin/src/shared/utils/ast/factories.rs
@@ -65,12 +65,6 @@ pub(crate) fn ident_factory(name: &str) -> Ident {
   Ident::from(name)
 }
 
-pub(crate) fn ident_name_factory(name: &str) -> Ident {
-  ident_factory(name)
-  // TODO: Uncomment this line to use after migration to swc_core >= 0.99.*
-  // IdentName::from(name)
-}
-
 // NOTE: Tests only using this function
 #[allow(dead_code)]
 pub(crate) fn prop_or_spread_expr_factory(key: &str, values: Vec<PropOrSpread>) -> PropOrSpread {

--- a/packages/swc-plugin/src/shared/utils/ast/mod.rs
+++ b/packages/swc-plugin/src/shared/utils/ast/mod.rs
@@ -1,2 +1,3 @@
 pub mod convertors;
 pub mod factories;
+pub(crate) mod tests;

--- a/packages/swc-plugin/src/shared/utils/ast/tests/convertors_tests.rs
+++ b/packages/swc-plugin/src/shared/utils/ast/tests/convertors_tests.rs
@@ -1,0 +1,34 @@
+#[cfg(test)]
+mod tests {
+  use crate::shared::utils::ast::convertors::string_to_prop_name;
+
+  #[test]
+  fn string_to_prop_name_with_quotes() {
+    let keys_with_quotes = vec!["2ip", "123", "1b3", "1bc", "2xl", "x*x", "x-x", "x,x"];
+
+    for key in keys_with_quotes {
+      assert!(
+        string_to_prop_name(key).unwrap().is_str(),
+        "Key '{}' should be wrapped in quotes",
+        key
+      );
+    }
+  }
+
+  #[test]
+  fn string_to_prop_name_without_quotes() {
+    let keys_without_quotes = vec![
+      "abc", "abc$", "abc_", "_abc_", "$abc_", "$abc$", "ABC", "_ABC_", "$ABC$", "$ABC123",
+      "$123AB", "xl", "if", "else", "for", "while", "do", "switch", "case", "default", "break",
+      "x_x", "x$x",
+    ];
+
+    for key in keys_without_quotes {
+      assert!(
+        string_to_prop_name(key).unwrap().is_ident(),
+        "Key '{}' should not be wrapped in quotes",
+        key
+      );
+    }
+  }
+}

--- a/packages/swc-plugin/src/shared/utils/ast/tests/mod.rs
+++ b/packages/swc-plugin/src/shared/utils/ast/tests/mod.rs
@@ -1,0 +1,1 @@
+mod convertors_tests;

--- a/packages/swc-plugin/src/shared/utils/core/evaluate_stylex_create_arg.rs
+++ b/packages/swc-plugin/src/shared/utils/core/evaluate_stylex_create_arg.rs
@@ -1,9 +1,12 @@
 use indexmap::IndexMap;
 use swc_core::{
   common::DUMMY_SP,
-  ecma::ast::{
-    ArrowExpr, BinExpr, BinaryOp, BindingIdent, BlockStmtOrExpr, CallExpr, Callee, CondExpr, Expr,
-    ExprOrSpread, KeyValueProp, ObjectLit, Pat, Prop, PropOrSpread, UnaryExpr, UnaryOp,
+  ecma::{
+    ast::{
+      ArrowExpr, BinExpr, BinaryOp, BindingIdent, BlockStmtOrExpr, CallExpr, Callee, CondExpr,
+      Expr, ExprOrSpread, KeyValueProp, ObjectLit, Pat, Prop, PropOrSpread, UnaryExpr, UnaryOp,
+    },
+    utils::quote_ident,
   },
 };
 
@@ -22,9 +25,7 @@ use crate::shared::{
         expr_to_str, ident_to_expression, null_to_expression, string_to_expression,
         transform_shorthand_to_key_values,
       },
-      factories::{
-        ident_name_factory, object_expression_factory, prop_or_spread_expression_factory,
-      },
+      factories::{object_expression_factory, prop_or_spread_expression_factory},
     },
     common::{create_hash, normalize_expr},
     css::common::get_number_suffix,
@@ -315,7 +316,7 @@ fn evaluate_partial_object_recursively(
                       span: DUMMY_SP,
                       callee: Callee::Expr(Box::new(Expr::Arrow(ArrowExpr {
                         span: DUMMY_SP,
-                        params: vec![Pat::Ident(BindingIdent::from(ident_name_factory("val")))],
+                        params: vec![Pat::Ident(BindingIdent::from(quote_ident!("val")))],
                         body: Box::new(BlockStmtOrExpr::Expr(Box::new(Expr::Cond(CondExpr {
                           span: DUMMY_SP,
                           test: Box::new(Expr::from(BinExpr {

--- a/packages/swc-plugin/src/shared/utils/core/flatten_raw_style_object.rs
+++ b/packages/swc-plugin/src/shared/utils/core/flatten_raw_style_object.rs
@@ -1,9 +1,11 @@
 use indexmap::IndexMap;
 use regex::Regex;
-use swc_core::{
-  common::DUMMY_SP,
-  ecma::ast::{Expr, KeyValueProp, Prop, PropName, PropOrSpread, Str},
-};
+use swc_core::
+  ecma::{
+    ast::{Expr, KeyValueProp, Prop, PropName, PropOrSpread},
+    utils::quote_str,
+  }
+;
 
 use crate::shared::{
   constants::messages::{ILLEGAL_PROP_ARRAY_VALUE, ILLEGAL_PROP_VALUE, NON_STATIC_VALUE},
@@ -233,11 +235,7 @@ pub(crate) fn flatten_raw_style_object(
                     at_rules_to_pass_down.push(condition.clone());
                   }
 
-                  inner_key_value.key = PropName::Str(Str {
-                    span: DUMMY_SP,
-                    value: css_property_key.clone().into(),
-                    raw: None,
-                  });
+                  inner_key_value.key = PropName::Str(quote_str!(css_property_key.clone()));
 
                   let pairs = flatten_raw_style_object(
                     &[inner_key_value],

--- a/packages/swc-plugin/src/shared/utils/core/make_string_expression.rs
+++ b/packages/swc-plugin/src/shared/utils/core/make_string_expression.rs
@@ -1,8 +1,11 @@
 use swc_core::{
   common::DUMMY_SP,
-  ecma::ast::{
-    BinExpr, BinaryOp, ComputedPropName, Expr, KeyValueProp, MemberExpr, MemberProp, Prop,
-    PropName, PropOrSpread, UnaryExpr, UnaryOp,
+  ecma::{
+    ast::{
+      BinExpr, BinaryOp, ComputedPropName, Expr, KeyValueProp, MemberExpr, MemberProp, Prop,
+      PropName, PropOrSpread, UnaryExpr, UnaryOp,
+    },
+    utils::quote_ident,
   },
 };
 
@@ -10,7 +13,7 @@ use crate::shared::{
   enums::data_structures::fn_result::FnResult,
   utils::ast::{
     convertors::{number_to_expression, string_to_expression},
-    factories::{ident_name_factory, object_expression_factory},
+    factories::object_expression_factory,
   },
 };
 
@@ -77,7 +80,7 @@ pub(crate) fn make_string_expression(
 
       if let Some(result) = fn_result_to_expression(&transform(&args).unwrap()) {
         let prop = PropOrSpread::Prop(Box::new(Prop::from(KeyValueProp {
-          key: PropName::Ident(ident_name_factory(key.to_string().as_str())),
+          key: PropName::Ident(quote_ident!(key.to_string())),
           value: Box::new(result),
         })));
 

--- a/packages/swc-plugin/src/shared/utils/core/tests/stylex_tests.rs
+++ b/packages/swc-plugin/src/shared/utils/core/tests/stylex_tests.rs
@@ -4,16 +4,16 @@ mod tests {
   use indexmap::IndexMap;
   use swc_core::{
     common::DUMMY_SP,
-    ecma::ast::{MemberExpr, MemberProp},
+    ecma::{
+      ast::{MemberExpr, MemberProp},
+      utils::quote_ident,
+    },
   };
 
   use crate::shared::{
     enums::data_structures::flat_compiled_styles_value::FlatCompiledStylesValue,
     utils::{
-      ast::{
-        convertors::string_to_expression,
-        factories::{ident_factory, ident_name_factory},
-      },
+      ast::{convertors::string_to_expression, factories::ident_factory},
       common::get_string_val_from_lit,
       core::{
         parse_nullable_style::{ResolvedArg, StyleObject},
@@ -38,7 +38,7 @@ mod tests {
         MemberExpr {
           span: DUMMY_SP,
           obj: Box::new(string_to_expression("test")),
-          prop: MemberProp::Ident(ident_name_factory("test")),
+          prop: MemberProp::Ident(quote_ident!("test")),
         },
       ))
     }

--- a/packages/swc-plugin/src/shared/utils/js/evaluate.rs
+++ b/packages/swc-plugin/src/shared/utils/js/evaluate.rs
@@ -14,7 +14,7 @@ use swc_core::{
       Lit, MemberProp, ModuleExportName, Number, ObjectLit, Prop, PropName, PropOrSpread,
       TplElement, VarDeclarator,
     },
-    utils::{drop_span, ident::IdentLike, ExprExt},
+    utils::{drop_span, ident::IdentLike, quote_ident, ExprExt},
   },
 };
 
@@ -48,9 +48,7 @@ use crate::shared::{
         big_int_to_expression, binary_expr_to_num, expr_to_num, expr_to_str, number_to_expression,
         string_to_expression, transform_shorthand_to_key_values,
       },
-      factories::{
-        array_expression_factory, ident_name_factory, lit_str_factory, object_expression_factory,
-      },
+      factories::{array_expression_factory, lit_str_factory, object_expression_factory},
     },
     common::{
       char_code_at, deep_merge_props, get_import_by_ident, get_key_str, get_string_val_from_lit,
@@ -628,7 +626,7 @@ fn _evaluate(
                 };
 
                 props.push(PropOrSpread::Prop(Box::new(Prop::from(KeyValueProp {
-                  key: PropName::Ident(ident_name_factory(key.unwrap().as_str())),
+                  key: PropName::Ident(quote_ident!(key.unwrap())),
                   value: value.clone(),
                 }))));
               }
@@ -1359,7 +1357,7 @@ fn _evaluate(
 
                   for (key, value) in entries {
                     let ident_name = if let Lit::Str(lit_str) = key.as_ref() {
-                      ident_name_factory(lit_str.value.as_str())
+                      quote_ident!(lit_str.value.as_ref())
                     } else {
                       panic!("Expected a string literal")
                     };

--- a/packages/swc-plugin/tests/__swc_snapshots__/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs/transforms_variables_object_with_key_containing_differend_symbols.js
+++ b/packages/swc-plugin/tests/__swc_snapshots__/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs/transforms_variables_object_with_key_containing_differend_symbols.js
@@ -1,0 +1,15 @@
+//__stylex_metadata_start__[{"class_name":"x1kgzsz","style":{"rtl":null,"ltr":":root{--x1eu87n9:blue;--x154dwga:red;--xs9h3s2:green;--xxznedr:yellow;--x1aros1l:purple;--x1gkvt5k:orange;--x17580al:black;--xnevu0s:white;--xdymszn:gray;--xshz03s:brown;}"},"priority":0}]__stylex_metadata_end__
+import stylex from 'stylex';
+export const buttonTokens = {
+    default: "var(--x1eu87n9)",
+    xl: "var(--x154dwga)",
+    "2xl": "var(--xs9h3s2)",
+    xl3: "var(--xxznedr)",
+    if: "var(--x1aros1l)",
+    else: "var(--x1gkvt5k)",
+    __underscore__: "var(--x17580al)",
+    "&lt": "var(--xnevu0s)",
+    "1": "var(--xdymszn)",
+    gt$eq: "var(--xshz03s)",
+    __themeName__: "x1kgzsz"
+};

--- a/packages/swc-plugin/tests/evaluation/stylex_evaluation/stylex_evaluation_common.rs
+++ b/packages/swc-plugin/tests/evaluation/stylex_evaluation/stylex_evaluation_common.rs
@@ -17,6 +17,7 @@ use swc_core::{
     },
     parser::{Syntax, TsSyntax},
     transforms::testing::{test, test_transform},
+    utils::quote_ident,
   },
 };
 
@@ -270,7 +271,7 @@ fn evaluates_custom_functions_used_as_spread_values() {
           let object_lit = ObjectLit {
             span: DUMMY_SP,
             props: vec![PropOrSpread::Prop(Box::new(Prop::from(KeyValueProp {
-              key: PropName::Ident("spreadValue".into()),
+              key: PropName::Ident(quote_ident!("spreadValue")),
               value: Box::new(arg),
             })))],
           };
@@ -320,11 +321,11 @@ fn evaluates_custom_functions_that_take_paths() {
             span: DUMMY_SP,
             props: vec![
               PropOrSpread::Prop(Box::new(Prop::from(KeyValueProp {
-                key: PropName::Ident("type".into()),
+                key: PropName::Ident(quote_ident!("type")),
                 value: Box::new(string_to_expression("StringLiteral")),
               }))),
               PropOrSpread::Prop(Box::new(Prop::from(KeyValueProp {
-                key: PropName::Ident("value".into()),
+                key: PropName::Ident(quote_ident!("value")),
                 value: Box::new(arg),
               }))),
             ],

--- a/packages/swc-plugin/tests/stylex_transform_create_test/stylex_create_call.rs
+++ b/packages/swc-plugin/tests/stylex_transform_create_test/stylex_create_call.rs
@@ -17,11 +17,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_style_object,
   r#"
         import stylex from 'stylex';
@@ -39,11 +35,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_style_object_with_import_wildcard,
   r#"
         import * as foo from 'stylex';
@@ -61,11 +53,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_style_object_with_named_imports,
   r#"
         import {create} from 'stylex';
@@ -83,11 +71,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_style_object_with_custom_property,
   r#"
         import stylex from 'stylex';
@@ -104,11 +88,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_style_object_with_custom_property_as_value,
   r#"
         import stylex from 'stylex';
@@ -125,11 +105,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_multiple_namespaces,
   r#"
         import stylex from 'stylex';
@@ -149,11 +125,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   does_not_transform_attr_fn_value,
   r#"
         import stylex from 'stylex';
@@ -170,11 +142,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_style_object_with_gradient,
   r#"
         import stylex from 'stylex';
@@ -238,11 +206,7 @@ fn handles_camel_cased_transition_properties() {
       tsx: true,
       ..Default::default()
     }),
-    |tr| ModuleTransformVisitor::new_test_styles(
-      tr.comments.clone(),
-      &PluginPass::default(),
-      None
-    )
+    |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None)
   ));
 }
 
@@ -251,11 +215,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   leaves_transition_properties_of_custom_properties_alone,
   r#"
         import stylex from 'stylex';
@@ -272,11 +232,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_nested_pseudo_class_to_css,
   r#"
         import stylex from 'stylex';
@@ -296,11 +252,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_nested_pseudo_class_within_properties_to_css,
   r#"
         import stylex from 'stylex';
@@ -322,11 +274,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_array_values_as_fallbacks,
   r#"
         import stylex from 'stylex';
@@ -343,11 +291,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_array_values_as_fallbacks_within_media_query,
   r#"
         import stylex from 'stylex';
@@ -368,11 +312,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_properties_requiring_vendor_prefixes,
   r#"
         import stylex from 'stylex';
@@ -389,11 +329,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_valid_shorthands,
   r#"
         const MEDIA_MOBILE = "@media (max-width: 700px)";
@@ -421,11 +357,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   uses_stylex_include_correctly_with_member_expressions,
   r#"
         import stylex from 'stylex';
@@ -442,11 +374,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   using_stylex_include_keeps_the_compiled_object,
   r#"
         import stylex from 'stylex';
@@ -474,11 +402,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   uses_stylex_first_that_works_correctly,
   r#"
         import stylex from 'stylex';
@@ -495,11 +419,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   transforms_complex_property_values_containing_custom_properties_variables,
   r#"
         import stylex from 'stylex';
@@ -516,11 +436,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   auto_expands_shorthands,
   r#"
         import stylex from 'stylex';
@@ -561,11 +477,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| ModuleTransformVisitor::new_test_styles(
-    tr.comments.clone(),
-    &PluginPass::default(),
-    None
-  ),
+  |tr| ModuleTransformVisitor::new_test_styles(tr.comments.clone(), &PluginPass::default(), None),
   last_property_wins_even_if_shorthand,
   r#"
         import stylex from 'stylex';
@@ -591,9 +503,7 @@ test!(
     tsx: true,
     ..Default::default()
   }),
-  |tr| {
-    ModuleTransformVisitor::new_test(tr.comments.clone(), &PluginPass::default(), None)
-  },
+  |tr| { ModuleTransformVisitor::new_test(tr.comments.clone(), &PluginPass::default(), None) },
   adds_null_for_constituent_properties_of_shorthands,
   r#"
     import stylex from 'stylex';

--- a/packages/swc-plugin/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs
+++ b/packages/swc-plugin/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs
@@ -691,3 +691,36 @@ test!(
     });
   "#
 );
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| {
+    ModuleTransformVisitor::new_test(
+      tr.comments.clone(),
+      &PluginPass {
+        cwd: None,
+        filename: FileName::Real("/stylex/packages/TestTheme.stylex.js".into()),
+      },
+      None,
+    )
+  },
+  transforms_variables_object_with_key_containing_differend_symbols,
+  r#"
+        import stylex from 'stylex';
+        export const buttonTokens = stylex.defineVars({
+          default: "blue",
+          xl: "red",
+          "2xl": "green",
+          "xl3": "yellow",
+          if: "purple",
+          else: "orange",
+          __underscore__: "black",
+          "&lt": "white",
+          1: "gray",
+          gt$eq: "brown",
+        });
+    "#
+);


### PR DESCRIPTION
This PR improves the validation of object keys, it was correctly noted in the PR #12, thank you to @budde377.

`Ident::verify_symbol` is used in pair with `ctx.is_reserved_word`  because reserved words do not need to be wrapped in quotes, as is done in StyleX babel plugin.