### PR TITLE
feat(folding): add new cycle to prevent filing state for non application's files

### DIFF
--- a/.changeset/fast-moles-flow.md
+++ b/.changeset/fast-moles-flow.md
@@ -1,0 +1,5 @@
+---
+'@stylexswc/swc-plugin': patch
+---
+
+add new cycle to prevent filing state for non application's files

--- a/packages/swc-plugin/src/shared/enums/core.rs
+++ b/packages/swc-plugin/src/shared/enums/core.rs
@@ -9,6 +9,7 @@ pub(crate) enum ModuleCycle {
   Cleaning,
   // The file has been processed and the plugin is skipped.
   Initializing,
+  StateFilling,
   Skip,
   InjectStyles,
 }

--- a/packages/swc-plugin/src/transform/fold/fold_export_decl.rs
+++ b/packages/swc-plugin/src/transform/fold/fold_export_decl.rs
@@ -20,7 +20,7 @@ where
       return export_decl;
     }
 
-    if self.cycle == ModuleCycle::Initializing {
+    if self.cycle == ModuleCycle::StateFilling {
       if let Decl::Var(var_decl) = &export_decl.decl {
         for decl in &var_decl.decls {
           if let Some(ident) = decl.name.as_ident() {

--- a/packages/swc-plugin/src/transform/fold/fold_expr.rs
+++ b/packages/swc-plugin/src/transform/fold/fold_expr.rs
@@ -14,7 +14,7 @@ where
       return expr;
     }
 
-    if self.cycle == ModuleCycle::Initializing {
+    if self.cycle == ModuleCycle::StateFilling {
       if let Some(call_expr) = expr.as_call() {
         self.state.all_call_expressions.push(call_expr.clone());
       }

--- a/packages/swc-plugin/src/transform/fold/fold_ident.rs
+++ b/packages/swc-plugin/src/transform/fold/fold_ident.rs
@@ -14,7 +14,7 @@ where
       return ident;
     }
 
-    if self.cycle == ModuleCycle::Initializing {
+    if self.cycle == ModuleCycle::StateFilling {
       increase_ident_count(&mut self.state, &ident);
     }
 

--- a/packages/swc-plugin/src/transform/fold/fold_import_decl.rs
+++ b/packages/swc-plugin/src/transform/fold/fold_import_decl.rs
@@ -1,9 +1,6 @@
 use swc_core::{
   common::comments::Comments,
-  ecma::{
-    ast::{ImportDecl, ImportNamedSpecifier, ImportSpecifier, ModuleExportName},
-    visit::FoldWith,
-  },
+  ecma::ast::{ImportDecl, ImportNamedSpecifier, ImportSpecifier, ModuleExportName},
 };
 
 use crate::{
@@ -97,11 +94,7 @@ where
         }
       }
 
-      if self.state.import_paths.is_empty() {
-        import_decl
-      } else {
-        import_decl.fold_children_with(self)
-      }
+      import_decl
     } else {
       import_decl
     }

--- a/packages/swc-plugin/src/transform/fold/fold_member_expression.rs
+++ b/packages/swc-plugin/src/transform/fold/fold_member_expression.rs
@@ -27,7 +27,7 @@ where
       return member_expression;
     }
 
-    if self.cycle == ModuleCycle::Initializing {
+    if self.cycle == ModuleCycle::StateFilling {
       if let Some(obj_ident) = member_expression.obj.as_ident() {
         increase_member_ident_count(&mut self.state, &obj_ident.sym);
       }

--- a/packages/swc-plugin/src/transform/fold/fold_module.rs
+++ b/packages/swc-plugin/src/transform/fold/fold_module.rs
@@ -5,7 +5,8 @@ use swc_core::{
 
 use crate::{
   shared::{
-    enums::core::ModuleCycle, structures::meta_data::MetaData, utils::common::fill_top_level_expressions,
+    enums::core::ModuleCycle, structures::meta_data::MetaData,
+    utils::common::fill_top_level_expressions,
   },
   ModuleTransformVisitor,
 };
@@ -18,6 +19,9 @@ where
     let mut module = module.fold_children_with(self);
 
     if !self.state.import_paths.is_empty() {
+      self.cycle = ModuleCycle::StateFilling;
+      module = module.fold_children_with(self);
+
       fill_top_level_expressions(&module, &mut self.state);
 
       self.cycle = ModuleCycle::TransformEnter;

--- a/packages/swc-plugin/src/transform/fold/fold_var_declarator.rs
+++ b/packages/swc-plugin/src/transform/fold/fold_var_declarator.rs
@@ -32,6 +32,7 @@ where
     mut var_declarator: VarDeclarator,
   ) -> VarDeclarator {
     if self.cycle != ModuleCycle::Initializing
+      && self.cycle != ModuleCycle::StateFilling
       && self.cycle != ModuleCycle::TransformEnter
       && self.cycle != ModuleCycle::TransformExit
       && self.cycle != ModuleCycle::PreCleaning
@@ -122,7 +123,7 @@ where
           });
 
         if let Some(declaration_string) = declaration_string {
-          if self.cycle == ModuleCycle::Initializing
+          if self.cycle == ModuleCycle::StateFilling
             && (member.as_str() == "create" || member.eq(declaration_string.as_str()))
           {
             self.props_declaration = var_declarator.name.as_ident().map(|ident| ident.to_id());


### PR DESCRIPTION
To speed up file processing, a new folding cycle has been added that allows processing only application files, skipping files that do not have StyleX package imports