### PR TITLE
feat(define_vars): allow nested calls

### DIFF
--- a/.changeset/fast-forks-clap.md
+++ b/.changeset/fast-forks-clap.md
@@ -1,0 +1,5 @@
+---
+'@stylexswc/swc-plugin': patch
+---
+
+allow nested definedVars calls

--- a/packages/swc-plugin/src/shared/structures/state_manager.rs
+++ b/packages/swc-plugin/src/shared/structures/state_manager.rs
@@ -388,10 +388,6 @@ impl StateManager {
       self.add_style_to_inject(&metadata, &inject_var_ident, ast);
     }
 
-    if self.options.runtime_injection.is_none() {
-      return;
-    }
-
     if let Some(item) = self
       .declarations
       .iter_mut()

--- a/packages/swc-plugin/tests/__swc_snapshots__/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs/transforms_variables_object_with_nested_defined_vars_call.js
+++ b/packages/swc-plugin/tests/__swc_snapshots__/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs/transforms_variables_object_with_nested_defined_vars_call.js
@@ -1,0 +1,10 @@
+//__stylex_metadata_start__[{"class_name":"xir4if5","style":{"rtl":null,"ltr":":root{--xbx9tme:#ff0000;}"},"priority":0},{"class_name":"x568ih9","style":{"rtl":null,"ltr":":root{--xgck17p:var(--xbx9tme);}"},"priority":0}]__stylex_metadata_end__
+import stylex from 'stylex';
+export const colors = {
+    primary: "var(--xbx9tme)",
+    __themeName__: "xir4if5"
+};
+export const buttonTheme = {
+    bgColor: "var(--xgck17p)",
+    __themeName__: "x568ih9"
+};

--- a/packages/swc-plugin/tests/__swc_snapshots__/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs/transforms_variables_object_with_nested_defined_vars_calls.js
+++ b/packages/swc-plugin/tests/__swc_snapshots__/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs/transforms_variables_object_with_nested_defined_vars_calls.js
@@ -1,0 +1,14 @@
+//__stylex_metadata_start__[{"class_name":"xir4if5","style":{"rtl":null,"ltr":":root{--xbx9tme:#ff0000;}"},"priority":0},{"class_name":"x7f146g","style":{"rtl":null,"ltr":":root{--x2toufr:var(--xbx9tme);}"},"priority":0},{"class_name":"x568ih9","style":{"rtl":null,"ltr":":root{--xgck17p:var(--x2toufr);}"},"priority":0}]__stylex_metadata_end__
+import stylex from 'stylex';
+export const colors = {
+    primary: "var(--xbx9tme)",
+    __themeName__: "xir4if5"
+};
+export const designSystem = {
+    primary: "var(--x2toufr)",
+    __themeName__: "x7f146g"
+};
+export const buttonTheme = {
+    bgColor: "var(--xgck17p)",
+    __themeName__: "x568ih9"
+};

--- a/packages/swc-plugin/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs
+++ b/packages/swc-plugin/tests/stylex_transform_define_vars_test/stylex_transform_define_vars.rs
@@ -697,6 +697,71 @@ test!(
     tsx: true,
     ..Default::default()
   }),
+  |tr| ModuleTransformVisitor::new_test(
+    tr.comments.clone(),
+    &PluginPass {
+      cwd: None,
+      filename: FileName::Real("/stylex/packages/TestTheme.stylex.js".into()),
+    },
+    Some(&mut StyleXOptionsParams {
+      runtime_injection: Some(false),
+      unstable_module_resolution: Some(StyleXOptions::get_haste_module_resolution(None)),
+      ..StyleXOptionsParams::default()
+    })
+  ),
+  transforms_variables_object_with_nested_defined_vars_call,
+  r#"
+        import stylex from 'stylex';
+        export const colors = stylex.defineVars({
+            primary: '#ff0000',
+        });
+        export const buttonTheme = stylex.defineVars({
+            bgColor: {
+                default: colors.primary,
+            },
+        });
+    "#
+);
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| ModuleTransformVisitor::new_test(
+    tr.comments.clone(),
+    &PluginPass {
+      cwd: None,
+      filename: FileName::Real("/stylex/packages/TestTheme.stylex.js".into()),
+    },
+    Some(&mut StyleXOptionsParams {
+      runtime_injection: Some(false),
+      unstable_module_resolution: Some(StyleXOptions::get_haste_module_resolution(None)),
+      ..StyleXOptionsParams::default()
+    })
+  ),
+  transforms_variables_object_with_nested_defined_vars_calls,
+  r#"
+        import stylex from 'stylex';
+        export const colors = stylex.defineVars({
+            primary: '#ff0000',
+        });
+        export const designSystem = stylex.defineVars({
+            primary: colors.primary,
+        });
+        export const buttonTheme = stylex.defineVars({
+            bgColor: {
+                default: designSystem.primary,
+            },
+        });
+    "#
+);
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
   |tr| {
     ModuleTransformVisitor::new_test(
       tr.comments.clone(),


### PR DESCRIPTION
Fixing #16 

This PR allows to use the result of calling the function defineWars as parameters of a similar function in the same file