### PR TITLE
fix(dynamic styles): correct evaluate arrow function body

### DIFF
--- a/crates/stylex-shared/src/shared/utils/js/evaluate.rs
+++ b/crates/stylex-shared/src/shared/utils/js/evaluate.rs
@@ -322,9 +322,13 @@ fn _evaluate(
       // )
     }
     Expr::Cond(cond) => {
-      let test_result = match *evaluate_cached(&cond.test, state, fns)
-        .expect("Test of condition must be an expression")
-      {
+      let test_result = evaluate_cached(&cond.test, state, fns);
+
+      if !state.confident {
+        return None;
+      }
+
+      let test_result = match *test_result.expect("Test of condition must be an expression") {
         EvaluateResultValue::Expr(expr) => expr_to_bool(&expr, &mut state.traversal_state, fns),
         _ => panic!("Test of condition must be an expression"),
       };

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/stylex_validation_create_test/stylex_validation_create_dynamic_test.rs/dynamic_style_function_with_conditional_expression_fallback.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/stylex_validation_create_test/stylex_validation_create_dynamic_test.rs/dynamic_style_function_with_conditional_expression_fallback.js
@@ -1,0 +1,19 @@
+//__stylex_metadata_start__[{"class_name":"x13jbg0v","style":{"rtl":null,"ltr":".x13jbg0v{font-size:var(--fontSize,revert)}"},"priority":3000}]__stylex_metadata_end__
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import stylex from "@stylexjs/stylex";
+_inject2(".x13jbg0v{font-size:var(--fontSize,revert)}", 3000);
+const styles = {
+    fontSizeFallback: (size: number)=>[
+            {
+                fontSize: "x13jbg0v",
+                $$css: true
+            },
+            {
+                "--fontSize": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : "initial")(size ?? '1em')
+            }
+        ]
+};
+const { className, style = {} } = {
+    ...stylex.props(styles.fontSizeFallback(size))
+};

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/stylex_validation_create_test/stylex_validation_create_dynamic_test.rs/dynamic_style_function_with_ternary_conditional_expression.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/stylex_validation_create_test/stylex_validation_create_dynamic_test.rs/dynamic_style_function_with_ternary_conditional_expression.js
@@ -1,0 +1,19 @@
+//__stylex_metadata_start__[{"class_name":"x13jbg0v","style":{"rtl":null,"ltr":".x13jbg0v{font-size:var(--fontSize,revert)}"},"priority":3000}]__stylex_metadata_end__
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import stylex from "@stylexjs/stylex";
+_inject2(".x13jbg0v{font-size:var(--fontSize,revert)}", 3000);
+const styles = {
+    fontSizeTernary: (size: number)=>[
+            {
+                fontSize: "x13jbg0v",
+                $$css: true
+            },
+            {
+                "--fontSize": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : "initial")(size < 10 ? '1em' : '2em')
+            }
+        ]
+};
+const { className, style = {} } = {
+    ...stylex.props(styles.fontSizeTernary(size))
+};

--- a/crates/stylex-shared/tests/stylex_validation_create_test/stylex_validation_create_dynamic_test.rs
+++ b/crates/stylex-shared/tests/stylex_validation_create_test/stylex_validation_create_dynamic_test.rs
@@ -161,19 +161,71 @@ test!(
     import stylex from "@stylexjs/stylex";
 
     const styles = stylex.create({
-        size: (size: number) => ({ fontSize: (8 * size)+'px'}),
-        count: {
-          fontWeight: 100,
-        },
-        largeNumber: {
-          fontSize: '1.5rem',
-        },
+      size: (size: number) => ({ fontSize: (8 * size)+'px'}),
+      count: {
+        fontWeight: 100,
+      },
+      largeNumber: {
+        fontSize: '1.5rem',
+      },
     });
 
     const { className, style = {} } = { ...stylex.props(
-              styles.count,
-              styles.size(size),
-              styles.largeNumber
+      styles.count,
+      styles.size(size),
+      styles.largeNumber
+    )}
+  "#
+);
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| {
+    StyleXTransform::new_test_force_runtime_injection(
+      tr.comments.clone(),
+      &PluginPass::default(),
+      None,
+    )
+  },
+  dynamic_style_function_with_conditional_expression_fallback,
+  r#"
+    import stylex from "@stylexjs/stylex";
+
+    const styles = stylex.create({
+      fontSizeFallback: (size: number) => ({ fontSize: size ?? '1em' }),
+    });
+
+    const { className, style = {} } = { ...stylex.props(
+      styles.fontSizeFallback(size),
+    )}
+  "#
+);
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| {
+    StyleXTransform::new_test_force_runtime_injection(
+      tr.comments.clone(),
+      &PluginPass::default(),
+      None,
+    )
+  },
+  dynamic_style_function_with_ternary_conditional_expression,
+  r#"
+    import stylex from "@stylexjs/stylex";
+
+    const styles = stylex.create({
+      fontSizeTernary: (size: number) => ({ fontSize: size < 10 ? '1em' : '2em' }),
+    });
+
+    const { className, style = {} } = { ...stylex.props(
+      styles.fontSizeTernary(size),
     )}
   "#
 );


### PR DESCRIPTION
This PR adds the correct transformation of arrow function body with conditional expressions.

See issue https://github.com/Dwlad90/stylex-swc-plugin/issues/49 for more details