### PR TITLE
fix(@stylexswc/rs-compiler): don't exit with exit code 1 when panic signal occurs

### DIFF
--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -2,6 +2,7 @@ mod structs;
 mod utils;
 use napi::{Env, Result};
 use std::env;
+use std::panic;
 use structs::{SourceMaps, StyleXMetadata, StyleXOptions, StyleXTransformResult};
 use swc_compiler_base::{print, PrintArgs, SourceMapsConfig};
 
@@ -29,64 +30,81 @@ pub fn transform(
 ) -> Result<StyleXTransformResult> {
   color_backtrace::install();
 
-  let cm: Lrc<SourceMap> = Default::default();
-  let filename = FileName::Real(filename.into());
+  let result = panic::catch_unwind(|| {
+    let cm: Lrc<SourceMap> = Default::default();
+    let filename = FileName::Real(filename.into());
 
-  let fm = cm.new_source_file(filename.clone(), code);
+    let fm = cm.new_source_file(filename.clone(), code);
 
-  let cwd = env::current_dir()?;
+    let cwd = env::current_dir()?;
 
-  let plugin_pass = PluginPass {
-    cwd: Some(cwd),
-    filename,
-  };
+    let plugin_pass = PluginPass {
+      cwd: Some(cwd),
+      filename,
+    };
 
-  let source_map = match options.source_map.as_ref() {
-    Some(SourceMaps::True) => SourceMapsConfig::Bool(true),
-    Some(SourceMaps::False) => SourceMapsConfig::Bool(false),
-    Some(SourceMaps::Inline) => SourceMapsConfig::Str("inline".to_string()),
-    None => SourceMapsConfig::Bool(true),
-  };
+    let source_map = match options.source_map.as_ref() {
+      Some(SourceMaps::True) => SourceMapsConfig::Bool(true),
+      Some(SourceMaps::False) => SourceMapsConfig::Bool(false),
+      Some(SourceMaps::Inline) => SourceMapsConfig::Str("inline".to_string()),
+      None => SourceMapsConfig::Bool(true),
+    };
 
-  let mut config: StyleXOptionsParams = options.into();
+    let mut config: StyleXOptionsParams = options.into();
 
-  let mut stylex: StyleXTransform<PluginCommentsProxy> =
-    StyleXTransform::new(PluginCommentsProxy, plugin_pass, &mut config);
+    let mut stylex: StyleXTransform<PluginCommentsProxy> =
+      StyleXTransform::new(PluginCommentsProxy, plugin_pass, &mut config);
 
-  let mut parser = Parser::new_from(Lexer::new(
-    Syntax::Typescript(TsSyntax {
-      tsx: true,
-      ..Default::default()
-    }),
-    EsVersion::latest(),
-    StringInput::from(&*fm),
-    None,
-  ));
+    let mut parser = Parser::new_from(Lexer::new(
+      Syntax::Typescript(TsSyntax {
+        tsx: true,
+        ..Default::default()
+      }),
+      EsVersion::latest(),
+      StringInput::from(&*fm),
+      None,
+    ));
 
-  let program = parser.parse_program().unwrap();
+    let program = parser.parse_program().unwrap();
 
-  let program = program.fold_with(&mut stylex).fold_with(&mut fixer(None));
+    let program = program.fold_with(&mut stylex).fold_with(&mut fixer(None));
 
-  let transformed_code = print(
-    cm,
-    &program,
-    PrintArgs {
-      source_map,
-      ..Default::default()
-    },
-  );
+    let transformed_code = print(
+      cm,
+      &program,
+      PrintArgs {
+        source_map,
+        ..Default::default()
+      },
+    );
 
-  let result = transformed_code.unwrap();
+    let result = transformed_code.unwrap();
 
-  let stylex_metadata = extract_stylex_metadata(env, &stylex)?;
+    let stylex_metadata = extract_stylex_metadata(env, &stylex)?;
 
-  let js_result = StyleXTransformResult {
-    code: result.code,
-    metadata: StyleXMetadata {
-      stylex: stylex_metadata,
-    },
-    map: result.map,
-  };
+    let js_result = StyleXTransformResult {
+      code: result.code,
+      metadata: StyleXMetadata {
+        stylex: stylex_metadata,
+      },
+      map: result.map,
+    };
 
-  Ok(js_result)
+    Ok(js_result)
+  });
+
+  match result {
+    Ok(res) => res,
+    Err(error) => {
+      let error_msg = match error.downcast_ref::<String>() {
+        Some(s) => format!("Panic occurred during transformation: {}", s),
+        None => match error.downcast_ref::<&str>() {
+          Some(s) => format!("Panic occurred during transformation: {}", s),
+          None => "Unknown panic occurred during transformation".to_string(),
+        },
+      };
+
+      Err(napi::Error::from_reason(error_msg))
+    }
+  }
 }


### PR DESCRIPTION
PR adds panic processing and the ability to continue working after the error has been resolved

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document