### PR TITLE
fix(radial-gradient): exclude from normalizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stylex_compiler_rs"
-version = "0.4.3"
+version = "0.4.4-rc.1"
 dependencies = [
  "color-backtrace",
  "napi",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "stylex_path_resolver"
-version = "0.4.3"
+version = "0.4.4-rc.1"
 dependencies = [
  "anyhow",
  "color-backtrace",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "stylex_shared"
-version = "0.4.3"
+version = "0.4.4-rc.1"
 dependencies = [
  "anyhow",
  "color-backtrace",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "stylex_swc_plugin"
-version = "0.4.3"
+version = "0.4.4-rc.1"
 dependencies = [
  "color-backtrace",
  "ctor",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "stylex_test_parser"
-version = "0.4.3"
+version = "0.4.4-rc.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/stylex-shared/src/shared/constants/common.rs
+++ b/crates/stylex-shared/src/shared/constants/common.rs
@@ -28,5 +28,5 @@ pub(crate) static ROOT_FONT_SIZE: i8 = 16;
 
 pub(crate) static THEME_NAME_KEY: &str = "__themeName__";
 
-pub(crate) static WHITE_LISTED_NORMALIZED_PROPERTY_VALUES: Lazy<[&str; 4]> =
-  Lazy::new(|| ["oklch", "lch", "oklab", "hsla"]);
+pub(crate) static WHITE_LISTED_NORMALIZED_PROPERTY_VALUES: Lazy<[&str; 5]> =
+  Lazy::new(|| ["oklch", "lch", "oklab", "hsla", "radial-gradient"]);

--- a/crates/stylex-shared/src/shared/regex.rs
+++ b/crates/stylex-shared/src/shared/regex.rs
@@ -43,3 +43,5 @@ pub(crate) static CLEAN_CSS_VAR: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\\3(\d
 
 pub(crate) static IS_CSS_VAR: Lazy<Regex> =
   Lazy::new(|| Regex::new(r#"^var\(--[a-zA-Z0-9-_]+\)$"#).unwrap());
+
+pub(crate) static MANY_SPACES: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\s+"#).unwrap());

--- a/crates/stylex-shared/src/shared/utils/css/common.rs
+++ b/crates/stylex-shared/src/shared/utils/css/common.rs
@@ -14,7 +14,7 @@ use crate::shared::{
     shorthands_of_shorthands::SHORTHANDS_OF_SHORTHANDS,
     unitless_number_properties::UNITLESS_NUMBER_PROPERTIES,
   },
-  regex::{CLEAN_CSS_VAR, CSS_ATTRIBUTE},
+  regex::{CLEAN_CSS_VAR, CSS_ATTRIBUTE, MANY_SPACES},
   structures::{
     injectable_style::InjectableStyle, pair::Pair, state_manager::StateManager,
     stylex_state_options::StyleXStateOptions,
@@ -478,7 +478,7 @@ pub(crate) fn normalize_css_property_value(
     .into_iter()
     .any(|css_fnc| css_property_value.starts_with(format!("{}(", css_fnc).as_str()))
   {
-    return css_property_value.to_string();
+    return MANY_SPACES.replace_all(css_property_value, " ").to_string();
   }
 
   let css_property = if css_property.starts_with("--") {

--- a/crates/stylex-shared/src/shared/utils/css/tests/css_custom_properties_validation_test.rs
+++ b/crates/stylex-shared/src/shared/utils/css/tests/css_custom_properties_validation_test.rs
@@ -184,6 +184,15 @@ mod css_tests {
       ),
       r#"oklch(from var(--xs74gcj) l c h / 0.5)"#
     );
+
+    assert_eq!(
+      transform_value_cached(
+        "color",
+        r#"radial-gradient(circle at 0% 0%, oklch(from   var(--colors-tile-background) calc(l + 0.1) calc(c + 0.2) h) 0, transparent 15%), radial-gradient(circle at 80% 100%,oklch(from var(--colors-tile-background) calc(l - 0.25) calc(c + 0.01) h) 0, transparent 30%), linear-gradient(45deg,var(--colors-tile-background) 0%, oklch(from var(--colors-tile-background) calc(l - 0.1) calc(c + 0.3) h) 100%)"#,
+        &mut StateManager::default()
+      ),
+      r#"radial-gradient(circle at 0% 0%, oklch(from var(--colors-tile-background) calc(l + 0.1) calc(c + 0.2) h) 0, transparent 15%), radial-gradient(circle at 80% 100%,oklch(from var(--colors-tile-background) calc(l - 0.25) calc(c + 0.01) h) 0, transparent 30%), linear-gradient(45deg,var(--colors-tile-background) 0%, oklch(from var(--colors-tile-background) calc(l - 0.1) calc(c + 0.3) h) 100%)"#
+    );
   }
 
   #[test]


### PR DESCRIPTION
SWC css parser does not handle color functions correctly, such as `oklch`

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document