### PR TITLE
fix(css functions): exclude color relative values from normalizing

### DIFF
--- a/crates/stylex-shared/src/shared/constants/common.rs
+++ b/crates/stylex-shared/src/shared/constants/common.rs
@@ -28,5 +28,20 @@ pub(crate) static ROOT_FONT_SIZE: i8 = 16;
 
 pub(crate) static THEME_NAME_KEY: &str = "__themeName__";
 
-pub(crate) static COLOR_FUNCTION_LISTED_NORMALIZED_PROPERTY_VALUES: Lazy<[&str; 2]> =
-  Lazy::new(|| ["oklab", "oklch"]);
+pub(crate) static COLOR_FUNCTION_LISTED_NORMALIZED_PROPERTY_VALUES: Lazy<[&str; 9]> =
+  Lazy::new(|| {
+    [
+      "oklch",
+      "lch",
+      "oklab",
+      "hsla",
+      "radial-gradient",
+      "hwb",
+      "lab",
+      "clamp",
+      "hsl",
+    ]
+  });
+
+pub(crate) static COLOR_RELATIVE_VALUES_LISTED_NORMALIZED_PROPERTY_VALUES: Lazy<[&str; 7]> =
+  Lazy::new(|| [" a ", " b ", " c ", " l ", " h ", " s ", " w "]);

--- a/crates/stylex-shared/src/shared/utils/css/common.rs
+++ b/crates/stylex-shared/src/shared/utils/css/common.rs
@@ -2,7 +2,10 @@ use core::panic;
 
 use crate::shared::{
   constants::{
-    common::COLOR_FUNCTION_LISTED_NORMALIZED_PROPERTY_VALUES,
+    common::{
+      COLOR_FUNCTION_LISTED_NORMALIZED_PROPERTY_VALUES,
+      COLOR_RELATIVE_VALUES_LISTED_NORMALIZED_PROPERTY_VALUES,
+    },
     long_hand_logical::LONG_HAND_LOGICAL,
     long_hand_physical::LONG_HAND_PHYSICAL,
     messages::LINT_UNCLOSED_FUNCTION,
@@ -475,8 +478,12 @@ pub(crate) fn normalize_css_property_value(
   options: &StyleXStateOptions,
 ) -> String {
   if COLOR_FUNCTION_LISTED_NORMALIZED_PROPERTY_VALUES
-    .into_iter()
-    .any(|css_fnc| css_property_value.contains(format!("{}(", css_fnc).as_str()))
+    .iter()
+    .chain(COLOR_RELATIVE_VALUES_LISTED_NORMALIZED_PROPERTY_VALUES.iter())
+    .any(|css_fnc| {
+      css_property_value.contains(format!("{}(", css_fnc).as_str())
+        || css_property_value.to_lowercase().contains(css_fnc)
+    })
   {
     return MANY_SPACES.replace_all(css_property_value, " ").to_string();
   }

--- a/crates/stylex-shared/src/shared/utils/css/tests/css_custom_properties_validation_test.rs
+++ b/crates/stylex-shared/src/shared/utils/css/tests/css_custom_properties_validation_test.rs
@@ -277,6 +277,36 @@ mod css_tests {
   }
 
   #[test]
+  fn clamp_colors() {
+    assert_eq!(
+      transform_value_cached(
+        "color",
+        r#"clamp(200px,  40%,     400px)"#,
+        &mut StateManager::default()
+      ),
+      r#"clamp(200px, 40%, 400px)"#
+    );
+
+    assert_eq!(
+      transform_value_cached(
+        "color",
+        r#"clamp(min(10vw,      20rem),     300px,     max(90vw,     55rem))"#,
+        &mut StateManager::default()
+      ),
+      r#"clamp(min(10vw, 20rem), 300px, max(90vw, 55rem))"#
+    );
+
+    assert_eq!(
+      transform_value_cached(
+        "color",
+        r#"clamp(0, (var(--l-threshold, 0.623)   /  l - 1)   *    infinity,    1)"#,
+        &mut StateManager::default()
+      ),
+      r#"clamp(0, (var(--l-threshold, 0.623) / l - 1) * infinity, 1)"#
+    );
+  }
+
+  #[test]
   fn allow_url_properties() {
     assert_eq!(
       transform_value_cached(


### PR DESCRIPTION
# Pull Request Template

## Description

This PR temporarily excludes color channels such as `l | c | h` from normalization


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document