### PR TITLE
fix(@stylexswc/path-resolver): exclude empty path from resolution

### DIFF
--- a/crates/stylex-path-resolver/src/resolvers/tests.rs
+++ b/crates/stylex-path-resolver/src/resolvers/tests.rs
@@ -643,7 +643,6 @@ mod resolve_path_tests {
       "{}/src/pages/home.js",
       get_root_dir(&test_path).as_path().display()
     );
-    let ext = ".js";
     let root_path = get_root_dir(&test_path).display().to_string();
     let aliases = Default::default();
 
@@ -653,7 +652,6 @@ mod resolve_path_tests {
       resolve_file_path(
         import_path_str,
         source_file_path.as_str(),
-        ext,
         root_path.as_str(),
         &aliases,
         &mut HashMap::default(),
@@ -674,7 +672,6 @@ mod resolve_path_tests {
       "{}/src/pages/home.js",
       get_root_dir(&test_path).as_path().display()
     );
-    let ext = ".js";
     let root_path = get_root_dir(&test_path).display().to_string();
     let aliases = Default::default();
 
@@ -684,7 +681,6 @@ mod resolve_path_tests {
       resolve_file_path(
         import_path_str,
         source_file_path.as_str(),
-        ext,
         root_path.as_str(),
         &aliases,
         &mut HashMap::default(),
@@ -705,7 +701,6 @@ mod resolve_path_tests {
       "{}/src/pages/home.js",
       get_root_dir(&test_path).as_path().display()
     );
-    let ext = ".js";
     let root_path = get_root_dir(&test_path).display().to_string();
     let mut aliases = FxHashMap::default();
     aliases.insert("@/*".to_string(), vec![format!("{}/src/*", root_path)]);
@@ -716,7 +711,6 @@ mod resolve_path_tests {
       resolve_file_path(
         import_path_str,
         source_file_path.as_str(),
-        ext,
         root_path.as_str(),
         &aliases,
         &mut HashMap::default(),
@@ -737,7 +731,6 @@ mod resolve_path_tests {
       "{}/src/pages/home.js",
       get_root_dir(&test_path).as_path().display()
     );
-    let ext = ".js";
     let root_path = get_root_dir(&test_path).display().to_string();
     let aliases = FxHashMap::default();
 
@@ -747,7 +740,6 @@ mod resolve_path_tests {
       resolve_file_path(
         import_path_str,
         source_file_path.as_str(),
-        ext,
         root_path.as_str(),
         &aliases,
         &mut HashMap::default(),
@@ -768,7 +760,6 @@ mod resolve_path_tests {
       "{}/src/pages/home.js",
       get_root_dir(&test_path).as_path().display()
     );
-    let ext = ".js";
     let root_path = get_root_dir(&test_path).display().to_string();
     let aliases = FxHashMap::default();
 
@@ -778,7 +769,6 @@ mod resolve_path_tests {
       resolve_file_path(
         import_path_str,
         source_file_path.as_str(),
-        ext,
         root_path.as_str(),
         &aliases,
         &mut HashMap::default(),
@@ -799,7 +789,6 @@ mod resolve_path_tests {
       "{}/src/pages/home.js",
       get_root_dir(&test_path).as_path().display()
     );
-    let ext = ".js";
     let root_path = get_root_dir(&test_path).display().to_string();
     let aliases = FxHashMap::default();
 
@@ -810,7 +799,6 @@ mod resolve_path_tests {
       resolve_file_path(
         import_path_str,
         source_file_path.as_str(),
-        ext,
         root_path.as_str(),
         &aliases,
         &mut HashMap::default(),
@@ -831,7 +819,6 @@ mod resolve_path_tests {
       "{}/src/pages/home.js",
       get_root_dir(&test_path).as_path().display()
     );
-    let ext = ".js";
     let root_path = get_root_dir(&test_path).display().to_string();
     let aliases = FxHashMap::default();
 
@@ -841,7 +828,6 @@ mod resolve_path_tests {
       resolve_file_path(
         import_path_str,
         source_file_path.as_str(),
-        ext,
         root_path.as_str(),
         &aliases,
         &mut HashMap::default(),
@@ -862,7 +848,6 @@ mod resolve_path_tests {
       "{}/src/pages/home.js",
       get_root_dir(&test_path).as_path().display()
     );
-    let ext = ".js";
     let root_path = get_root_dir(&test_path).display().to_string();
     let aliases = FxHashMap::default();
 
@@ -872,7 +857,6 @@ mod resolve_path_tests {
       resolve_file_path(
         import_path_str,
         source_file_path.as_str(),
-        ext,
         root_path.as_str(),
         &aliases,
         &mut HashMap::default(),

--- a/crates/stylex-shared/src/shared/structures/state_manager.rs
+++ b/crates/stylex-shared/src/shared/structures/state_manager.rs
@@ -854,30 +854,21 @@ fn file_path_resolver(
     unimplemented!("Extension match found, but handling is unimplemented");
   }
 
-  for ext in EXTENSIONS.iter() {
-    let import_path_str = if relative_file_path.starts_with('.') {
-      format!("{}{}", relative_file_path, ext)
+  let resolved_file_path = resolve_file_path(
+    relative_file_path,
+    source_file_path,
+    root_path,
+    aliases,
+    package_json_seen,
+  );
+
+  if let Ok(resolved_path) = resolved_file_path {
+    let resolved_path_str = resolved_path.display().to_string();
+
+    if resolved_path_str.contains("/app/@") {
+      return resolved_path_str.replace("/app/@", "/node_modules/@");
     } else {
-      relative_file_path.to_string()
-    };
-
-    let resolved_file_path = resolve_file_path(
-      &import_path_str,
-      source_file_path,
-      ext,
-      root_path,
-      aliases,
-      package_json_seen,
-    );
-
-    if let Ok(resolved_path) = resolved_file_path {
-      let resolved_path_str = resolved_path.display().to_string();
-
-      if resolved_path_str.contains("/app/@") {
-        return resolved_path_str.replace("/app/@", "/node_modules/@");
-      } else {
-        return resolved_path_str;
-      }
+      return resolved_path_str;
     }
   }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an #179  with resolving theme style import paths when using `bun`'s monorepo.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document