### PR TITLE
fix(@stylexwc/nextjs-plugin): only log webpack details in debug mode

### DIFF
--- a/packages/nextjs-plugin/src/index.ts
+++ b/packages/nextjs-plugin/src/index.ts
@@ -103,16 +103,18 @@ const withStyleX =
 
         const { buildId, dev, isServer } = ctx;
 
-        console.log(
-          [
-            '!!!GETTING WEBPACK CONFIG!!!',
-            '======================',
-            `Count: ${++count}`,
-            `Build ID: ${buildId}`,
-            `Server: ${isServer}`,
-            `Env: ${dev ? 'dev' : 'prod'}`,
-          ].join('\n')
-        );
+        if (pluginOptions?.rsOptions.debug || process.env.STYLEX_DEBUG) {
+          console.log(
+            [
+              '!!!GETTING WEBPACK CONFIG!!!',
+              '======================',
+              `Count: ${++count}`,
+              `Build ID: ${buildId}`,
+              `Server: ${isServer}`,
+              `Env: ${dev ? 'dev' : 'prod'}`,
+            ].join('\n')
+          );
+        }
 
         // For some reason, Next 11.0.1 has `config.optimization.splitChunks`
         // set to `false` when webpack 5 is enabled.


### PR DESCRIPTION
# Pull Request Template

## Description

As described in https://github.com/Dwlad90/stylex-swc-plugin/pull/189#issuecomment-2588086598 - we believe it is cleaner to only log the webpack environment information when a debug flag is defined.

## Fixes

only log webpack details in debug mode

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document