### PR TITLE
chore(get_package_json): generate more detailed error when package.json parsing failed

### DIFF
--- a/crates/stylex-path-resolver/src/package_json/mod.rs
+++ b/crates/stylex-path-resolver/src/package_json/mod.rs
@@ -42,8 +42,17 @@ pub fn get_package_json(
         let data = read_to_string(file_path);
 
         data.ok().map(|package_json_raw| {
-          let json =
-            serde_json::from_str::<PackageJsonExtended>(package_json_raw.as_str()).unwrap();
+          let json = serde_json::from_str::<PackageJsonExtended>(package_json_raw.as_str())
+            .unwrap_or_else(|error| {
+              panic!(
+                "Failed to parse `{}` file. Error: {}.\n\nPossible reasons:\n\
+                  - The required field `name` might be missing.\n\
+                  - The JSON structure might be incorrect.\n\
+                  - There might be a syntax error in the JSON.\n\
+                  - Ensure all required fields are present and correctly formatted.",
+                file_path_string, error
+              );
+            });
 
           package_json_seen.insert(file_path.to_string(), json.clone());
           json


### PR DESCRIPTION
# Pull Request Template

## Description

This PR add more detailed error when parsing `package.json` failed

## Fixes

(Optional) Fixes #193

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document