### PR TITLE
fix(@stylexswc/postcss-plugin): provide resolved pathname to postcss plugin builder

### DIFF
--- a/packages/postcss-plugin/src/builder.ts
+++ b/packages/postcss-plugin/src/builder.ts
@@ -101,7 +101,7 @@ function createBuilder() {
     });
 
     // Normalize file paths
-    files = files.map(file => (file.includes(cwd || '/') ? file : path.join(cwd || '/', file)));
+    files = files.map(file => (file.includes(cwd || '/') ? file : path.resolve(cwd || '/', file)));
 
     return files;
   }


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

pnpm installs dependencies locally for each package. npm (and also bun) install at the root of a monorepo.

The postcss-plugin example considers both of these install locations, however, the postcss-plugin builder code uses a `path.join` then it encounters an import path that does not match the current package path resulting in a path that is not accurate.

e.g.

```
cwd: /dwlad/stylex-swc-plugin/apps/nextjs-postcss-example/
filename: /dwlad/stylex-swc-plugin/node_modules/@stylexjs/open-props/lib/animationNames.stylex.js
```

The combination above (where `@stylexjs/open-props` has been installed at root) will result in:

```
Error: ENOENT: no such file or directory, open '/dwlad/stylex-swc-plugin/apps/nextjs-postcss-example/dwlad/stylex-swc-plugin/node_modules/@stylexjs/open-props/lib/animationNames.stylex.js'
```

It should provide the absolute path to the third-party dependency as it was supplied.


## Additional Info

### Repro

There is a separate issue with monorepo roots within `stylex-path-resolver` which masks the postcss error when installing a monorepo using npm.

[This minimal repo can be used as an example](https://github.com/mattstyles/stylexswc-npm-monorepo/tree/postcss-path-resolution) which shows the path issue mentioned above (where cwd and filename are both absolute, but joined rather than resolved).

The link above symlinks `open-props` into the app/node_modules. This does not match how npm installs but evades the issue with rs-compiler being unable to find the dependency and panicking before we get to the postcss stuff (the `main` branch at that link highlights this issue with the stylex-path-resolver).

**Alternative**

* Use this repo example
* symlink apps/nextjs-postcss-example node_modules open-props to `<root>/node_modules/@stylexjs/open-props` 
* Comment out line 33 from `apps/nextjs-postcss-example/postcss.config.js` to force using the 'correct' path at monorepo root

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document