### PR TITLE
feat(stylex_compiler_rs): add `normalize_rs_options` util

### DIFF
--- a/crates/stylex-rs-compiler/src/structs/mod.rs
+++ b/crates/stylex-rs-compiler/src/structs/mod.rs
@@ -7,6 +7,7 @@ use stylex_shared::shared::structures::{
 };
 
 #[napi(object)]
+#[derive(Debug)]
 pub struct StyleXModuleResolution {
   pub r#type: String,
   pub root_dir: Option<String>,
@@ -14,6 +15,7 @@ pub struct StyleXModuleResolution {
 }
 
 #[napi(string_enum)]
+#[derive(Debug)]
 pub enum SourceMaps {
   True,
   False,
@@ -21,6 +23,7 @@ pub enum SourceMaps {
 }
 
 #[napi(object)]
+#[derive(Debug)]
 pub struct StyleXOptions {
   pub style_resolution: Option<String>,
   pub use_rem_for_font_size: Option<bool>,

--- a/crates/stylex-shared/src/shared/structures/state_manager.rs
+++ b/crates/stylex-shared/src/shared/structures/state_manager.rs
@@ -241,14 +241,9 @@ impl StateManager {
   ) -> Option<String> {
     let filename = self.get_filename();
 
-    let unstable_module_resolution = self
-      .options
-      .unstable_module_resolution
-      .as_ref()
-      .cloned()
-      .unwrap_or_default();
+    let unstable_module_resolution = &self.options.unstable_module_resolution;
 
-    let theme_file_extension = match &unstable_module_resolution {
+    let theme_file_extension = match unstable_module_resolution {
       CheckModuleResolution::CommonJS(ModuleResolution {
         theme_file_extension,
         ..
@@ -263,10 +258,7 @@ impl StateManager {
       }) => theme_file_extension.as_deref().unwrap_or(".stylex"),
     };
 
-    if filename.is_empty()
-      || !matches_file_suffix(theme_file_extension, filename)
-      || self.options.unstable_module_resolution.is_none()
-    {
+    if filename.is_empty() || !matches_file_suffix(theme_file_extension, filename) {
       return None;
     }
 
@@ -327,22 +319,20 @@ impl StateManager {
       }
     }
 
-    if let Some(module_resolution) = &self.options.unstable_module_resolution {
-      if let Some(root_dir) = match &module_resolution {
-        CheckModuleResolution::CommonJS(module_resolution) => module_resolution.root_dir.as_deref(),
-        CheckModuleResolution::Haste(module_resolution) => module_resolution.root_dir.as_deref(),
-        CheckModuleResolution::CrossFileParsing(module_resolution) => {
-          module_resolution.root_dir.as_deref()
-        }
-      } {
-        let file_path = Path::new(file_path);
-        let root_dir = Path::new(root_dir);
-
-        if let Some(root_dir) = relative_path(file_path, root_dir).to_str() {
-          return root_dir.to_string();
-        }
+    if let Some(root_dir) = match &self.options.unstable_module_resolution {
+      CheckModuleResolution::CommonJS(module_resolution) => module_resolution.root_dir.as_deref(),
+      CheckModuleResolution::Haste(module_resolution) => module_resolution.root_dir.as_deref(),
+      CheckModuleResolution::CrossFileParsing(module_resolution) => {
+        module_resolution.root_dir.as_deref()
       }
-    }
+    } {
+      let file_path = Path::new(file_path);
+      let root_dir = Path::new(root_dir);
+
+      if let Some(root_dir) = relative_path(file_path, root_dir).to_str() {
+        return root_dir.to_string();
+      }
+    };
 
     let file_name = Path::new(file_path)
       .file_name()
@@ -363,11 +353,7 @@ impl StateManager {
       return ImportPathResolution::False;
     }
 
-    let Some(unstable_module_resolution) = &self.options.unstable_module_resolution else {
-      return ImportPathResolution::False;
-    };
-
-    match unstable_module_resolution {
+    match &self.options.unstable_module_resolution {
       CheckModuleResolution::CommonJS(module_resolution) => {
         let filename = self.get_filename();
 

--- a/crates/stylex-shared/src/shared/structures/stylex_state_options.rs
+++ b/crates/stylex-shared/src/shared/structures/stylex_state_options.rs
@@ -22,7 +22,7 @@ pub struct StyleXStateOptions {
   pub treeshake_compensation: Option<bool>,
   pub gen_conditional_classes: bool,
   pub aliases: Option<FxHashMap<String, Vec<String>>>,
-  pub unstable_module_resolution: Option<CheckModuleResolution>,
+  pub unstable_module_resolution: CheckModuleResolution,
 }
 
 impl Default for StyleXStateOptions {
@@ -39,14 +39,16 @@ impl Default for StyleXStateOptions {
       runtime_injection: None,
       gen_conditional_classes: false,
       aliases: None,
-      unstable_module_resolution: None,
+      unstable_module_resolution: CheckModuleResolution::CommonJS(
+        StyleXOptions::get_common_js_module_resolution(None),
+      ),
     }
   }
 }
 
 impl Default for CheckModuleResolution {
   fn default() -> Self {
-    CheckModuleResolution::Haste(StyleXOptions::get_haste_module_resolution(None))
+    CheckModuleResolution::CommonJS(StyleXOptions::get_common_js_module_resolution(None))
   }
 }
 impl From<StyleXOptions> for StyleXStateOptions {

--- a/crates/stylex-shared/src/shared/structures/tests/get_canonical_file_path_test.rs
+++ b/crates/stylex-shared/src/shared/structures/tests/get_canonical_file_path_test.rs
@@ -62,11 +62,11 @@ mod get_canonical_file_path {
     let mut stage_manager = StateManager::default();
 
     stage_manager.options.unstable_module_resolution =
-      Some(CheckModuleResolution::CommonJS(ModuleResolution {
+      CheckModuleResolution::CommonJS(ModuleResolution {
         r#type: "commonjs".to_string(),
         root_dir: Some(fixture_path.parent().unwrap().to_string_lossy().into()),
         theme_file_extension: None,
-      }));
+      });
 
     let canonical_path = stage_manager
       .get_canonical_file_path(fixture_path.to_str().unwrap(), &mut FxHashMap::default());
@@ -83,11 +83,11 @@ mod get_canonical_file_path {
     let mut stage_manager = StateManager::default();
 
     stage_manager.options.unstable_module_resolution =
-      Some(CheckModuleResolution::CommonJS(ModuleResolution {
+      CheckModuleResolution::CommonJS(ModuleResolution {
         r#type: "commonjs".to_string(),
         root_dir: Some(root_dir.to_string_lossy().into()),
         theme_file_extension: None,
-      }));
+      });
 
     let canonical_path = stage_manager.get_canonical_file_path(
       root_dir.join("src/components").to_str().unwrap(),

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,4 +1,4 @@
-import { transform } from '@stylexswc/rs-compiler';
+import { transform, normalizeRsOptions } from '@stylexswc/rs-compiler';
 import { createHash } from 'crypto';
 
 import type { StyleXOptions } from '@stylexswc/rs-compiler';
@@ -16,7 +16,11 @@ const process: SyncTransformer<JestTransformerConfig>['process'] = function proc
   sourcePath,
   options
 ) {
-  const { code } = transform(sourcePath, sourceText, options.transformerConfig.rsOptions ?? {});
+  const { code } = transform(
+    sourcePath,
+    sourceText,
+    normalizeRsOptions(options.transformerConfig.rsOptions ?? {})
+  );
 
   return { code };
 };

--- a/packages/postcss-plugin/src/bundler.ts
+++ b/packages/postcss-plugin/src/bundler.ts
@@ -1,5 +1,6 @@
 import stylexBabelPlugin from '@stylexjs/babel-plugin';
-import { StyleXOptions, transform as stylexTransform } from '@stylexswc/rs-compiler';
+import { transform as stylexTransform, normalizeRsOptions } from '@stylexswc/rs-compiler';
+import type { StyleXOptions } from '@stylexswc/rs-compiler';
 
 import type { TransformOptions, StyleXPluginOption } from './types';
 
@@ -28,7 +29,7 @@ export default function createBundler() {
     };
 
     try {
-      transformResult = stylexTransform(id, sourceCode, rsOptions);
+      transformResult = stylexTransform(id, sourceCode, normalizeRsOptions(rsOptions ?? {}));
     } catch (error) {
       if (shouldSkipTransformError) {
         console.warn(

--- a/packages/postcss-plugin/src/index.ts
+++ b/packages/postcss-plugin/src/index.ts
@@ -42,14 +42,7 @@ const plugin = ({
           include,
           exclude,
           cwd,
-          rsOptions: {
-            useRemForFontSize: true,
-            runtimeInjection: false,
-            genConditionalClasses: true,
-            treeshakeCompensation: true,
-            importSources: ['stylex', '@stylexjs/stylex'],
-            ...rsOptions,
-          },
+          rsOptions,
           useCSSLayers,
           isDev,
         });

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -8,8 +8,10 @@ import type { BuildOptions } from 'vite';
 import getStyleXRules from './utils/getStyleXRules';
 import normalizeOptions from './utils/normalizeOptions';
 import type { UnpluginStylexRSOptions } from './types';
-import stylexRsCompiler, { StyleXMetadata } from '@stylexswc/rs-compiler';
+import stylexRsCompiler from '@stylexswc/rs-compiler';
 import generateHash from './utils/generateHash';
+
+import type { StyleXMetadata } from '@stylexswc/rs-compiler';
 
 const { writeFile, mkdir } = promises;
 

--- a/packages/unplugin/src/utils/normalizeOptions.ts
+++ b/packages/unplugin/src/utils/normalizeOptions.ts
@@ -1,6 +1,6 @@
-import type { UnpluginStylexRSOptions } from '../types';
+import { normalizeRsOptions } from '@stylexswc/rs-compiler';
 
-const IS_DEV_ENV = process.env.NODE_ENV === 'development';
+import type { UnpluginStylexRSOptions } from '../types';
 
 export default function normalizeOptions(
   options: UnpluginStylexRSOptions
@@ -10,15 +10,7 @@ export default function normalizeOptions(
     fileName: options.fileName ?? 'stylex.css',
     useCSSLayers: options.useCSSLayers ?? false,
     pageExtensions: options.pageExtensions ?? ['tsx', 'jsx', 'js', 'ts'],
-    rsOptions: {
-      ...options.rsOptions,
-      dev: options.rsOptions?.dev ?? IS_DEV_ENV,
-      unstable_moduleResolution: options.rsOptions?.unstable_moduleResolution ?? {
-        type: 'commonJS',
-        rootDir: process.cwd(),
-      },
-      importSources: options.rsOptions?.importSources ?? ['stylex', '@stylexjs/stylex'],
-    },
+    rsOptions: normalizeRsOptions(options.rsOptions || {}),
     extractCSS: options.extractCSS ?? true,
   };
 }

--- a/packages/webpack-plugin/src/utils.ts
+++ b/packages/webpack-plugin/src/utils.ts
@@ -1,4 +1,4 @@
-import stylexPlugin from '@stylexswc/rs-compiler';
+import stylexPlugin, { normalizeRsOptions } from '@stylexswc/rs-compiler';
 
 import type webpack from 'webpack';
 import type { Rule } from '@stylexjs/babel-plugin';
@@ -49,5 +49,5 @@ export function generateStyleXOutput(
     return { code, map, metadata };
   }
 
-  return stylexPlugin.transform(resourcePath, inputSource, rsOptions);
+  return stylexPlugin.transform(resourcePath, inputSource, normalizeRsOptions(rsOptions ?? {}));
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This function is used to normalize the options passed to the transform function of `@stylexswc/rs-compiler` crate. This is useful for ensuring that the options are in a consistent format before being passed to the compiler.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document