### PR TITLE
fix(whitespace_normalizer): parsing expressions with negative values

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -263,8 +263,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cache
-          key: ${{ matrix.settings.target }}-benchmark-${{ github.ref }}
+          key: ${{ matrix.settings.target }}-benchmark-${{ matrix.node }}-${{ github.ref }}
           restore-keys: |
+            ${{ matrix.settings.target }}-benchmark-${{ matrix.node }}-
             ${{ matrix.settings.target }}-benchmark-
       - name: Run benchmarks
         run: pnpm run --filter @stylexswc/rs-compiler bench

--- a/crates/stylex-shared/src/shared/regex.rs
+++ b/crates/stylex-shared/src/shared/regex.rs
@@ -8,7 +8,7 @@ pub(crate) static CSS_RULE_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"\w+:\s*([^;}]+);?").unwrap());
 
 pub(crate) static WHITESPACE_NORMALIZER_MATH_SIGNS_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"(\d+%?|\))\s*([+\-*/%])\s*(\d*\.?\d+|\()").unwrap());
+  Lazy::new(|| Regex::new(r"(\d+%?|\))(\s*)([+\-*/%])(\s*)(\d*\.?\d+|\()").unwrap());
 
 pub(crate) static SANITIZE_CLASS_NAME_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"[^.a-zA-Z0-9_-]").unwrap());

--- a/crates/stylex-shared/src/shared/utils/css/normalizers/whitespace_normalizer.rs
+++ b/crates/stylex-shared/src/shared/utils/css/normalizers/whitespace_normalizer.rs
@@ -24,14 +24,25 @@ pub(crate) fn whitespace_normalizer(content: String) -> String {
   // Normalize math signs
   css = WHITESPACE_NORMALIZER_MATH_SIGNS_REGEX
     .replace_all(&css, |caps: &regex::Captures| {
-      let num1 = &caps[1];
-      let op = &caps[2];
-      let num2 = &caps[3];
+      let left = &caps[1];
+      let op = &caps[3];
+      // Represents the trailing whitespace captured by the regular expression.
+      // Will be empty if there is no whitespace after the value.
+      let right_space = &caps[4];
+      let right = &caps[5];
 
       if op == "%" {
-        format!("{}{} {}", num1, op, num2)
+        // Attach percent to left with no space, then one space before right.
+        format!("{}{} {}", left, op, right)
+      } else if op == "-" {
+        if right_space.is_empty() {
+          format!("{} {}{}", left, op, right)
+        } else {
+          format!("{} {} {}", left, op, right)
+        }
       } else {
-        format!("{} {} {}", num1, op, num2)
+        // Other operators, always normalize to one space around.
+        format!("{} {} {}", left, op, right)
       }
     })
     .to_string();

--- a/crates/stylex-shared/src/shared/utils/css/tests/css_custom_properties_validation_test.rs
+++ b/crates/stylex-shared/src/shared/utils/css/tests/css_custom_properties_validation_test.rs
@@ -380,4 +380,24 @@ mod css_tests {
       r#"url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAMUlEQVQ4T2NkYGAQYcAP3uCTZhw1gGGYhAGBZIA/nYDCgBDAm9BGDWAAJyRCgLaBCAAgXwixzAS0pgAAAABJRU5ErkJggg==")"#,
     );
   }
+  #[test]
+  fn filter_properties() {
+    assert_eq!(
+      transform_value_cached(
+        "filter",
+        "drop-shadow(0 2px 10px rgba(0, 0, 0, 0.1))",
+        &mut StateManager::default()
+      ),
+      "drop-shadow(0 2px 10px rgba(0,0,0,.1))"
+    );
+
+    assert_eq!(
+      transform_value_cached(
+        "filter",
+        "drop-shadow(0 -2px 10px rgba(0, 0, 0, 0.1))",
+        &mut StateManager::default()
+      ),
+      "drop-shadow(0 -2px 10px rgba(0,0,0,.1))"
+    );
+  }
 }


### PR DESCRIPTION
# Pull Request Template

## Description


This PR includes changes to improve the handling of whitespace in CSS math expressions and adds new tests for CSS property transformations.

## Fixes 

(Optional) Issue #232 

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
