### PR TITLE
fix(nextjs-plugin): pass the path to resource file to the postcss process to prevent warning

### DIFF
--- a/packages/nextjs-plugin/README.md
+++ b/packages/nextjs-plugin/README.md
@@ -85,7 +85,7 @@ npm install --save-dev @stylexswc/nextjs-plugin
 
 #### `transformCss`
 
-- Type: `(css: string) => string | Buffer | Promise<string | Buffer>`
+- Type: `(css: string, filePath: string | undefined) => string | Buffer | Promise<string | Buffer>`
 - Optional
 - Description: Custom CSS transformation function. Since the plugin injects CSS
   after all loaders, use this to apply PostCSS or other CSS transformations.
@@ -111,9 +111,15 @@ module.exports = stylexPlugin({
   },
   stylexImports: ['@stylexjs/stylex', { from: './theme', as: 'tokens' }],
   useCSSLayers: true,
-  transformCss: async css => {
+  transformCss: async (css, filePath) => {
     const postcss = require('postcss');
-    const result = await postcss([require('autoprefixer')]).process(css);
+    const result = await postcss([require('autoprefixer')]).process(css, {
+      from: filePath,
+      map: {
+        inline: false,
+        annotation: false,
+      },
+    });
     return result.css;
   },
 })({

--- a/packages/nextjs-plugin/src/index.ts
+++ b/packages/nextjs-plugin/src/index.ts
@@ -217,12 +217,19 @@ const withStyleX =
             nextjsMode: true,
             ...(extractCSS
               ? {
-                  async transformCss(css) {
+                  async transformCss(css, filePath) {
                     const { postcssWithPlugins } = await postcss();
-                    const result = await postcssWithPlugins.process(css);
+
+                    const result = await postcssWithPlugins.process(css, {
+                      from: filePath,
+                      map: {
+                        inline: false,
+                        annotation: false,
+                      },
+                    });
 
                     if (typeof pluginOptions?.transformCss === 'function') {
-                      return pluginOptions.transformCss(result.css);
+                      return pluginOptions.transformCss(result.css, filePath);
                     }
 
                     return result.css;

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -37,11 +37,16 @@ const config = (env, argv) => ({
   plugins: [
     new StylexPlugin({
       // ... Other StyleX options
-      transformCss: css => {
-        // Transform CSS here, for example, using PostCSS
-        const transformedCSS = css;
-
-        return transformedCSS;
+      transformCss: async (css, filePath) => {
+        const postcss = require('postcss');
+        const result = await postcss([require('autoprefixer')]).process(css, {
+          from: filePath,
+          map: {
+            inline: false,
+            annotation: false,
+          },
+        });
+        return result.css;
       },
     }),
   ],
@@ -95,7 +100,7 @@ module.exports = config;
 
 #### `transformCss`
 
-- Type: `(css: string) => string | Buffer | Promise<string | Buffer>`
+- Type: `(css: string, filePath: string | undefined) => string | Buffer | Promise<string | Buffer>`
 - Optional
 - Description: Custom CSS transformation function. Since the plugin injects CSS
   after all loaders, use this to apply PostCSS or other CSS transformations.

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -214,8 +214,8 @@ export default class StyleXPlugin {
             return;
           }
 
-          const finalCss = await this.transformCss(stylexCSS);
           const cssAsset = stylexAsset?.[0];
+          const finalCss = await this.transformCss(stylexCSS, cssAsset);
 
           if (cssAsset) {
             compilation.updateAsset(

--- a/packages/webpack-plugin/src/types.ts
+++ b/packages/webpack-plugin/src/types.ts
@@ -8,7 +8,10 @@ type AsyncFnParams = Parameters<ReturnType<LoaderContext<unknown>['async']>>;
 export type InputCode = AsyncFnParams['1'];
 export type SourceMap = AsyncFnParams['2'];
 
-export type CSSTransformer = (_css: string) => string | Buffer | Promise<string | Buffer>;
+export type CSSTransformer = (
+  _css: string,
+  _filePath: string | undefined
+) => string | Buffer | Promise<string | Buffer>;
 export interface StyleXPluginOption extends Pick<StyleXWebpackLoaderOptions, 'transformer'> {
   /**
    * stylex options passed to stylex babel plugin


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request includes several updates to enhance the CSS transformation functionality in both the Next.js and Webpack plugins. The primary changes involve modifying the `transformCss` function to accept an additional `filePath` parameter, which allows for better handling of source maps and file annotations.

## Fixes

(Optional) Fixes #236 

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
