### PR TITLE
fix(stylex_shared): prevent variable name conflicts with imported theme variable

### DIFF
--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/stylex_transform_stylex_props_test/naming_conventions_with_dynamisms.rs/stylex_call_props_with_renaming_dynamic_styles_prop_and_conflict_import_name.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/stylex_transform_stylex_props_test/naming_conventions_with_dynamisms.rs/stylex_call_props_with_renaming_dynamic_styles_prop_and_conflict_import_name.js
@@ -1,0 +1,32 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import "@stylexjs/open-props/lib/fonts.stylex";
+import * as stylex from '@stylexjs/stylex';
+import { fonts as foo } from '@stylexjs/open-props/lib/fonts.stylex';
+import { type ReactNode } from 'react';
+_inject2(".x13rv2e4{color:hotpink}", 3000);
+const styles = {
+    text: {
+        color: "x13rv2e4",
+        $$css: true
+    }
+};
+_inject2(".x1nbzn64{font-size:var(--xz4eux4)}", 3000);
+_inject2(".xx5h6fz{font-size:var(--xsnljwq)}", 3000);
+const variants = {
+    small: {
+        fontSize: "x1nbzn64",
+        $$css: true
+    },
+    big: {
+        fontSize: "xx5h6fz",
+        $$css: true
+    }
+};
+export interface TextProps {
+    children: ReactNode;
+    size: keyof typeof variants;
+}
+export function Text2({ children, size: foo }: TextProps) {
+    return <div {...stylex.props(styles.text, variants[foo])}>{children}</div>;
+}

--- a/crates/stylex-shared/tests/stylex_transform_stylex_props_test/naming_conventions_with_dynamisms.rs
+++ b/crates/stylex-shared/tests/stylex_transform_stylex_props_test/naming_conventions_with_dynamisms.rs
@@ -230,3 +230,46 @@ test!(
 
     "#
 );
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| StyleXTransform::new_test_force_runtime_injection_with_pass(
+    tr.comments.clone(),
+    PluginPass::default(),
+    None
+  ),
+  stylex_call_props_with_renaming_dynamic_styles_prop_and_conflict_import_name,
+  r#"
+        import * as stylex from '@stylexjs/stylex';
+        import { fonts as foo } from '@stylexjs/open-props/lib/fonts.stylex';
+
+        import { type ReactNode } from 'react';
+
+        const styles = stylex.create({
+          text: {
+            color: 'hotpink',
+          },
+        });
+
+        const variants = stylex.create({
+          small: {
+            fontSize: foo.size1
+          },
+          big: {
+            fontSize: foo.size7
+          }
+        })
+
+        export interface TextProps {
+          children: ReactNode;
+          size: keyof typeof variants;
+        }
+
+        export function Text2({ children, size: foo }: TextProps) {
+          return <div {...stylex.props(styles.text, variants[foo])}>{children}</div>;
+        }
+    "#
+);


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request includes changes to improve error handling and add a new test case in the `stylex-shared` crate. The most important changes include enhancing the evaluation function to handle theme references and adding a test for dynamic style properties with conflicting import names.

## Fixes

Issue #240

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
