### PR TITLE
refactor(stylex_shared): improve error message when theme used as object property

### DIFF
--- a/crates/stylex-shared/src/shared/constants/messages.rs
+++ b/crates/stylex-shared/src/shared/constants/messages.rs
@@ -72,3 +72,6 @@ pub(crate) static UNPREFIXED_CUSTOM_PROPERTIES: &str = "Unprefixed custom proper
 
 pub(crate) static NON_CONTIGUOUS_VARS: &str =
   "All variables passed to `stylex.firstThatWorks` must be contiguous.";
+
+pub(crate) static THEME_IMPORT_KEY_AS_OBJECT_KEY: &str =
+  "Theme import keys cannot be used as object keys. Please use a valid object key.";


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request introduces a new error message for theme import keys and integrates it into the existing codebase. The changes ensure that theme import keys are not used as object keys and provide appropriate error handling and messaging.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
