### PR TITLE
fix(resolve_file_path): allow resolution of aliases that don't includes root path

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -57,10 +57,25 @@ jobs:
       repository-projects: write
 
     steps:
-      - name: Checkout code
+      - uses: actions/github-script@v6
+        if: github.event.pull_request.number != null
+        id: pr
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            return pullRequest
+      - name: Checkout PR code
+        if: github.event.pull_request.number != null
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{fromJSON(steps.pr.outputs.result).merge_commit_sha}}
+
+      - name: Checkout branch code
+        if: github.event.pull_request.number == null
+        uses: actions/checkout@v4
 
       - name: Setup environment
         uses: ./.github/actions/setup

--- a/crates/stylex-path-resolver/src/resolvers/mod.rs
+++ b/crates/stylex-path-resolver/src/resolvers/mod.rs
@@ -371,7 +371,6 @@ pub fn resolve_file_path(
   } else {
     let mut possible_file_paths = possible_aliased_paths(import_path_str, aliases)
       .iter()
-      .filter_map(|path| path.strip_prefix(root_path).ok())
       .map(PathBuf::from)
       .collect::<IndexSet<PathBuf>>();
 
@@ -431,7 +430,7 @@ pub fn resolve_file_path(
           resolved_file_path.set_extension(format!("{}{}", subpath, ext));
         }
       } else {
-        resolved_file_path.set_extension(ext);
+        resolved_file_path.set_extension(ext.trim_start_matches("."));
       }
 
       let cleaned_path = resolved_file_path.to_string_lossy().to_string();


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request includes several changes to the `stylex-path-resolver` module, focusing on improving the path resolution logic and adding new test cases. The most important changes include modifying the `resolve_file_path` function to handle extensions correctly, adding new test cases for workspace alias resolution, and updating existing test modules.

## Fixes

(Optional) Issue #258

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
