### PR TITLE
fix(stylex.props): not reduce var decl counts

### DIFF
--- a/crates/stylex-shared/src/shared/utils/core/stylex_merge.rs
+++ b/crates/stylex-shared/src/shared/utils/core/stylex_merge.rs
@@ -196,7 +196,7 @@ pub(crate) fn stylex_merge(
       bail_out_index = member_transform.bail_out_index;
       non_null_props = member_transform.non_null_props;
 
-      *state = member_transform.state.clone();
+      *state = member_transform.state;
     }
 
     for arg in args.iter() {

--- a/crates/stylex-shared/src/transform/fold/fold_member_expression.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_member_expression.rs
@@ -28,13 +28,13 @@ where
         if let Some(obj_ident) = member_expression.obj.as_ident() {
           match self.state.cycle {
             TransformationCycle::StateFilling => {
-              increase_member_ident_count(&mut self.state, &obj_ident.sym)
+              increase_member_ident_count(&mut self.state, &obj_ident.sym);
             }
             TransformationCycle::Recounting => {
-              reduce_member_ident_count(&mut self.state, &obj_ident.sym)
+              reduce_member_ident_count(&mut self.state, &obj_ident.sym);
             }
             _ => {}
-          }
+          };
         }
         member_expression.fold_children_with(self)
       }

--- a/crates/stylex-shared/tests/fixture/buttons-demo/input.stylex.js
+++ b/crates/stylex-shared/tests/fixture/buttons-demo/input.stylex.js
@@ -4,12 +4,12 @@ import * as stylex from "@stylexjs/stylex";
 import { buttonTokens } from "./ButtonTokens.stylex";
 import ThemeableButton from "./ThemeableButton";
 
-export default function ButtonsDemo(_props) {
+export default function ButtonsDemo(props) {
   const onClick = () => {
     console.log("click");
   };
   return (
-    <div {...stylex.props(styles.container)}>
+    <div {...stylex.props(styles.container, intents[props.intent])}>
       <ThemeableButton onClick={onClick}>Vanilla Button</ThemeableButton>
 
       <ThemeableButton onClick={onClick} style={styles.bordered}>
@@ -63,3 +63,20 @@ const styles = stylex.create({
     borderColor: "green",
   },
 });
+
+
+const priorityIntent = stylex.createTheme(buttonTokens, {
+  background: { default: '#000' },
+  text: { default: '#fff' },
+});
+
+const defaultIntent = stylex.createTheme(buttonTokens, {
+  // backgroundColor: `color-mix(red, white 20%)`, // red but 20% more white
+  background: { default: '#000000' },
+  text: { default: '#555555' },
+});
+
+const intents = {
+  priority: priorityIntent,
+  default: defaultIntent,
+};

--- a/crates/stylex-shared/tests/fixture/buttons-demo/output.js
+++ b/crates/stylex-shared/tests/fixture/buttons-demo/output.js
@@ -5,14 +5,11 @@ import "./ButtonTokens.stylex";
 import * as stylex from "@stylexjs/stylex";
 import { buttonTokens } from "./ButtonTokens.stylex";
 import ThemeableButton from "./ThemeableButton";
-export default function ButtonsDemo(_props) {
+export default function ButtonsDemo(props) {
     const onClick = ()=>{
         console.log("click");
     };
-    return <div {...{
-        className: "display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-xl56j7k gap-xou54vl paddingBottom-xzk7aed",
-        "data-style-src": "input.stylex.js:49"
-    }}>
+    return <div {...stylex.props(styles.container, intents[props.intent])}>
       <ThemeableButton onClick={onClick}>Vanilla Button</ThemeableButton>
 
       <ThemeableButton onClick={onClick} style={styles.bordered}>
@@ -54,6 +51,17 @@ _inject2(".borderStyle-x1y0btm7{border-style:solid}", 2000);
 _inject2(".borderColor-x71xlcl{border-color:red}", 2000);
 _inject2(".borderColor-x1bg2uv5{border-color:green}", 2000);
 const styles = {
+    container: {
+        display: "display-x78zum5",
+        flexDirection: "flexDirection-xdt5ytf",
+        alignItems: "alignItems-x6s0dn4",
+        justifyContent: "justifyContent-xl56j7k",
+        gap: "gap-xou54vl",
+        rowGap: null,
+        columnGap: null,
+        paddingBottom: "paddingBottom-xzk7aed",
+        $$css: "input.stylex.js:49"
+    },
     bordered: {
         borderWidth: "borderWidth-xdh2fpr",
         borderInlineWidth: null,
@@ -96,4 +104,20 @@ const styles = {
         borderBottomColor: null,
         $$css: "input.stylex.js:62"
     }
+};
+_inject2(".xm1pwqw, .xm1pwqw:root{--background-x166rmrk:#000;--text-x1rr8s3j:#fff;}", 0.5);
+const priorityIntent = {
+    input__priorityIntent: "input__priorityIntent",
+    $$css: true,
+    "__themeName__-xhq9i64": "xm1pwqw "
+};
+_inject2(".x1h9f7e8, .x1h9f7e8:root{--background-x166rmrk:#000000;--text-x1rr8s3j:#555555;}", 0.5);
+const defaultIntent = {
+    input__defaultIntent: "input__defaultIntent",
+    $$css: true,
+    "__themeName__-xhq9i64": "x1h9f7e8 "
+};
+const intents = {
+    priority: priorityIntent,
+    default: defaultIntent
 };

--- a/crates/stylex-shared/tests/fixture/buttons-demo/output_prod.js
+++ b/crates/stylex-shared/tests/fixture/buttons-demo/output_prod.js
@@ -2,13 +2,11 @@
 import * as stylex from "@stylexjs/stylex";
 import { buttonTokens } from "./ButtonTokens.stylex";
 import ThemeableButton from "./ThemeableButton";
-export default function ButtonsDemo(_props) {
+export default function ButtonsDemo(props) {
     const onClick = ()=>{
         console.log("click");
     };
-    return <div {...{
-        className: "x78zum5 xdt5ytf x6s0dn4 xl56j7k xou54vl xzk7aed"
-    }}>
+    return <div {...stylex.props(styles.container, intents[props.intent])}>
       <ThemeableButton onClick={onClick}>Vanilla Button</ThemeableButton>
 
       <ThemeableButton onClick={onClick} style={styles.bordered}>
@@ -38,6 +36,17 @@ const redTheme = {
     xhq9i64: "x1idg7kz "
 };
 const styles = {
+    container: {
+        display: "x78zum5",
+        flexDirection: "xdt5ytf",
+        alignItems: "x6s0dn4",
+        justifyContent: "xl56j7k",
+        gap: "xou54vl",
+        rowGap: null,
+        columnGap: null,
+        paddingBottom: "xzk7aed",
+        $$css: true
+    },
     bordered: {
         borderWidth: "xdh2fpr",
         borderInlineWidth: null,
@@ -80,4 +89,16 @@ const styles = {
         borderBottomColor: null,
         $$css: true
     }
+};
+const priorityIntent = {
+    $$css: true,
+    xhq9i64: "x13g83z8 "
+};
+const defaultIntent = {
+    $$css: true,
+    xhq9i64: "x13xmhq7 "
+};
+const intents = {
+    priority: priorityIntent,
+    default: defaultIntent
 };


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request includes several changes to the `stylex-shared` crate, focusing on improving the handling of style intents and refining the error handling and state management in various modules. The most important changes include updates to the `ButtonsDemo` component, enhancements to the `evaluate` function, and refinements to state management in the `stylex_merge` and `fold_member_expression` functions.

## Fixes

(Optional) Issue #258

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
