### PR TITLE
docs(stylexswc/rs-compiler): add `debug` section

### DIFF
--- a/crates/stylex-rs-compiler/README.md
+++ b/crates/stylex-rs-compiler/README.md
@@ -137,6 +137,41 @@ const styleProps = {
 > [issue](https://github.com/Dwlad90/stylex-swc-plugin/issues/new) with an
 > attached link to reproduce the problem.
 
+## Debug
+
+You can enable debug logging for the StyleX compiler using the `STYLEX_DEBUG` environment variable. This is useful for troubleshooting and understanding the internal processing of StyleX code.
+
+### Log Levels
+
+The following log levels are available:
+- `error`: Only shows error messages
+- `warn`: Shows warnings and errors (default)
+- `info`: Shows informational messages, warnings, and errors
+- `debug`: Shows debug information and all above levels
+- `trace`: Shows very detailed execution information
+
+### Usage
+
+Set the environment variable before running your build command:
+
+```bash
+# Set to debug level
+STYLEX_DEBUG=debug npm run build
+
+# Set to trace for most verbose output
+STYLEX_DEBUG=trace npm run dev
+```
+
+For Windows Command Prompt:
+```cmd
+set STYLEX_DEBUG=debug && npm run build
+```
+
+For PowerShell:
+```powershell
+$env:STYLEX_DEBUG="debug"; npm run build
+```
+
 ## License
 
 StyleX is MIT licensed. StyleX NAPI-RS compiler is also MIT licensed.


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request includes updates to the `crates/stylex-rs-compiler/README.md` file to add a new section on enabling debug logging for the StyleX compiler. The most important changes include the addition of log levels, usage instructions for setting the `STYLEX_DEBUG` environment variable, and examples for different operating systems.

Documentation updates:

* Added a new "Debug" section explaining how to enable debug logging for the StyleX compiler using the `STYLEX_DEBUG` environment variable.
* Listed available log levels: `error`, `warn`, `info`, `debug`, and `trace`, with descriptions for each.
* Provided usage instructions for setting the `STYLEX_DEBUG` environment variable before running build commands.
* Included examples for setting the `STYLEX_DEBUG` variable in Bash, Windows Command Prompt, and PowerShell.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
