### PR TITLE
ci(release): add dev-deps label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -69,6 +69,11 @@ changelog:
         - 'deps-updates'
         - 'deps-update'
         - 'deps-updates'
+    - title: Development Dependency Updates 🛠
+      labels:
+        - 'dev-deps'
+        - 'dev-dependencies'
+        - 'dev-dependency'
     - title: Chores 🧹
       labels:
         - 'chore'


### PR DESCRIPTION
## Description

This pull request includes changes to the `.github/release.yml` file to add new labels for dependency updates.

* Added new labels for development dependencies: `dev-deps`, `dev-dependencies`, and `dev-depedency`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
