### PR TITLE
chore(cargo.toml): remove unnecessary stylex_path_resolver from workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ colored = { version = "3.0.0" }
 node-resolve = { version = "2.2.0" }
 path-clean = { version = "1.0.1" }
 cssparser = { version = "0.34.0" }
-stylex_path_resolver = { path = "../path-resolver" }
 testing = "8.0.0"
 insta = { version = "1.42.2" }
 anyhow = "1.0.97"


### PR DESCRIPTION
## Description

This pull request includes a small change to the `Cargo.toml` file. The change removes the dependency on `stylex_path_resolver` by deleting the line specifying its path.

Dependency removal:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L54): Removed the dependency on `stylex_path_resolver` by deleting its path specification.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
