### PR TITLE
ci(ga): use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/cleanup-pr.yaml
+++ b/.github/workflows/cleanup-pr.yaml
@@ -3,9 +3,6 @@ on:
   pull_request:
     types:
       - closed
-  pull_request_target:
-    types:
-      - closed
 
 jobs:
   cleanup:

--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -1,7 +1,7 @@
 name: Conventional Release Labels
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, edited]
 
 permissions:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,20 +1,7 @@
 name: Pull Request Validation
 
 on:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - reopened
-  #     - synchronize
-  #     - ready_for_review
-  #     - converted_to_draft
-  #   paths-ignore:
-  #     - '**/*.md'
-  #     - LICENSE
-  #     - '**/*.gitignore'
-  #     - .editorconfig
-  #     - docs/**
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened


### PR DESCRIPTION
GitHub workflows can be triggered through various repository events, including incoming pull requests (PRs) or comments on Issues/PRs. A potentially dangerous misuse of the triggers such as pull_request_target or issue_comment followed by an explicit checkout of untrusted code (Pull Request HEAD) may lead to repository compromise if untrusted code gets executed in a privileged job.

## Description


This pull request updates GitHub Actions workflows to replace the use of the `pull_request_target` event with the `pull_request` event for improved security and consistency. The most important changes are outlined below.

### Workflow Event Updates:

* [`.github/workflows/cleanup-pr.yaml`](diffhunk://#diff-1f5c754b0cf9ef2da78aef14fdb8d04264ebe35e725f068a0554b00c8f91ea95L6-L8): Removed the `pull_request_target` event and retained only the `pull_request` event for the `closed` type.
* [`.github/workflows/conventional-label.yaml`](diffhunk://#diff-30cacd4bd2bbdae6e0d4b0324847c420f5ad1e3ff93b9e9524090ee2229fc112L4-R4): Replaced the `pull_request_target` event with the `pull_request` event for types `opened`, `synchronize`, `reopened`, and `edited`.
* [`.github/workflows/pr-validation.yml`](diffhunk://#diff-04af3c9c96028eebf4fa93d5c67e1fa08255fb7a3682f912ccd5bea1dff5ccd4L4-R4): Switched from the `pull_request_target` event to the `pull_request` event and removed commented-out configurations for paths to ignore.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
