### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ run-name:
   ${{ inputs.type }} | ${{ github.event.inputs.prerelease == 'true' && format('{0}',
   inputs.prerelease-type) || 'stable' }} | ${{ github.ref_name }} | @${{ github.actor }}
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -359,6 +362,8 @@ jobs:
     name: Merge to master branch
     needs: [merge-develop, calculate-version]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: 🛠️ Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/31](https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/31)

To fix the issue, we will add a `permissions` block to the `merge-master` job to explicitly define the least privileges required. Since the job involves merging branches and pushing changes, it requires `contents: write` permissions. We will also add a `permissions` block at the workflow level with `contents: read` as the default, ensuring other jobs inherit minimal permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
