### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup-branch.yaml
+++ b/.github/workflows/cleanup-branch.yaml
@@ -1,4 +1,7 @@
 name: Clean up branch caches
+permissions:
+  contents: read
+  actions: write
 on:
   push:
     branches:

--- a/.github/workflows/cleanup-pr.yaml
+++ b/.github/workflows/cleanup-pr.yaml
@@ -1,4 +1,7 @@
 name: Clean up PR caches
+permissions:
+  contents: read
+  pull-requests: read
 on:
   pull_request:
     types:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,4 +1,6 @@
 name: Clean up caches
+permissions:
+  contents: write
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   merge:
     name: Fast Forward PR Merge
+    permissions:
+      contents: write
+      actions: write
     if: |
       github.event.issue.pull_request != '' &&
       contains(github.event.comment.body, '/merge') &&

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -62,6 +62,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{fromJSON(steps.pr.outputs.result).merge_commit_sha}}
+          fetch-depth: 0
+          fetch-tags: false
 
       - name: Checkout branch code
         if: github.event.pull_request.number == null

--- a/.github/workflows/self-approve.yml
+++ b/.github/workflows/self-approve.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   self-approve:
     name: Self Approve PR
+    permissions:
+      contents: read
+      pull-requests: write
     if: |
       github.event.issue.pull_request != '' &&
       contains(github.event.comment.body, '/approve') &&

--- a/apps/esbuild-unplugin-example/playwright.config.ts
+++ b/apps/esbuild-unplugin-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3002);
 

--- a/apps/farm-unplugin-example/playwright.config.ts
+++ b/apps/farm-unplugin-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3003);
 

--- a/apps/nextjs-example/playwright.config.ts
+++ b/apps/nextjs-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3000);
 

--- a/apps/nextjs-postcss-example/playwright.config.ts
+++ b/apps/nextjs-postcss-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3001);
 

--- a/apps/rollup-unplugin-example/playwright.config.ts
+++ b/apps/rollup-unplugin-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3004);
 

--- a/apps/rsbuild-unplugin-example/playwright.config.ts
+++ b/apps/rsbuild-unplugin-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3005);
 

--- a/apps/rspack-unplugin-example/playwright.config.ts
+++ b/apps/rspack-unplugin-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3006);
 

--- a/apps/solid-unplugin-example/playwright.config.ts
+++ b/apps/solid-unplugin-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3007);
 

--- a/apps/vite-unplugin-example/playwright.config.ts
+++ b/apps/vite-unplugin-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3008);
 

--- a/apps/vue-unplugin-example/playwright.config.ts
+++ b/apps/vue-unplugin-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3009);
 

--- a/apps/webpack-unplugin-example/playwright.config.ts
+++ b/apps/webpack-unplugin-example/playwright.config.ts
@@ -1,5 +1,5 @@
-import defaultConfig from '@stylexswc/playwright';
 import { defineConfig } from '@playwright/test';
+import defaultConfig from '@stylexswc/playwright';
 
 const PORT = +(process.env.PORT || 3010);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/19](https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/19)

Potential fix for [https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/20](https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/20)

Potential fix for [https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/21](https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/21)

Potential fix for [https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/22](https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/22)

Potential fix for [https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/23](https://github.com/Dwlad90/stylex-swc-plugin/security/code-scanning/23)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the workflow to function correctly. Since the workflow approves pull requests, it requires `pull-requests: write`. Additionally, the `contents: read` permission is needed for basic repository access. These permissions will be added at the job level to limit their scope to the `self-approve` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
