### PR TITLE
chore(rust): bump version 1.89.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
       "pnpmVersion": "9.15.4"
     },
     "ghcr.io/devcontainers/features/rust:1": {
-      "version": "1.86.0",
+      "version": "1.89.0",
       "targets": [
         "wasm32-wasip1",
         "x86_64-apple-darwin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/stylex-*"]
 [workspace.package]
 version = "0.10.6"
 edition = "2024"
-rust-version = "1.86.0"
+rust-version = "1.89.0"
 license = "MIT"
 repository = "https://github.com/Dwlad90/stylex-swc-plugin.git"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -22,5 +22,5 @@ ignore-interior-mutability = [
   "swc_atoms::JsWord",
   "swc_ecma_ast::Id",
 ]
-msrv = "1.86.0"
+msrv = "1.89.0"
 type-complexity-threshold = 25000

--- a/crates/stylex-css-parser/Cargo.toml
+++ b/crates/stylex-css-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stylex_css_parser"
 version = "0.10.6"
 edition = "2024"
-rust-version = "1.86.0"
+rust-version = "1.89.0"
 description = "CSS value parser"
 license = "MIT"
 repository = "https://github.com/Dwlad90/stylex-swc-plugin.git"

--- a/crates/stylex-css-parser/src/at_queries/media_query_transform.rs
+++ b/crates/stylex-css-parser/src/at_queries/media_query_transform.rs
@@ -67,10 +67,10 @@ fn dfs_process_queries_with_depth(obj: &[KeyValueProp], depth: u32) -> Vec<KeyVa
         // Extract key-value pairs from the object
         let mut key_values = Vec::new();
         for obj_prop in &obj_lit.props {
-          if let PropOrSpread::Prop(p) = obj_prop {
-            if let Prop::KeyValue(kv) = &**p {
-              key_values.push(kv.clone());
-            }
+          if let PropOrSpread::Prop(p) = obj_prop
+            && let Prop::KeyValue(kv) = &**p
+          {
+            key_values.push(kv.clone());
           }
         }
 
@@ -158,26 +158,26 @@ fn transform_media_queries_in_result(result: Vec<KeyValueProp>) -> Vec<KeyValueP
 
   // Process media queries with negations
   for (i, media_key) in media_keys.iter().enumerate() {
-    if let Some(original_kv) = result.iter().find(|kv| key_value_to_str(kv) == *media_key) {
-      if let Ok(base_mq) = MediaQuery::parser().parse_to_end(media_key) {
-        let mut reversed_negations = accumulated_negations[i].clone();
-        reversed_negations.reverse();
+    if let Some(original_kv) = result.iter().find(|kv| key_value_to_str(kv) == *media_key)
+      && let Ok(base_mq) = MediaQuery::parser().parse_to_end(media_key)
+    {
+      let mut reversed_negations = accumulated_negations[i].clone();
+      reversed_negations.reverse();
 
-        let combined_query = combine_media_query_with_negations(base_mq, reversed_negations);
-        let new_media_key = combined_query.to_string();
+      let combined_query = combine_media_query_with_negations(base_mq, reversed_negations);
+      let new_media_key = combined_query.to_string();
 
-        result_map.insert(
-          new_media_key,
-          KeyValueProp {
-            key: PropName::Str(Str {
-              span: DUMMY_SP,
-              value: Atom::from(combined_query.to_string()),
-              raw: None,
-            }),
-            value: original_kv.value.clone(),
-          },
-        );
-      }
+      result_map.insert(
+        new_media_key,
+        KeyValueProp {
+          key: PropName::Str(Str {
+            span: DUMMY_SP,
+            value: Atom::from(combined_query.to_string()),
+            raw: None,
+          }),
+          value: original_kv.value.clone(),
+        },
+      );
     }
   }
 

--- a/crates/stylex-css-parser/src/tests/at_queries/media_query_transform_test.rs
+++ b/crates/stylex-css-parser/src/tests/at_queries/media_query_transform_test.rs
@@ -90,16 +90,16 @@ fn expr_to_json(expr: &Expr) -> Value {
     Expr::Object(obj) => {
       let mut result = serde_json::Map::new();
       for prop in &obj.props {
-        if let PropOrSpread::Prop(p) = prop {
-          if let Prop::KeyValue(kv) = &**p {
-            let key = match &kv.key {
-              PropName::Str(s) => s.value.to_string(),
-              PropName::Ident(id) => id.sym.to_string(),
-              _ => continue,
-            };
-            let value = expr_to_json(&kv.value);
-            result.insert(key, value);
-          }
+        if let PropOrSpread::Prop(p) = prop
+          && let Prop::KeyValue(kv) = &**p
+        {
+          let key = match &kv.key {
+            PropName::Str(s) => s.value.to_string(),
+            PropName::Ident(id) => id.sym.to_string(),
+            _ => continue,
+          };
+          let value = expr_to_json(&kv.value);
+          result.insert(key, value);
         }
       }
       Value::Object(result)

--- a/crates/stylex-path-resolver/src/package_json/mod.rs
+++ b/crates/stylex-path-resolver/src/package_json/mod.rs
@@ -155,10 +155,9 @@ pub(crate) fn resolve_package_from_package_json(
 
   if let Some(resolution) =
     get_node_modules_path(resolver, file_name, import_path_str, package_json_seen)
+    && let FileName::Real(_) = &resolution.filename
   {
-    if let FileName::Real(_) = &resolution.filename {
-      return Some(resolution);
-    }
+    return Some(resolution);
   }
 
   let parts: Vec<&str> = import_path_str.split(PATH_SEPARATOR).collect();

--- a/crates/stylex-path-resolver/src/resolvers/mod.rs
+++ b/crates/stylex-path-resolver/src/resolvers/mod.rs
@@ -150,16 +150,15 @@ fn get_package_path_by_package_json(
         let resolved_node_modules_path =
           get_node_modules_path(&resolver, &file_name, name, package_json_seen);
 
-        if let Some(resolved_node_modules_path) = resolved_node_modules_path {
-          if let FileName::Real(real_resolved_node_modules_path) =
+        if let Some(resolved_node_modules_path) = resolved_node_modules_path
+          && let FileName::Real(real_resolved_node_modules_path) =
             resolved_node_modules_path.filename
-          {
-            potential_package_path = resolve_exports_path(
-              &real_resolved_node_modules_path,
-              Path::new(potential_file_path),
-              package_json_seen,
-            );
-          }
+        {
+          potential_package_path = resolve_exports_path(
+            &real_resolved_node_modules_path,
+            Path::new(potential_file_path),
+            package_json_seen,
+          );
         }
 
         if potential_package_path.as_os_str().is_empty() {
@@ -215,10 +214,10 @@ pub(crate) fn get_node_modules_path(
   {
     match resolver.resolve(file_name, name) {
       Ok(resolution) => {
-        if let FileName::Real(real_filename) = &resolution.filename {
-          if real_filename.to_string_lossy().contains("node_modules/") {
-            return Some(resolution);
-          }
+        if let FileName::Real(real_filename) = &resolution.filename
+          && real_filename.to_string_lossy().contains("node_modules/")
+        {
+          return Some(resolution);
         }
         None
       }
@@ -561,27 +560,25 @@ fn resolve_package_with_pnpm_path(
   package_json_seen: &mut FxHashMap<String, PackageJsonExtended>,
 ) -> Option<(PackageJsonExtended, PathBuf)> {
   let closest_package_json_path = find_closest_package_json_folder(&PathBuf::from(source_file_dir));
-  if let Some(closest_package_json_directory) = closest_package_json_path {
-    if let Ok(directories) =
+  if let Some(closest_package_json_directory) = closest_package_json_path
+    && let Ok(directories) =
       get_directories(&closest_package_json_directory.join("node_modules/.pnpm"))
-    {
-      let normalized_name = if package_name.starts_with('@') {
-        package_name.replace('/', "+")
-      } else {
-        package_name.to_string()
+  {
+    let normalized_name = if package_name.starts_with('@') {
+      package_name.replace('/', "+")
+    } else {
+      package_name.to_string()
+    };
+
+    for path in directories.iter() {
+      if path.to_string_lossy().contains(&normalized_name)
+        && let Ok(resolved_node_modules_path_buff) =
+          resolve_node_modules_path_buff(path, import_path_str, package_json_seen)
+      {
+        let (package_json, _) = get_package_json(path, package_json_seen);
+
+        return Some((package_json, resolved_node_modules_path_buff));
       };
-
-      for path in directories.iter() {
-        if path.to_string_lossy().contains(&normalized_name) {
-          if let Ok(resolved_node_modules_path_buff) =
-            resolve_node_modules_path_buff(path, import_path_str, package_json_seen)
-          {
-            let (package_json, _) = get_package_json(path, package_json_seen);
-
-            return Some((package_json, resolved_node_modules_path_buff));
-          };
-        }
-      }
     }
   };
 
@@ -600,10 +597,9 @@ fn resolve_node_modules_path_buff(
     &FileName::Real(path.to_path_buf()),
     import_path_str,
     package_json_seen,
-  ) {
-    if let FileName::Real(resolved_node_modules_path_buf) = package_resolution.filename {
-      return Ok::<PathBuf, std::io::Error>(resolved_node_modules_path_buf);
-    }
+  ) && let FileName::Real(resolved_node_modules_path_buf) = package_resolution.filename
+  {
+    return Ok::<PathBuf, std::io::Error>(resolved_node_modules_path_buf);
   }
 
   Result::Err(std::io::Error::new(

--- a/crates/stylex-shared/src/shared/constants/legacy_expand_shorthands_order.rs
+++ b/crates/stylex-shared/src/shared/constants/legacy_expand_shorthands_order.rs
@@ -130,12 +130,13 @@ impl Shorthands {
     let mut coll: Vec<String> = Vec::with_capacity(parts.len());
 
     for part in parts {
-      if let Some(last_element) = coll.last() {
-        if last_element == "auto" && !part.is_empty() {
-          coll.pop();
-          coll.push(format!("auto {}", part));
-          continue;
-        }
+      if let Some(last_element) = coll.last()
+        && last_element == "auto"
+        && !part.is_empty()
+      {
+        coll.pop();
+        coll.push(format!("auto {}", part));
+        continue;
       }
       coll.push(part);
     }

--- a/crates/stylex-shared/src/shared/structures/base_css_type.rs
+++ b/crates/stylex-shared/src/shared/structures/base_css_type.rs
@@ -30,7 +30,7 @@ impl BaseCSSType {
     value: ValueWithDefault,
     top_key: Option<String>,
   ) -> Vec<PropOrSpread> {
-    let value = match value {
+    match value {
       ValueWithDefault::Number(n) => {
         let value_prop = prop_or_spread_string_factory(
           top_key.unwrap_or(String::from("value")).as_str(),
@@ -65,9 +65,7 @@ impl BaseCSSType {
 
         vec![prop]
       }
-    };
-
-    value
+    }
   }
 }
 

--- a/crates/stylex-shared/src/shared/transformers/stylex_keyframes.rs
+++ b/crates/stylex-shared/src/shared/transformers/stylex_keyframes.rs
@@ -194,9 +194,7 @@ pub(crate) fn get_keyframes_fn() -> FunctionConfig {
         .other_injected_css_rules
         .insert(animation_name.clone(), Rc::new(injected_style));
 
-      let result = string_to_expression(animation_name.as_str());
-
-      result
+      string_to_expression(animation_name.as_str())
     }),
     takes_path: false,
   }

--- a/crates/stylex-shared/src/shared/transformers/stylex_position_try.rs
+++ b/crates/stylex-shared/src/shared/transformers/stylex_position_try.rs
@@ -169,9 +169,7 @@ pub(crate) fn get_position_try_fn() -> FunctionConfig {
         .other_injected_css_rules
         .insert(position_try_name.clone(), Rc::new(injected_style));
 
-      let result = string_to_expression(position_try_name.as_str());
-
-      result
+      string_to_expression(position_try_name.as_str())
     }),
     takes_path: false,
   }

--- a/crates/stylex-shared/src/shared/utils/ast/convertors.rs
+++ b/crates/stylex-shared/src/shared/utils/ast/convertors.rs
@@ -116,7 +116,7 @@ pub fn unari_to_num(
 
   match &op {
     UnaryOp::Minus => match expr_to_num(arg, state, traversal_state, fns) {
-      Ok(result) => result * -1.0,
+      Ok(result) => -result,
       Err(error) => panic!("{}", error),
     },
     UnaryOp::Plus => match expr_to_num(arg, state, traversal_state, fns) {
@@ -516,13 +516,10 @@ pub fn handle_tpl_to_expression(
       // If a variable declaration was found
       if let Some(var_decl) = &var_decl {
         // Swap the placeholder expression in the template with the variable declaration's initializer
-        std::mem::swap(
-          expr,
-          &mut var_decl
-            .init
-            .clone()
-            .expect("Variable declaration has no initializer"),
-        );
+        *expr = var_decl
+          .init
+          .clone()
+          .expect("Variable declaration has no initializer");
       }
     };
   }

--- a/crates/stylex-shared/src/shared/utils/ast/factories.rs
+++ b/crates/stylex-shared/src/shared/utils/ast/factories.rs
@@ -137,7 +137,7 @@ pub(crate) fn _create_spreaded_array(values: &[Expr]) -> ArrayLit {
 // NOTE: Tests only using this function
 #[allow(dead_code)]
 fn array_fabric(values: &[Expr], spread: Option<Span>) -> ArrayLit {
-  let array = ArrayLit {
+  ArrayLit {
     span: DUMMY_SP,
     elems: values
       .iter()
@@ -148,7 +148,5 @@ fn array_fabric(values: &[Expr], spread: Option<Span>) -> ArrayLit {
         })
       })
       .collect(),
-  };
-
-  array
+  }
 }

--- a/crates/stylex-shared/src/shared/utils/common.rs
+++ b/crates/stylex-shared/src/shared/utils/common.rs
@@ -415,37 +415,37 @@ pub(crate) fn get_css_value(key_value: KeyValueProp) -> (Box<Expr>, Option<BaseC
 
         match prop.deref() {
           Prop::KeyValue(key_value) => {
-            if let Some(ident) = key_value.key.as_ident() {
-              if ident.sym == "syntax" {
-                let value = obj.props.iter().find(|prop| {
-                  match prop {
-                    PropOrSpread::Spread(_) => unimplemented!("Spread"),
-                    PropOrSpread::Prop(prop) => {
-                      let mut prop = prop.clone();
-                      transform_shorthand_to_key_values(&mut prop);
+            if let Some(ident) = key_value.key.as_ident()
+              && ident.sym == "syntax"
+            {
+              let value = obj.props.iter().find(|prop| {
+                match prop {
+                  PropOrSpread::Spread(_) => unimplemented!("Spread"),
+                  PropOrSpread::Prop(prop) => {
+                    let mut prop = prop.clone();
+                    transform_shorthand_to_key_values(&mut prop);
 
-                      match prop.as_ref() {
-                        Prop::KeyValue(key_value) => {
-                          if let Some(ident) = key_value.key.as_ident() {
-                            return ident.sym == "value";
-                          }
+                    match prop.as_ref() {
+                      Prop::KeyValue(key_value) => {
+                        if let Some(ident) = key_value.key.as_ident() {
+                          return ident.sym == "value";
                         }
-                        _ => unimplemented!(),
                       }
+                      _ => unimplemented!(),
                     }
                   }
-
-                  false
-                });
-
-                if let Some(value) = value {
-                  let result_key_value = value
-                    .as_prop()
-                    .and_then(|prop| prop.as_key_value())
-                    .unwrap();
-
-                  return (result_key_value.value.clone(), Some(obj.clone().into()));
                 }
+
+                false
+              });
+
+              if let Some(value) = value {
+                let result_key_value = value
+                  .as_prop()
+                  .and_then(|prop| prop.as_key_value())
+                  .unwrap();
+
+                return (result_key_value.value.clone(), Some(obj.clone().into()));
               }
             }
           }
@@ -517,16 +517,16 @@ pub(crate) fn fill_top_level_expressions(module: &Module, state: &mut StateManag
     }
     ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => {
       for decl in &var.decls {
-        if let Some(decl_init) = decl.init.as_ref() {
-          if decl.name.as_ident().is_some() {
-            state.top_level_expressions.push(TopLevelExpression(
-              TopLevelExpressionKind::Stmt,
-              *drop_span(decl_init.clone()),
-              Some(decl.name.as_ident().unwrap().sym.clone()),
-            ));
+        if let Some(decl_init) = decl.init.as_ref()
+          && decl.name.as_ident().is_some()
+        {
+          state.top_level_expressions.push(TopLevelExpression(
+            TopLevelExpressionKind::Stmt,
+            *drop_span(decl_init.clone()),
+            Some(decl.name.as_ident().unwrap().sym.clone()),
+          ));
 
-            fill_state_declarations(state, decl);
-          }
+          fill_state_declarations(state, decl);
         }
       }
     }

--- a/crates/stylex-shared/src/shared/utils/core/define_vars_utils.rs
+++ b/crates/stylex-shared/src/shared/utils/core/define_vars_utils.rs
@@ -143,15 +143,14 @@ pub(crate) fn collect_vars_by_at_rules(
 }
 
 fn get_nitial_value_of_css_type(values: &IndexMap<String, ValueWithDefault>) -> String {
-  let initial_value = values
+  values
     .get("default")
     .map(|value| match value {
       ValueWithDefault::Number(num) => num.to_string(),
       ValueWithDefault::String(strng) => strng.clone(),
       ValueWithDefault::Map(map) => get_nitial_value_of_css_type(map),
     })
-    .expect("Default value is not defined");
-  initial_value
+    .expect("Default value is not defined")
 }
 
 pub(crate) fn wrap_with_at_rules(ltr: &str, at_rule: &str) -> String {

--- a/crates/stylex-shared/src/shared/utils/core/dev_class_name.rs
+++ b/crates/stylex-shared/src/shared/utils/core/dev_class_name.rs
@@ -88,11 +88,10 @@ fn namespace_to_dev_class_name(
       .unwrap_or_default(),
     namespace
   );
-  let sanitized_class_name = SANITIZE_CLASS_NAME_REGEX
-    .replace_all(&class_name, "$1 $2")
-    .to_string();
 
-  sanitized_class_name
+  SANITIZE_CLASS_NAME_REGEX
+    .replace_all(&class_name, "$1 $2")
+    .to_string()
 }
 
 fn convert_theme_to_base_styles(

--- a/crates/stylex-shared/src/shared/utils/core/evaluate_stylex_create_arg.rs
+++ b/crates/stylex-shared/src/shared/utils/core/evaluate_stylex_create_arg.rs
@@ -145,16 +145,12 @@ pub fn evaluate_stylex_create_arg(
 
                     let value_to_insert = match val.value.as_ref().unwrap() {
                       EvaluateResultValue::Expr(expr) => match expr {
-                        Expr::Object(obj_expr) => {
-                          let obj_expr_props = obj_expr
-                            .props
-                            .iter()
-                            .filter_map(|prop| prop.as_prop().and_then(|prop| prop.as_key_value()))
-                            .cloned()
-                            .collect::<Vec<_>>();
-
-                          obj_expr_props
-                        }
+                        Expr::Object(obj_expr) => obj_expr
+                          .props
+                          .iter()
+                          .filter_map(|prop| prop.as_prop().and_then(|prop| prop.as_key_value()))
+                          .cloned()
+                          .collect::<Vec<_>>(),
                         _ => panic!("{}", ILLEGAL_NAMESPACE_VALUE),
                       },
                       _ => panic!("{}", ILLEGAL_NAMESPACE_VALUE),

--- a/crates/stylex-shared/src/shared/utils/core/member_expression.rs
+++ b/crates/stylex-shared/src/shared/utils/core/member_expression.rs
@@ -48,10 +48,10 @@ pub(crate) fn member_expression(
 
   let style_non_null_props: NonNullProps;
 
-  if let Some(bail_out_index) = bail_out_index {
-    if index > bail_out_index {
-      *non_null_props = NonNullProps::True;
-    }
+  if let Some(bail_out_index) = bail_out_index
+    && index > bail_out_index
+  {
+    *non_null_props = NonNullProps::True;
   }
 
   if let NonNullProps::True = non_null_props {
@@ -69,32 +69,31 @@ pub(crate) fn member_expression(
         style_non_null_props = non_null_props.clone();
       }
 
-      if let NonNullProps::Vec(vec) = non_null_props {
-        if let Some(EvaluateResultValue::Expr(Expr::Object(ObjectLit { props, .. }))) =
+      if let NonNullProps::Vec(vec) = non_null_props
+        && let Some(EvaluateResultValue::Expr(Expr::Object(ObjectLit { props, .. }))) =
           evaluate_result.value
-        {
-          let namespaces = props
-            .iter()
-            .filter_map(|item| match item {
-              PropOrSpread::Spread(_) => unimplemented!("Spread"),
-              PropOrSpread::Prop(prop) => match prop.as_ref() {
-                Prop::KeyValue(key_value) => match key_value.value.as_ref() {
-                  Expr::Lit(Lit::Null(_)) => None,
-                  _ => Some(
-                    key_value
-                      .key
-                      .as_ident()
-                      .map(|ident| &ident.sym)
-                      .expect("Key not an ident"),
-                  ),
-                },
-                _ => unimplemented!(),
+      {
+        let namespaces = props
+          .iter()
+          .filter_map(|item| match item {
+            PropOrSpread::Spread(_) => unimplemented!("Spread"),
+            PropOrSpread::Prop(prop) => match prop.as_ref() {
+              Prop::KeyValue(key_value) => match key_value.value.as_ref() {
+                Expr::Lit(Lit::Null(_)) => None,
+                _ => Some(
+                  key_value
+                    .key
+                    .as_ident()
+                    .map(|ident| &ident.sym)
+                    .expect("Key not an ident"),
+                ),
               },
-            })
-            .collect::<Vec<&Atom>>();
+              _ => unimplemented!(),
+            },
+          })
+          .collect::<Vec<&Atom>>();
 
-          vec.extend(namespaces.into_iter().cloned());
-        }
+        vec.extend(namespaces.into_iter().cloned());
       }
     }
   }

--- a/crates/stylex-shared/src/shared/utils/core/parse_nullable_style.rs
+++ b/crates/stylex-shared/src/shared/utils/core/parse_nullable_style.rs
@@ -55,40 +55,38 @@ pub(crate) fn parse_nullable_style(
       let mut obj_name: Option<String> = None;
       let mut prop_name: Option<String> = None;
 
-      if let Some(obj_ident) = member.obj.as_ident() {
-        if state.style_map.contains_key(obj_ident.sym.as_str()) {
-          if should_reduce_count {
-            if let Some(member_ident) = member.obj.as_ident() {
-              reduce_ident_count(state, member_ident);
-            }
-          }
+      if let Some(obj_ident) = member.obj.as_ident()
+        && state.style_map.contains_key(obj_ident.sym.as_str())
+      {
+        if should_reduce_count && let Some(member_ident) = member.obj.as_ident() {
+          reduce_ident_count(state, member_ident);
+        }
 
-          match &member.prop {
-            MemberProp::Ident(prop_ident) => {
-              obj_name = Some(obj_ident.sym.as_str().to_string());
-              prop_name = Some(prop_ident.sym.as_str().to_string());
-            }
-            MemberProp::Computed(computed) => {
-              if let Some(lit) = computed.expr.as_lit() {
-                obj_name = Some(obj_ident.sym.as_str().to_string());
-                prop_name = lit_to_string(lit);
-              }
-            }
-            MemberProp::PrivateName(_) => {}
+        match &member.prop {
+          MemberProp::Ident(prop_ident) => {
+            obj_name = Some(obj_ident.sym.as_str().to_string());
+            prop_name = Some(prop_ident.sym.as_str().to_string());
           }
+          MemberProp::Computed(computed) => {
+            if let Some(lit) = computed.expr.as_lit() {
+              obj_name = Some(obj_ident.sym.as_str().to_string());
+              prop_name = lit_to_string(lit);
+            }
+          }
+          MemberProp::PrivateName(_) => {}
         }
       }
 
-      if let Some(obj_name) = obj_name {
-        if let Some(prop_name) = prop_name {
-          let style = state.style_map.get(&obj_name);
+      if let Some(obj_name) = obj_name
+        && let Some(prop_name) = prop_name
+      {
+        let style = state.style_map.get(&obj_name);
 
-          if let Some(style) = style {
-            let style_value = style.get(&prop_name);
+        if let Some(style) = style {
+          let style_value = style.get(&prop_name);
 
-            if let Some(style_value) = style_value {
-              return StyleObject::Style((**style_value).clone());
-            }
+          if let Some(style_value) = style_value {
+            return StyleObject::Style((**style_value).clone());
           }
         }
       }

--- a/crates/stylex-shared/src/shared/utils/core/props.rs
+++ b/crates/stylex-shared/src/shared/utils/core/props.rs
@@ -34,13 +34,13 @@ pub(crate) fn props(styles: &[ResolvedArg]) -> Option<FnResult> {
     unimplemented!("Inline style");
   }
 
-  if let Some(data_style_src) = data_style_src {
-    if !data_style_src.is_empty() {
-      props_map.insert(
-        "data-style-src".to_string(),
-        Rc::new(FlatCompiledStylesValue::String(data_style_src)),
-      );
-    }
+  if let Some(data_style_src) = data_style_src
+    && !data_style_src.is_empty()
+  {
+    props_map.insert(
+      "data-style-src".to_string(),
+      Rc::new(FlatCompiledStylesValue::String(data_style_src)),
+    );
   }
 
   Some(FnResult::Props(

--- a/crates/stylex-shared/src/shared/utils/css/common.rs
+++ b/crates/stylex-shared/src/shared/utils/css/common.rs
@@ -268,9 +268,7 @@ pub(crate) fn transform_value(key: &str, value: &str, state: &StateManager) -> S
     return format!("\"{}\"", value);
   }
 
-  let result = normalize_css_property_value(key, value.as_ref(), &state.options);
-
-  result
+  normalize_css_property_value(key, value.as_ref(), &state.options)
 }
 
 pub(crate) fn transform_value_cached(key: &str, value: &str, state: &mut StateManager) -> String {
@@ -347,7 +345,7 @@ pub(crate) fn normalize_css_property_value(
     panic!("{}, css rule: {}", error_message, css_rule)
   }
 
-  let ast_normalized = match parsed_css {
+  match parsed_css {
     Ok(parsed_css_property_value) => {
       // let validators: Vec<Validator> = vec![
       //   unprefixed_custom_properties_validator,
@@ -381,9 +379,7 @@ pub(crate) fn normalize_css_property_value(
     Err(err) => {
       panic!("{}", err.message())
     }
-  };
-
-  ast_normalized
+  }
 }
 
 // type Normalizer = fn(Stylesheet, bool) -> Stylesheet;

--- a/crates/stylex-shared/src/shared/utils/css/normalizers/base.rs
+++ b/crates/stylex-shared/src/shared/utils/css/normalizers/base.rs
@@ -21,12 +21,12 @@ impl CssFolder {
     &'a mut self,
     declaration: &'a mut Declaration,
   ) -> &'a mut Declaration {
-    if let DeclarationName::Ident(ident) = &declaration.name {
-      if ident.value == "fontSize" || self.parent_key.as_deref() == Some("fontSize") {
-        self.parent_key = Some("fontSize".into());
-        declaration.value = declaration.value.clone().fold_children_with(self);
-        self.parent_key = None;
-      }
+    if let DeclarationName::Ident(ident) = &declaration.name
+      && (ident.value == "fontSize" || self.parent_key.as_deref() == Some("fontSize"))
+    {
+      self.parent_key = Some("fontSize".into());
+      declaration.value = declaration.value.clone().fold_children_with(self);
+      self.parent_key = None;
     }
 
     declaration
@@ -129,10 +129,10 @@ fn kebab_case_normalizer(declaration: &mut Declaration) -> &mut Declaration {
   }
 
   declaration.value.iter_mut().for_each(|value| {
-    if let ComponentValue::Ident(ident) = value {
-      if !ident.value.starts_with("--") {
-        ident.value = dashify(ident.value.as_str()).into();
-      }
+    if let ComponentValue::Ident(ident) = value
+      && !ident.value.starts_with("--")
+    {
+      ident.value = dashify(ident.value.as_str()).into();
     }
   });
 

--- a/crates/stylex-shared/src/shared/utils/css/validators/unprefixed_custom_properties.rs
+++ b/crates/stylex-shared/src/shared/utils/css/validators/unprefixed_custom_properties.rs
@@ -9,11 +9,11 @@ use crate::shared::utils::css::common::swc_parse_css;
 fn process_function(func: &Function) {
   if let FunctionName::Ident(func_name_ident) = &func.name {
     let func_name = get_value_from_ident(func_name_ident);
-    if func_name == "var" {
-      if let Some(ComponentValue::Ident(ident)) = func.value.first() {
-        let value = get_value_from_ident(ident.as_ref());
-        assert!(value.starts_with("--"), "{}", UNPREFIXED_CUSTOM_PROPERTIES);
-      }
+    if func_name == "var"
+      && let Some(ComponentValue::Ident(ident)) = func.value.first()
+    {
+      let value = get_value_from_ident(ident.as_ref());
+      assert!(value.starts_with("--"), "{}", UNPREFIXED_CUSTOM_PROPERTIES);
     }
   }
 }

--- a/crates/stylex-shared/src/shared/utils/js/native_functions.rs
+++ b/crates/stylex-shared/src/shared/utils/js/native_functions.rs
@@ -83,13 +83,11 @@ pub(crate) fn evaluate_join(
   let result = args
     .iter()
     .map(|arg_ref| {
-      let str_arg = arg_ref
+      arg_ref
         .as_ref()
         .and_then(|arg| arg.as_expr())
         .map(|arg| expr_to_str(arg, state, functions))
-        .expect("Failed parsing \"join\" argument to string");
-
-      str_arg
+        .expect("Failed parsing \"join\" argument to string")
     })
     .collect::<Vec<String>>()
     .join(&join_arg);

--- a/crates/stylex-shared/src/shared/utils/log/build_code_frame_error.rs
+++ b/crates/stylex-shared/src/shared/utils/log/build_code_frame_error.rs
@@ -87,10 +87,7 @@ fn read_source_file(file_name: &FileName) -> Result<String, std::io::Error> {
     FileName::Real(path) => fs::read_to_string(path),
     FileName::Custom(path) => fs::read_to_string(path),
     FileName::Url(url) => fs::read_to_string(Path::new(url.path())),
-    _ => Err(std::io::Error::new(
-      std::io::ErrorKind::Other,
-      "Unsupported file name type",
-    )),
+    _ => Err(std::io::Error::other("Unsupported file name type")),
   }
 }
 

--- a/crates/stylex-shared/src/shared/utils/validators.rs
+++ b/crates/stylex-shared/src/shared/utils/validators.rs
@@ -709,15 +709,15 @@ pub(crate) fn assert_valid_properties(
   error_message: &str,
   state: &mut StateManager,
 ) {
-  if let EvaluateResultValue::Expr(expr) = obj {
-    if let Expr::Object(object) = expr {
-      let key_values = get_key_values_from_object(object);
+  if let EvaluateResultValue::Expr(expr) = obj
+    && let Expr::Object(object) = expr
+  {
+    let key_values = get_key_values_from_object(object);
 
-      for key_value in key_values.iter() {
-        let key = key_value_to_str(key_value);
-        if !valid_keys.contains(&key.as_str()) {
-          build_code_frame_error_and_panic(expr, expr, error_message, state);
-        }
+    for key_value in key_values.iter() {
+      let key = key_value_to_str(key_value);
+      if !valid_keys.contains(&key.as_str()) {
+        build_code_frame_error_and_panic(expr, expr, error_message, state);
       }
     }
   }

--- a/crates/stylex-shared/src/transform/fold/fold_export_decl.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_export_decl.rs
@@ -20,13 +20,13 @@ where
       return export_decl;
     }
 
-    if self.state.cycle == TransformationCycle::StateFilling {
-      if let Decl::Var(var_decl) = &export_decl.decl {
-        for decl in &var_decl.decls {
-          if let Some(ident) = decl.name.as_ident() {
-            // HACK: For preventing removing named export declarations need to increase the count by 2.
-            increase_ident_count_by_count(&mut self.state, ident, 2);
-          }
+    if self.state.cycle == TransformationCycle::StateFilling
+      && let Decl::Var(var_decl) = &export_decl.decl
+    {
+      for decl in &var_decl.decls {
+        if let Some(ident) = decl.name.as_ident() {
+          // HACK: For preventing removing named export declarations need to increase the count by 2.
+          increase_ident_count_by_count(&mut self.state, ident, 2);
         }
       }
     }

--- a/crates/stylex-shared/src/transform/fold/fold_expr.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_expr.rs
@@ -22,21 +22,20 @@ where
 
     let normalized_expr = normalize_expr(&mut expr);
 
-    if self.state.cycle == TransformationCycle::StateFilling {
-      if let Some(call_expr) = normalized_expr.as_call() {
-        self
-          .state
-          .all_call_expressions
-          .insert(stable_hash(&call_expr), call_expr.clone());
-      }
+    if self.state.cycle == TransformationCycle::StateFilling
+      && let Some(call_expr) = normalized_expr.as_call()
+    {
+      self
+        .state
+        .all_call_expressions
+        .insert(stable_hash(&call_expr), call_expr.clone());
     }
 
-    if self.state.cycle == TransformationCycle::TransformEnter
-      || self.state.cycle == TransformationCycle::TransformExit
+    if (self.state.cycle == TransformationCycle::TransformEnter
+      || self.state.cycle == TransformationCycle::TransformExit)
+      && let Some(value) = self.transform_call_expression(normalized_expr)
     {
-      if let Some(value) = self.transform_call_expression(normalized_expr) {
-        return value;
-      }
+      return value;
     }
 
     expr.fold_children_with(self)

--- a/crates/stylex-shared/src/transform/fold/fold_import_decl.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_import_decl.rs
@@ -146,15 +146,15 @@ where
     local_name: &str,
     import_specifier: &ImportNamedSpecifier,
   ) {
-    if let Some(source_path) = self.state.import_as(source_path) {
-      if source_path.eq(&imported_name) {
-        self.state.import_paths.insert(source_path.clone());
+    if let Some(source_path) = self.state.import_as(source_path)
+      && source_path.eq(&imported_name)
+    {
+      self.state.import_paths.insert(source_path.clone());
 
-        self
-          .state
-          .stylex_import
-          .insert(ImportSources::Regular(local_name.to_string()));
-      }
+      self
+        .state
+        .stylex_import
+        .insert(ImportSources::Regular(local_name.to_string()));
     }
 
     if self.state.import_as(source_path).is_none() {

--- a/crates/stylex-shared/src/transform/fold/fold_member_expression.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_member_expression.rs
@@ -41,20 +41,18 @@ where
       TransformationCycle::PreCleaning => {
         if let Expr::Ident(ident) = member_expression.obj.as_ref() {
           let obj_ident_name = ident.sym.to_string();
-          if self.state.style_map.contains_key(&obj_ident_name) {
-            if let MemberProp::Ident(prop_ident) = &member_expression.prop {
-              if let Some(count) = self.state.member_object_ident_count_map.get(&ident.sym) {
-                if count > &0 {
-                  increase_ident_count(&mut self.state, ident);
-                  let style_var_to_keep = StyleVarsToKeep(
-                    ident.sym.clone(),
-                    NonNullProp::Atom(prop_ident.sym.clone()),
-                    NonNullProps::True,
-                  );
-                  self.state.style_vars_to_keep.insert(style_var_to_keep);
-                }
-              }
-            }
+          if self.state.style_map.contains_key(&obj_ident_name)
+            && let MemberProp::Ident(prop_ident) = &member_expression.prop
+            && let Some(count) = self.state.member_object_ident_count_map.get(&ident.sym)
+            && count > &0
+          {
+            increase_ident_count(&mut self.state, ident);
+            let style_var_to_keep = StyleVarsToKeep(
+              ident.sym.clone(),
+              NonNullProp::Atom(prop_ident.sym.clone()),
+              NonNullProps::True,
+            );
+            self.state.style_vars_to_keep.insert(style_var_to_keep);
           }
         }
         member_expression.fold_children_with(self)

--- a/crates/stylex-shared/src/transform/fold/fold_module_items.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_module_items.rs
@@ -91,11 +91,10 @@ where
           .first()
           .and_then(|first| first.as_stmt())
           .and_then(|stmp| stmp.as_expr())
+          && let Some(Lit::Str(_)) = first.expr.as_lit()
         {
-          if let Some(Lit::Str(_)) = first.expr.as_lit() {
-            result_module_items.insert(0, module_items.first().unwrap().clone());
-            items_to_skip = 1;
-          }
+          result_module_items.insert(0, module_items.first().unwrap().clone());
+          items_to_skip = 1;
         }
 
         for module_item in module_items.iter().skip(items_to_skip) {

--- a/crates/stylex-shared/src/transform/fold/fold_stmt.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_stmt.rs
@@ -21,13 +21,13 @@ where
     if self.state.cycle == TransformationCycle::Cleaning {
       let mut stmt = stmt.fold_children_with(self);
 
-      if let Some(Stmt::Decl(Decl::Var(var))) = stmt.as_ref() {
-        if var.decls.is_empty() {
-          // Variable declaration without declarator is invalid.
-          //
-          // After this, `stmt` becomes `Stmt::Empty`.
-          stmt.take();
-        }
+      if let Some(Stmt::Decl(Decl::Var(var))) = stmt.as_ref()
+        && var.decls.is_empty()
+      {
+        // Variable declaration without declarator is invalid.
+        //
+        // After this, `stmt` becomes `Stmt::Empty`.
+        stmt.take();
       }
 
       stmt

--- a/crates/stylex-shared/src/transform/fold/fold_var_declarator.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_var_declarator.rs
@@ -36,28 +36,26 @@ where
       TransformationCycle::StateFilling => {
         fill_state_declarations(&mut self.state, &var_declarator);
 
-        if let Some(Expr::Call(call)) = var_declarator.init.as_deref_mut() {
-          if let Some((declaration, member)) = self.process_declaration(call) {
-            let stylex_imports = self.state.stylex_import_stringified();
+        if let Some(Expr::Call(call)) = var_declarator.init.as_deref_mut()
+          && let Some((declaration, member)) = self.process_declaration(call)
+        {
+          let stylex_imports = self.state.stylex_import_stringified();
 
-            if let Some(declaration_string) = stylex_imports
-              .into_iter()
-              .find(|item| item.eq(declaration.0.as_str()))
-              .or_else(|| {
-                self
-                  .state
-                  .stylex_create_import
-                  .iter()
-                  .find(|decl| decl.eq_ignore_span(&&declaration.0.clone()))
-                  .map(|decl| decl.to_string())
-              })
-            {
-              if self.state.cycle == TransformationCycle::StateFilling
-                && (member.as_str() == "create" || member.eq(declaration_string.as_str()))
-              {
-                self.props_declaration = var_declarator.name.as_ident().map(|ident| ident.to_id());
-              }
-            }
+          if let Some(declaration_string) = stylex_imports
+            .into_iter()
+            .find(|item| item.eq(declaration.0.as_str()))
+            .or_else(|| {
+              self
+                .state
+                .stylex_create_import
+                .iter()
+                .find(|decl| decl.eq_ignore_span(&&declaration.0.clone()))
+                .map(|decl| decl.to_string())
+            })
+            && self.state.cycle == TransformationCycle::StateFilling
+            && (member.as_str() == "create" || member.eq(declaration_string.as_str()))
+          {
+            self.props_declaration = var_declarator.name.as_ident().map(|ident| ident.to_id());
           }
         }
 
@@ -111,29 +109,27 @@ where
               },
             );
 
-            if let Some(TopLevelExpression(kind, _, _)) = top_level_expression {
-              if kind == TopLevelExpressionKind::Stmt {
-                if let Some(object) = var_declarator
-                  .init
-                  .as_mut()
-                  .and_then(|var_decl| var_decl.as_object())
-                {
-                  let namespaces_to_keep =
-                    match vars_to_keep.get(&var_name.name.as_ident().unwrap().sym) {
-                      Some(NonNullProps::Vec(vec)) => vec.clone(),
-                      _ => Vec::new(),
-                    };
+            if let Some(TopLevelExpression(kind, _, _)) = top_level_expression
+              && kind == TopLevelExpressionKind::Stmt
+              && let Some(object) = var_declarator
+                .init
+                .as_mut()
+                .and_then(|var_decl| var_decl.as_object())
+            {
+              let namespaces_to_keep =
+                match vars_to_keep.get(&var_name.name.as_ident().unwrap().sym) {
+                  Some(NonNullProps::Vec(vec)) => vec.clone(),
+                  _ => Vec::new(),
+                };
 
-                  if !namespaces_to_keep.is_empty() {
-                    let mut new_object = object.clone();
+              if !namespaces_to_keep.is_empty() {
+                let mut new_object = object.clone();
 
-                    let props =
-                      self.retain_object_props(&mut new_object, namespaces_to_keep, &var_name);
-                    new_object.props = props;
+                let props =
+                  self.retain_object_props(&mut new_object, namespaces_to_keep, &var_name);
+                new_object.props = props;
 
-                    *var_declarator.init.as_mut().unwrap() = Box::new(Expr::Object(new_object));
-                  }
-                }
+                *var_declarator.init.as_mut().unwrap() = Box::new(Expr::Object(new_object));
               }
             }
           }
@@ -168,48 +164,48 @@ where
           _ => None,
         };
 
-        if let Some(key_as_string) = key_as_ident {
-          if namespace_to_keep.contains(&key_as_string.sym) {
-            let var_id = &var_name.name.as_ident().unwrap().sym;
-            let key_id = NonNullProp::Atom(key_as_ident.unwrap().clone().sym);
+        if let Some(key_as_string) = key_as_ident
+          && namespace_to_keep.contains(&key_as_string.sym)
+        {
+          let var_id = &var_name.name.as_ident().unwrap().sym;
+          let key_id = NonNullProp::Atom(key_as_ident.unwrap().clone().sym);
 
-            let all_nulls_to_keep = self
-              .state
-              .style_vars_to_keep
-              .iter()
-              .filter_map(|top_level_expression| {
-                let StyleVarsToKeep(var, namespace_name, prop) = top_level_expression;
+          let all_nulls_to_keep = self
+            .state
+            .style_vars_to_keep
+            .iter()
+            .filter_map(|top_level_expression| {
+              let StyleVarsToKeep(var, namespace_name, prop) = top_level_expression;
 
-                if var_id.eq_ignore_span(var) && namespace_name.eq(&key_id.clone()) {
-                  Some(prop.clone())
-                } else {
-                  None
-                }
-              })
-              .collect::<Vec<NonNullProps>>();
-
-            if !all_nulls_to_keep.contains(&NonNullProps::True) {
-              let nulls_to_keep = all_nulls_to_keep
-                .into_iter()
-                .filter_map(|item| match item {
-                  NonNullProps::Vec(vec) => Some(vec),
-                  NonNullProps::True => None,
-                })
-                .flatten()
-                .collect::<Vec<Atom>>();
-
-              if let Some(style_object) = prop
-                .as_mut_key_value()
-                .expect("Prop not a key value")
-                .value
-                .as_mut_object()
-              {
-                retain_style_props(style_object, nulls_to_keep);
+              if var_id.eq_ignore_span(var) && namespace_name.eq(&key_id.clone()) {
+                Some(prop.clone())
+              } else {
+                None
               }
-            }
+            })
+            .collect::<Vec<NonNullProps>>();
 
-            props.push(object_prop.clone())
+          if !all_nulls_to_keep.contains(&NonNullProps::True) {
+            let nulls_to_keep = all_nulls_to_keep
+              .into_iter()
+              .filter_map(|item| match item {
+                NonNullProps::Vec(vec) => Some(vec),
+                NonNullProps::True => None,
+              })
+              .flatten()
+              .collect::<Vec<Atom>>();
+
+            if let Some(style_object) = prop
+              .as_mut_key_value()
+              .expect("Prop not a key value")
+              .value
+              .as_mut_object()
+            {
+              retain_style_props(style_object, nulls_to_keep);
+            }
           }
+
+          props.push(object_prop.clone())
         }
       }
     }
@@ -225,8 +221,8 @@ fn retain_style_props(style_object: &mut ObjectLit, nulls_to_keep: Vec<Atom>) {
 
       transform_shorthand_to_key_values(&mut prop);
 
-      if let Prop::KeyValue(key_value) = &*prop {
-        if key_value
+      if let Prop::KeyValue(key_value) = &*prop
+        && key_value
           .value
           .as_lit()
           .and_then(|lit| match lit {
@@ -234,12 +230,10 @@ fn retain_style_props(style_object: &mut ObjectLit, nulls_to_keep: Vec<Atom>) {
             _ => None,
           })
           .is_some()
-          && matches!(key_value.key, PropName::Ident(_))
-        {
-          if let PropName::Ident(ident) = &key_value.key {
-            return nulls_to_keep.contains(&ident.sym);
-          }
-        }
+        && matches!(key_value.key, PropName::Ident(_))
+        && let PropName::Ident(ident) = &key_value.key
+      {
+        return nulls_to_keep.contains(&ident.sym);
       }
 
       true

--- a/crates/stylex-shared/src/transform/mod.rs
+++ b/crates/stylex-shared/src/transform/mod.rs
@@ -190,10 +190,9 @@ where
         Expr::Member(member) => {
           if let (Expr::Ident(obj_ident), MemberProp::Ident(prop_ident)) =
             (member.obj.as_ref(), &member.prop)
+            && self.is_stylex_import(obj_ident.sym.as_ref())
           {
-            if self.is_stylex_import(obj_ident.sym.as_ref()) {
-              return Some((obj_ident.to_id(), prop_ident.sym.to_string()));
-            }
+            return Some((obj_ident.to_id(), prop_ident.sym.to_string()));
           }
         }
         _ => {}
@@ -237,10 +236,10 @@ where
       })
       .cloned();
 
-    if let Some(ref parent_var_decl) = parent_var_decl {
-      if let Some(ident) = parent_var_decl.name.as_ident() {
-        var_name = Some(ident.sym.to_string());
-      }
+    if let Some(ref parent_var_decl) = parent_var_decl
+      && let Some(ident) = parent_var_decl.name.as_ident()
+    {
+      var_name = Some(ident.sym.to_string());
     }
 
     (var_name, parent_var_decl)

--- a/crates/stylex-shared/src/transform/styleq/common.rs
+++ b/crates/stylex-shared/src/transform/styleq/common.rs
@@ -92,10 +92,10 @@ pub(crate) fn styleq(arguments: &[ResolvedArg]) -> StyleQResult {
 
                     let mut compiled_key_value_is_true = false;
 
-                    if let FlatCompiledStylesValue::Bool(value) = compiled_key_value.as_ref() {
-                      if *value {
-                        compiled_key_value_is_true = true;
-                      }
+                    if let FlatCompiledStylesValue::Bool(value) = compiled_key_value.as_ref()
+                      && *value
+                    {
+                      compiled_key_value_is_true = true;
                     }
 
                     if !compiled_key_value_is_true {

--- a/crates/stylex-shared/src/transform/stylex/transform_stylex_call.rs
+++ b/crates/stylex-shared/src/transform/stylex/transform_stylex_call.rs
@@ -23,10 +23,9 @@ where
             .state
             .stylex_import
             .contains(&ImportSources::Regular(ident.sym.to_string()))
+            && let Some(value) = stylex_merge(call, stylex, &mut self.state)
           {
-            if let Some(value) = stylex_merge(call, stylex, &mut self.state) {
-              return Some(value);
-            }
+            return Some(value);
           }
           None
         }

--- a/crates/stylex-shared/src/transform/stylex/transform_stylex_calls.rs
+++ b/crates/stylex-shared/src/transform/stylex/transform_stylex_calls.rs
@@ -66,10 +66,10 @@ where
     }
 
     if self.state.cycle == TransformationCycle::TransformExit {
-      if self.state.stylex_props_import.contains(ident_name) {
-        if let Some(value) = self.transform_stylex_props_call(call_expr) {
-          return Some(value);
-        }
+      if self.state.stylex_props_import.contains(ident_name)
+        && let Some(value) = self.transform_stylex_props_call(call_expr)
+      {
+        return Some(value);
       }
 
       if let Some(value) = self.transform_stylex_call(call_expr) {

--- a/crates/stylex-shared/src/transform/stylex/transform_stylex_create_call.rs
+++ b/crates/stylex-shared/src/transform/stylex/transform_stylex_create_call.rs
@@ -307,11 +307,12 @@ where
         &mut self.state,
       );
 
-      if let Some(fns) = evaluated_arg.fns {
-        if let Some(object) = result_ast.as_object() {
-          let key_values = get_key_values_from_object(object);
+      if let Some(fns) = evaluated_arg.fns
+        && let Some(object) = result_ast.as_object()
+      {
+        let key_values = get_key_values_from_object(object);
 
-          let props = key_values
+        let props = key_values
             .iter()
             .map(|key_value| {
               let orig_key = key_value_to_str(key_value);
@@ -325,8 +326,8 @@ where
 
               let mut prop: Option<PropOrSpread> = None;
 
-              if let Some(key) = key {
-                if let Some((params, inline_styles)) = fns.get(&key) {
+              if let Some(key) = key
+                && let Some((params, inline_styles)) = fns.get(&key) {
                   let mut orig_class_paths = IndexMap::new();
 
                   if let Some(namespace) = class_paths_per_namespace.get(&key) {
@@ -584,7 +585,6 @@ where
                     prop = Some(prop_or_spread_expression_factory(orig_key.as_str(), value));
                   }
                 }
-              }
 
               prop.unwrap_or_else(|| {
                 prop_or_spread_expression_factory(orig_key.as_str(), *value.clone())
@@ -592,12 +592,11 @@ where
             })
             .collect::<Vec<PropOrSpread>>();
 
-          result_ast = path_replace_hoisted(
-            object_expression_factory(props),
-            is_program_level,
-            &mut self.state,
-          );
-        }
+        result_ast = path_replace_hoisted(
+          object_expression_factory(props),
+          is_program_level,
+          &mut self.state,
+        );
       };
 
       self

--- a/crates/stylex-shared/src/transform/stylex/transform_stylex_create_theme_call.rs
+++ b/crates/stylex-shared/src/transform/stylex/transform_stylex_create_theme_call.rs
@@ -44,7 +44,7 @@ where
   pub(crate) fn transform_stylex_create_theme_call(&mut self, call: &CallExpr) -> Option<Expr> {
     let is_create_theme_call = is_create_theme_call(call, &self.state);
 
-    let result = if is_create_theme_call {
+    if is_create_theme_call {
       let (_, parent_var_decl) = &self.get_call_var_name(call);
 
       validate_stylex_create_theme_indent(parent_var_decl, call, &mut self.state);
@@ -219,8 +219,6 @@ where
       Some(result_ast)
     } else {
       None
-    };
-
-    result
+    }
   }
 }

--- a/crates/stylex-shared/src/transform/stylex/transform_stylex_keyframes_call.rs
+++ b/crates/stylex-shared/src/transform/stylex/transform_stylex_keyframes_call.rs
@@ -36,7 +36,7 @@ where
   ) -> Option<Expr> {
     let is_keyframes_call = is_keyframes_call(var_decl, &self.state);
 
-    let result = if is_keyframes_call {
+    if is_keyframes_call {
       validate_stylex_keyframes_indent(var_decl, &mut self.state);
 
       let call = var_decl
@@ -137,8 +137,6 @@ where
       Some(result_ast)
     } else {
       None
-    };
-
-    result
+    }
   }
 }

--- a/crates/stylex-shared/src/transform/stylex/transform_stylex_position_try_call.rs
+++ b/crates/stylex-shared/src/transform/stylex/transform_stylex_position_try_call.rs
@@ -43,7 +43,7 @@ where
   ) -> Option<Expr> {
     let is_position_try_call = is_position_try_call(var_decl, &self.state);
 
-    let result = if is_position_try_call {
+    if is_position_try_call {
       validate_stylex_position_try_indent(var_decl, &mut self.state);
 
       let call = var_decl
@@ -151,8 +151,6 @@ where
       Some(result_ast)
     } else {
       None
-    };
-
-    result
+    }
   }
 }

--- a/crates/stylex-shared/src/transform/stylex/transform_stylex_view_transition_class_call.rs
+++ b/crates/stylex-shared/src/transform/stylex/transform_stylex_view_transition_class_call.rs
@@ -46,7 +46,7 @@ where
   ) -> Option<Expr> {
     let is_view_transition_class_call = is_view_transition_class_call(var_decl, &self.state);
 
-    let result = if is_view_transition_class_call {
+    if is_view_transition_class_call {
       validate_stylex_view_transition_class_indent(var_decl, &mut self.state);
 
       let call = var_decl
@@ -178,8 +178,6 @@ where
       Some(result_ast)
     } else {
       None
-    };
-
-    result
+    }
   }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]
 targets = [
   "wasm32-wasip1",


### PR DESCRIPTION
## Description

This pull request primarily refactors Rust code to use more concise and modern pattern matching with `if let` and `&&` chaining, improving readability and maintainability across multiple crates. Additionally, it updates the minimum supported Rust version to 1.89.0 in configuration files and workspace manifests. The changes are grouped below by theme.

**Rust version updates:**

* Updated the Rust toolchain and minimum supported Rust version to `1.89.0` in `.devcontainer/devcontainer.json`, workspace `Cargo.toml`, `clippy.toml`, and `crates/stylex-css-parser/Cargo.toml`. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L10-R10) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L9-R9) [[3]](diffhunk://#diff-f3dbfb2563c3490394f44c26b51837018e79a79e75fd31e89b19e943a38317eaL25-R25) [[4]](diffhunk://#diff-f2bbbc98b184aa1b316db5b1847d5d3b31fc7aca7c5ca57b056d87cba1a16bcaL5-R5)

**Pattern matching and code simplification:**

* Refactored numerous conditional blocks to use `if let ... && ...` pattern matching for more concise and idiomatic Rust, especially in `crates/stylex-css-parser/src/at_queries/media_query.rs`, `media_query_transform.rs`, `tests/at_queries/media_query_transform_test.rs`, `crates/stylex-path-resolver/src/resolvers/mod.rs`, and `crates/stylex-path-resolver/src/package_json/mod.rs`. [[1]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L307-L316) [[2]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L544-R548) [[3]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L573-L600) [[4]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L634-L638) [[5]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L764-R764) [[6]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L1682-R1682) [[7]](diffhunk://#diff-ed8b0b80b5cd933044bd99ed8ba4bde5ae3fa40a6631b05344eee7db312e18b1L70-L75) [[8]](diffhunk://#diff-ed8b0b80b5cd933044bd99ed8ba4bde5ae3fa40a6631b05344eee7db312e18b1L161-R163) [[9]](diffhunk://#diff-f0e8eb6ba2d8ecae5c4c66d1df076c89cb4c8ed2d80891f710502571ce67dba8L93-R95) [[10]](diffhunk://#diff-f852b0de7bb9590bdb25b0dd118443e974330e593450c4fc00fcb2faac92f158R158-L162) [[11]](diffhunk://#diff-eaae2a77e43e1c6d00ecdf04ab9c5001ad7d773acd22fcac6ce8e8c16c10a618L153-R154) [[12]](diffhunk://#diff-eaae2a77e43e1c6d00ecdf04ab9c5001ad7d773acd22fcac6ce8e8c16c10a618L218-L222) [[13]](diffhunk://#diff-eaae2a77e43e1c6d00ecdf04ab9c5001ad7d773acd22fcac6ce8e8c16c10a618L564-R564) [[14]](diffhunk://#diff-eaae2a77e43e1c6d00ecdf04ab9c5001ad7d773acd22fcac6ce8e8c16c10a618L575-L585) [[15]](diffhunk://#diff-eaae2a77e43e1c6d00ecdf04ab9c5001ad7d773acd22fcac6ce8e8c16c10a618L603-L607) [[16]](diffhunk://#diff-f0caa53cc1aac4b306967df76db73347cb7ac8f2de54dbb4ada1db7aa3a37fbaL133-L139)

**Code cleanup and minor logic improvements:**

* Removed redundant closing braces and simplified control flow in several places, resulting in cleaner and easier-to-follow logic. [[1]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L660-L661) [[2]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L774-R777) [[3]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L787) [[4]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L1695) [[5]](diffhunk://#diff-b763d77570f379f29af5ebcb355199e5c14f24629386339bdbb3171e34631fc7L1827) [[6]](diffhunk://#diff-ed8b0b80b5cd933044bd99ed8ba4bde5ae3fa40a6631b05344eee7db312e18b1L182) [[7]](diffhunk://#diff-f0e8eb6ba2d8ecae5c4c66d1df076c89cb4c8ed2d80891f710502571ce67dba8L104) [[8]](diffhunk://#diff-eaae2a77e43e1c6d00ecdf04ab9c5001ad7d773acd22fcac6ce8e8c16c10a618L163)

**Minor logic changes:**

* Improved handling of value assignment and removed unnecessary variable shadowing in `base_css_type.rs`. [[1]](diffhunk://#diff-29b42858d8c1c530ec7476088c8c1e5d23f64646654463628bfdfff805791436L33-R33) [[2]](diffhunk://#diff-29b42858d8c1c530ec7476088c8c1e5d23f64646654463628bfdfff805791436L68-R68)

These updates collectively modernize the codebase, make it more idiomatic, and ensure compatibility with the latest Rust features.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
