### PR TITLE
deps(@stylexjs/stylex): bump version 0.15.3

### DIFF
--- a/apps/esbuild-unplugin-example/package.json
+++ b/apps/esbuild-unplugin-example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "@stylexswc/unplugin": "0.11.0-rc.1",

--- a/apps/farm-unplugin-example/package.json
+++ b/apps/farm-unplugin-example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "@stylexswc/unplugin": "0.11.0-rc.1",

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/nextjs-plugin": "0.11.0-rc.1",
     "next": "^15.4.7",
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
-    "@stylexjs/eslint-plugin": "^0.15.0",
+    "@stylexjs/eslint-plugin": "^0.15.3",
     "@stylexswc/jest": "0.11.0-rc.1",
     "@stylexswc/playwright": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",

--- a/apps/nextjs-postcss-example/package.json
+++ b/apps/nextjs-postcss-example/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/nextjs-plugin": "0.11.0-rc.1",
     "@stylexswc/postcss-plugin": "0.11.0-rc.1",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
-    "@stylexjs/eslint-plugin": "^0.15.0",
+    "@stylexjs/eslint-plugin": "^0.15.3",
     "@stylexswc/jest": "0.11.0-rc.1",
     "@stylexswc/playwright": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",

--- a/apps/rollup-example/package.json
+++ b/apps/rollup-example/package.json
@@ -11,7 +11,7 @@
     "test:visual": "playwright test"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/apps/rollup-large-example/package.json
+++ b/apps/rollup-large-example/package.json
@@ -9,7 +9,7 @@
     "start": "pnpx rollup --config ./rollup.config.mjs --watch"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/rollup-plugin": "0.11.0-rc.1"
   }
 }

--- a/apps/rollup-unplugin-example/package.json
+++ b/apps/rollup-unplugin-example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "@stylexswc/unplugin": "0.11.0-rc.1",

--- a/apps/rsbuild-unplugin-example/package.json
+++ b/apps/rsbuild-unplugin-example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "@stylexswc/unplugin": "0.11.0-rc.1",

--- a/apps/rspack-unplugin-example/package.json
+++ b/apps/rspack-unplugin-example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "@stylexswc/unplugin": "0.11.0-rc.1",

--- a/apps/solid-unplugin-example/package.json
+++ b/apps/solid-unplugin-example/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@playwright/test": "^1.54.2",
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/playwright": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",

--- a/apps/vite-unplugin-example/package.json
+++ b/apps/vite-unplugin-example/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@playwright/test": "^1.54.2",
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/playwright": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",

--- a/apps/vue-unplugin-example/package.json
+++ b/apps/vue-unplugin-example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "@stylexswc/unplugin": "0.11.0-rc.1",

--- a/apps/webpack-example/package.json
+++ b/apps/webpack-example/package.json
@@ -9,7 +9,7 @@
     "start": "webpack --watch"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.15.0"
+    "@stylexjs/stylex": "^0.15.3"
   },
   "devDependencies": {
     "@stylexswc/webpack-plugin": "0.11.0-rc.1",

--- a/apps/webpack-unplugin-example/package.json
+++ b/apps/webpack-unplugin-example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/design-system": "0.11.0-rc.1",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "@stylexswc/unplugin": "0.11.0-rc.1",

--- a/crates/stylex-rs-compiler/package.json
+++ b/crates/stylex-rs-compiler/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "@stylexjs/open-props": "^0.11.1",
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/shared": "0.11.0-rc.1",
     "@swc-node/register": "^1.10.10",
     "@swc/core": "^1.13.3",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.15.0",
+    "@stylexjs/stylex": "^0.15.3",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/packages/postcss-plugin/package.json
+++ b/packages/postcss-plugin/package.json
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@stylexjs/babel-plugin": "^0.14.1",
+    "@stylexjs/babel-plugin": "^0.15.3",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "fast-glob": "^3.3.3",
     "glob-parent": "^6.0.2",
@@ -48,8 +48,8 @@
     "@types/jest": "^30.0.0",
     "@types/loader-utils": "^2.0.6",
     "@types/node": "^24.1.0",
-    "jest-chain-transform": "^0.0.8",
     "jest": "^30.0.5",
+    "jest-chain-transform": "^0.0.8",
     "ts-jest": "^29.4.0"
   },
   "keywords": [

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@stylexjs/babel-plugin": "^0.14.1",
+    "@stylexjs/babel-plugin": "^0.15.3",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "lightningcss": "^1.30.1"
   },

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -87,7 +87,7 @@
     }
   },
   "dependencies": {
-    "@stylexjs/babel-plugin": "^0.14.1",
+    "@stylexjs/babel-plugin": "^0.15.3",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "unplugin": "^2.3.5",
     "vite": "^7.0.7",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@stylexjs/babel-plugin": "^0.14.1",
+    "@stylexjs/babel-plugin": "^0.15.3",
     "@stylexswc/rs-compiler": "0.11.0-rc.1",
     "loader-utils": "^3.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -138,8 +138,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -187,8 +187,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -209,8 +209,8 @@ importers:
         specifier: ^1.54.2
         version: 1.54.2
       '@stylexjs/eslint-plugin':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/jest':
         specifier: 0.11.0-rc.1
         version: link:../../packages/jest
@@ -275,8 +275,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -300,8 +300,8 @@ importers:
         specifier: ^1.54.2
         version: 1.54.2
       '@stylexjs/eslint-plugin':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/jest':
         specifier: 0.11.0-rc.1
         version: link:../../packages/jest
@@ -363,8 +363,8 @@ importers:
   apps/rollup-example:
     dependencies:
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -409,8 +409,8 @@ importers:
   apps/rollup-large-example:
     dependencies:
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/rollup-plugin':
         specifier: 0.11.0-rc.1
         version: link:../../packages/rollup-plugin
@@ -421,8 +421,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -476,8 +476,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -522,8 +522,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -577,8 +577,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -626,8 +626,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -669,8 +669,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -712,8 +712,8 @@ importers:
   apps/webpack-example:
     dependencies:
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
     devDependencies:
       '@stylexswc/webpack-plugin':
         specifier: 0.11.0-rc.1
@@ -740,8 +740,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/design-system':
         specifier: 0.11.0-rc.1
         version: link:../../packages/design-system
@@ -825,8 +825,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/shared':
         specifier: 0.11.0-rc.1
         version: link:../stylex-shared
@@ -900,8 +900,8 @@ importers:
   packages/design-system:
     dependencies:
       '@stylexjs/stylex':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/rs-compiler':
         specifier: 0.11.0-rc.1
         version: link:../../crates/stylex-rs-compiler
@@ -1036,8 +1036,8 @@ importers:
   packages/postcss-plugin:
     dependencies:
       '@stylexjs/babel-plugin':
-        specifier: ^0.14.1
-        version: 0.14.1
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/rs-compiler':
         specifier: 0.11.0-rc.1
         version: link:../../crates/stylex-rs-compiler
@@ -1094,8 +1094,8 @@ importers:
   packages/rollup-plugin:
     dependencies:
       '@stylexjs/babel-plugin':
-        specifier: ^0.14.1
-        version: 0.14.1
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/rs-compiler':
         specifier: 0.11.0-rc.1
         version: link:../../crates/stylex-rs-compiler
@@ -1145,8 +1145,8 @@ importers:
         specifier: '>=1.7.10 <2.0.0'
         version: 1.7.10
       '@stylexjs/babel-plugin':
-        specifier: ^0.14.1
-        version: 0.14.1
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/rs-compiler':
         specifier: 0.11.0-rc.1
         version: link:../../crates/stylex-rs-compiler
@@ -1227,8 +1227,8 @@ importers:
   packages/webpack-plugin:
     dependencies:
       '@stylexjs/babel-plugin':
-        specifier: ^0.14.1
-        version: 0.14.1
+        specifier: ^0.15.3
+        version: 0.15.4
       '@stylexswc/rs-compiler':
         specifier: 0.11.0-rc.1
         version: link:../../crates/stylex-rs-compiler
@@ -3262,11 +3262,11 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
-  '@stylexjs/babel-plugin@0.14.1':
-    resolution: {integrity: sha512-K7KzSfdFaWKJqZztR0haXowu3lmc0RXDTWIAKBADOChEEw0Z08e8FD3C97NHAHCktgsSc/bCe85g+wmu9a4xuQ==}
+  '@stylexjs/babel-plugin@0.15.4':
+    resolution: {integrity: sha512-QfL2j3VCU+KTyIEoPBhdwq8KW1Gv0FVvwSzfjjdQ0J2Ei/DJBx2AXVsDYzBcVw0WI+KsEfQUHFZ1Fk2t1U/9Iw==}
 
-  '@stylexjs/eslint-plugin@0.15.0':
-    resolution: {integrity: sha512-RR1/rsDQbbJyoUVIfjlvDNOqSqk7ZmomF4yxec1tARf4OnS1RaRGKYDAlnG4DmA0t98d/lmozWzSurSUF7Ki1A==}
+  '@stylexjs/eslint-plugin@0.15.4':
+    resolution: {integrity: sha512-P33h+QdudEI3oSzIvVXhNHeAfbUzG4xGYW7tt4hdMizAl+bwIj58+8TK7fxQPV01yBMMNGrBlA/aCmzfQOP8Gw==}
 
   '@stylexjs/open-props@0.11.1':
     resolution: {integrity: sha512-UYeJV34LOmDZ1igQknB+iM3JMg+lbncHr/zG7i1tBwwQslNNWOMM7iR4hwSUvczQYcW5G8vMAorP/2j4T8XBjA==}
@@ -3275,11 +3275,8 @@ packages:
   '@stylexjs/stylex@0.11.1':
     resolution: {integrity: sha512-1OofsiCP2DYV+Cw/iIuHYTAJRy34TtxQt0FDuQGTnNH915hb6NkPmX6iPa++9t4KP3HWR9oVRmAHkpP58BIYbw==}
 
-  '@stylexjs/stylex@0.14.1':
-    resolution: {integrity: sha512-UlAGhGUHTqZoMThHdpLUFhO0fjWxJ3VDFRsGK0mNwCD4IEe2EPkIjtZTjHZepidDAbUcNoXlTQoK/y1fcd5f/w==}
-
-  '@stylexjs/stylex@0.15.0':
-    resolution: {integrity: sha512-D56b61D7vIvNNoTUQKQJhE1I3kxbLWBAO4FTbAFFei2ZHqy3P+vy4m6hpssrw8iRt04I3aoHziZVMj5X/IjkCw==}
+  '@stylexjs/stylex@0.15.4':
+    resolution: {integrity: sha512-UQT75p3qxwCIsVpH87YfgHvzWGDyMbQcFKhguj4noBZCc+npEh5h7J4BIHMgrxpyJa9mislLfXv+M5TmP2YH5A==}
 
   '@swc-node/core@1.13.3':
     resolution: {integrity: sha512-OGsvXIid2Go21kiNqeTIn79jcaX4l0G93X2rAnas4LFoDyA9wAwVK7xZdm+QsKoMn5Mus2yFLCc4OtX2dD/PWA==}
@@ -11583,19 +11580,19 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@stylexjs/babel-plugin@0.14.1':
+  '@stylexjs/babel-plugin@0.15.4':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-imports': 7.27.1
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.2
       '@dual-bundle/import-meta-resolve': 4.1.0
-      '@stylexjs/stylex': 0.14.1
+      '@stylexjs/stylex': 0.15.4
       postcss-value-parser: 4.2.0
     transitivePeerDependencies:
       - supports-color
 
-  '@stylexjs/eslint-plugin@0.15.0':
+  '@stylexjs/eslint-plugin@0.15.4':
     dependencies:
       css-shorthand-expand: 1.2.0
       micromatch: 4.0.8
@@ -11610,13 +11607,7 @@ snapshots:
       invariant: 2.2.4
       styleq: 0.2.1
 
-  '@stylexjs/stylex@0.14.1':
-    dependencies:
-      css-mediaquery: 0.1.2
-      invariant: 2.2.4
-      styleq: 0.2.1
-
-  '@stylexjs/stylex@0.15.0':
+  '@stylexjs/stylex@0.15.4':
     dependencies:
       css-mediaquery: 0.1.2
       invariant: 2.2.4


### PR DESCRIPTION
## Description

This pull request updates several dependencies across multiple example apps and packages, primarily focusing on upgrading `@stylexjs/stylex` and `@stylexjs/babel-plugin` to version `0.15.3`. These updates help ensure compatibility and bring in the latest features and fixes from the StyleX ecosystem. Additionally, there are minor adjustments to the ordering of devDependencies in one package.

**Dependency version upgrades:**

* Updated `@stylexjs/stylex` to version `^0.15.3` in all example app `package.json` files, including Next.js, Rollup, Vite, Webpack, Solid, Vue, Rsbuild, Rspack, Farm, and Esbuild examples. [[1]](diffhunk://#diff-c5454707cf7f8f8014d18945ab920c84285c61bec42d07e3f393f11878acab5bL15-R15) [[2]](diffhunk://#diff-f428c52e09babcd9450a96a54817d66fbe8a55d407301006a6fa37e116b991beL15-R15) [[3]](diffhunk://#diff-42d95041844ffeb8391778ecd69c79be29736a1b1d3adcb9333c15bdebd6a370L24-R24) [[4]](diffhunk://#diff-6e638040715ebb1752b492845fdd6805bbe5c2b7b217e21e2f32ab7102622503L24-R24) [[5]](diffhunk://#diff-a3431edbca73f89fd3ae9acc9180a06d69010861e43ce1a1e87523eb0b3dfdb3L14-R14) [[6]](diffhunk://#diff-92b48d65051a64b02f140f35cdb9a2dd7b1d761e453dfd56c4e34af1dff9600aL12-R12) [[7]](diffhunk://#diff-fd271f75fa8bb9ce52f9a0c615df5808c05653a48d2d443d3e7abe08bb844f11L15-R15) [[8]](diffhunk://#diff-4972f2ef3a509994fa29e111e7dcad2f70a968c52e7c4fd1804ff775ea0b9006L15-R15) [[9]](diffhunk://#diff-9733d5521035092a4da9396921cec9b0d76fa8503c4bfda9b7bcd1b129eb414eL15-R15) [[10]](diffhunk://#diff-ea81110236d0817edc9e01c80b83a43ddfaf7cef5e42e7c2cc65c0ccec7253c7L16-R16) [[11]](diffhunk://#diff-c68f34c891ae37c0bce4103622cb8c12c8c440e178af8ded128a722265afc6d5L16-R16) [[12]](diffhunk://#diff-9636deeb3f7ac1a35245dc76713b8ac00dda2abcd5f026945a3f908b01fe6637L15-R15) [[13]](diffhunk://#diff-9245001726b55e76baa0f9c2ce0dc90baf95a4c5dd22ba556d77b2a85a5f0e14L12-R12) [[14]](diffhunk://#diff-8814d8792e0dc7be1342ad0c487f7eb6908b534a8cbb680eb2c5fdd325318adeL15-R15) [[15]](diffhunk://#diff-f156afdf6246ccb2a97ca19963838efdd319ebeb6db6e8cdbd455f4c749ae29dL45-R45) [[16]](diffhunk://#diff-a4c0abcf0f908370abfbae102f74a6ce5fa6453eac6d389f6fc78cece44782f9L37-R37)

* Updated `@stylexjs/babel-plugin` to version `^0.15.3` in the main plugin packages: `postcss-plugin`, `rollup-plugin`, `unplugin`, and `webpack-plugin`. [[1]](diffhunk://#diff-dde432aaf5184b3a6ad1ade95a6af0940eb9cc8ffc92274dc0d0390162cd7037L34-R34) [[2]](diffhunk://#diff-fc4d0162f6bc3fada5d5af6eb8c18dd46c76771fd9905e46687c11d561031bddL34-R34) [[3]](diffhunk://#diff-68a8641818414cf8bbf1abd09f5941e81f69b4ce6ce7127c5c37775faec4649dL90-R90) [[4]](diffhunk://#diff-993aa4a0b8cd6f305b8990e0941cdf5d7e8daa5c1a15868690a7cfaba793dde6L34-R34)

**DevDependency updates:**

* Updated `@stylexjs/eslint-plugin` to version `^0.15.3` in the Next.js example apps. [[1]](diffhunk://#diff-42d95041844ffeb8391778ecd69c79be29736a1b1d3adcb9333c15bdebd6a370L33-R33) [[2]](diffhunk://#diff-6e638040715ebb1752b492845fdd6805bbe5c2b7b217e21e2f32ab7102622503L34-R34)

**Minor dependency ordering fix:**

* Moved `jest-chain-transform` to the correct alphabetical position in the devDependencies of `packages/postcss-plugin/package.json`.

These changes collectively ensure all related packages and examples are using the latest stable versions of StyleX dependencies, reducing risk of incompatibilities and taking advantage of recent improvements.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
