### PR TITLE
fix(add_source_map_data): fix with using template string

### DIFF
--- a/crates/stylex-shared/src/shared/transformers/tests/stylex_create_test.rs
+++ b/crates/stylex-shared/src/shared/transformers/tests/stylex_create_test.rs
@@ -6,6 +6,7 @@ mod stylex_create {
   use swc_core::ecma::ast::{Expr, ExprOrSpread, KeyValueProp};
 
   use crate::shared::{
+    constants::common::COMPILED_KEY,
     enums::data_structures::{
       evaluate_result_value::EvaluateResultValue,
       flat_compiled_styles_value::FlatCompiledStylesValue, injectable_style::InjectableStyleKind,
@@ -222,7 +223,7 @@ mod stylex_create {
       let mut default_val = IndexMap::new();
 
       default_val.insert(
-        "$$css".to_string(),
+        COMPILED_KEY.to_string(),
         Rc::new(FlatCompiledStylesValue::Bool(true)),
       );
 

--- a/crates/stylex-shared/src/transform/fold/fold_jsx_attr_or_spread.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_jsx_attr_or_spread.rs
@@ -57,7 +57,6 @@ where
           })
           .collect();
 
-        // dbg!(&jsx_attrs, &result);
         result.fold_children_with(self)
       }
       _ => jsx_attrs.fold_children_with(self),


### PR DESCRIPTION
## Description

This pull request introduces several improvements and fixes to the StyleX shared utilities, primarily focusing on more robust handling of source maps, error logging, and expression parsing. The most significant changes include enhanced diagnostics for Next.js mismatches, consistent usage of the `COMPILED_KEY` constant, and improved logic for locating expression spans in source code. Additionally, new logic was added to better handle string concatenation expressions when generating code frames.

### Diagnostics and Logging Improvements
* Added a warning message for users of Next.js when a source map span cannot be found, explaining potential server/client AST mismatches and how to debug them (`add_source_map_data.rs`).
* Improved debug and warning log formatting in both `add_source_map_data.rs` and `build_code_frame_error.rs` for clearer diagnostics. [[1]](diffhunk://#diff-56c4ba74d21f34158602b2b5e8c591ecbc89f564b20eb10d1ad99bf53180d734R64-R77) [[2]](diffhunk://#diff-eed505603805caa78a3840843ed569033027145bed7ebfbb5898f0895824650aL107-R116)

### Source Map and Key Consistency
* Standardized usage of the `COMPILED_KEY` constant throughout the codebase for storing and checking compiled style metadata in maps, replacing previous hardcoded string values. [[1]](diffhunk://#diff-0c6eef7616002a1879f4d0631897a8dcb3966a434ac339c380f58c50b4d57267R9) [[2]](diffhunk://#diff-0c6eef7616002a1879f4d0631897a8dcb3966a434ac339c380f58c50b4d57267L225-R226) [[3]](diffhunk://#diff-56c4ba74d21f34158602b2b5e8c591ecbc89f564b20eb10d1ad99bf53180d734L86-R93) [[4]](diffhunk://#diff-56c4ba74d21f34158602b2b5e8c591ecbc89f564b20eb10d1ad99bf53180d734L116-R122)

### Expression Span Resolution Enhancements
* Refactored the logic for finding the span of a target expression in `build_code_frame_error.rs` to first try direct lookup, then fallback to a template literal conversion if necessary, improving reliability for complex expressions. [[1]](diffhunk://#diff-eed505603805caa78a3840843ed569033027145bed7ebfbb5898f0895824650aL141-L142) [[2]](diffhunk://#diff-eed505603805caa78a3840843ed569033027145bed7ebfbb5898f0895824650aR154-R171)

### Template Literal Handling
* Added a new `TplConverter` fold and helper function to transform string concatenation expressions (e.g., `.concat()`) into template literals for more accurate code frame error reporting.

### Minor Cleanups
* Removed an unnecessary debug statement from `fold_jsx_attr_or_spread.rs` to clean up test output.

## Fixes

(Optional) Fixes #558

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
