### PR TITLE
fix(stylexswc/unplugin): correct compile reset css with vite plugin

### DIFF
--- a/apps/vite-unplugin-virtual-css-example/src/App.tsx
+++ b/apps/vite-unplugin-virtual-css-example/src/App.tsx
@@ -13,7 +13,6 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-around',
-    backgroundColor: colors.violet1,
     flexDirection: 'column',
   },
   card: {

--- a/apps/vite-unplugin-virtual-css-example/src/index.tsx
+++ b/apps/vite-unplugin-virtual-css-example/src/index.tsx
@@ -1,3 +1,4 @@
+import './reset.css';
 import 'virtual:stylex.css';
 
 import { createRoot } from 'react-dom/client';

--- a/apps/vite-unplugin-virtual-css-example/src/reset.css
+++ b/apps/vite-unplugin-virtual-css-example/src/reset.css
@@ -1,0 +1,29 @@
+/* Reset CSS */
+@layer reset {
+  * {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+  }
+}
+
+/* Global styles */
+@layer global {
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+    background-color: #e5dbff;
+  }
+
+  h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+}

--- a/apps/vue-unplugin-virtual-css-example/src/App.vue
+++ b/apps/vue-unplugin-virtual-css-example/src/App.vue
@@ -16,7 +16,6 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-around',
-    backgroundColor: colors.violet1,
     flexDirection: 'column',
   },
   card: {

--- a/apps/vue-unplugin-virtual-css-example/src/index.ts
+++ b/apps/vue-unplugin-virtual-css-example/src/index.ts
@@ -1,3 +1,4 @@
+import './reset.css';
 import 'virtual:stylex.css';
 
 import { createApp } from 'vue';

--- a/apps/vue-unplugin-virtual-css-example/src/reset.css
+++ b/apps/vue-unplugin-virtual-css-example/src/reset.css
@@ -1,0 +1,29 @@
+/* Reset CSS */
+@layer reset {
+  * {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+  }
+}
+
+/* Global styles */
+@layer global {
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+    background-color: #e5dbff;
+  }
+
+  h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+}

--- a/crates/stylex-shared/tests/transform_stylex_create_test/dynamic_styles.rs
+++ b/crates/stylex-shared/tests/transform_stylex_create_test/dynamic_styles.rs
@@ -589,7 +589,6 @@ test!(
   "#
 );
 
-
 test!(
   Syntax::Typescript(TsSyntax {
     tsx: true,

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -236,6 +236,20 @@ For TypeScript projects, add the type definition to your `tsconfig.json`:
 > [!NOTE]
 > When `useViteCssPipeline` is enabled, you need to explicitly import `virtual:stylex.css` in your application. The plugin will no longer inject CSS automatically into the HTML.
 
+> [!IMPORTANT]
+> **Reset CSS and Other Global Styles**
+>
+> The `virtual:stylex.css` module should only contain StyleX-generated CSS. If you need to include reset CSS, global styles, or other non-StyleX CSS, import them from separate CSS files:
+>
+> ```typescript
+> // src/main.ts
+> import './reset.css';        // Your reset CSS
+> import './global.css';       // Other global styles
+> import 'virtual:stylex.css'; // StyleX-generated CSS
+> ```
+>
+> **Do not** put reset CSS or other styles inside the virtual module, as they should be managed separately from the StyleX-generated styles. See the examples in [`apps/vite-unplugin-virtual-css-example`](../../apps/vite-unplugin-virtual-css-example) and [`apps/vue-unplugin-virtual-css-example`](../../apps/vue-unplugin-virtual-css-example) for reference.
+
 ### Example Configuration
 
 ```typescript

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -20,7 +20,8 @@ const { writeFile, mkdir } = promises;
 
 const VIRTUAL_CSS_MODULE_ID = 'virtual:stylex.css';
 const RESOLVED_VIRTUAL_CSS_MODULE_ID = '\0' + VIRTUAL_CSS_MODULE_ID;
-const VIRTUAL_CSS_MARKER = ':root{--stylex-placeholder:1}';
+const VIRTUAL_CSS_MARKER_VAR = '--stylex-placeholder';
+const VIRTUAL_CSS_MARKER = `:root{${VIRTUAL_CSS_MARKER_VAR}:1}`;
 
 let viteDevServer: ViteDevServer | null = null;
 let hasInvalidatedInitialCSS = false;
@@ -224,7 +225,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         }
       },
 
-      generateBundle(options, bundle) {
+      generateBundle(_options, bundle) {
         if (!normalizedOptions.useViteCssPipeline) return;
 
         const collectedCSS = getStyleXRules(stylexRules, normalizedOptions.useCSSLayers);
@@ -235,9 +236,9 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           // Look for CSS assets that contain our placeholder
           if (output.type === 'asset' && fileName.endsWith('.css')) {
             const source = output.source.toString();
-            if (source.includes('--stylex-placeholder')) {
-              // Replace the placeholder with actual CSS
-              output.source = collectedCSS;
+            if (source.includes(VIRTUAL_CSS_MARKER)) {
+              // Replace only the placeholder with actual CSS, preserving other CSS
+              output.source = source.replace(VIRTUAL_CSS_MARKER, collectedCSS);
               break;
             }
           }


### PR DESCRIPTION
## Description

This pull request introduces global CSS resets and improved stylig for both the React and Vue example apps, along with a refinement to the plugin’s CSS injection logic. The main changes are grouped into improvements to global styles and plugin behavior.

**Global style improvements:**

* Added a `reset.css` file for both React (`apps/vite-unplugin-virtual-css-example/src/reset.css`) and Vue (`apps/vue-unplugin-virtual-css-example/src/reset.css`) apps, establishing a CSS reset and global styles for consistent appearance and layout.
* Imported the new `reset.css` in both entry files: `src/index.tsx` (React) and `src/index.ts` (Vue), ensuring the reset is applied app-wide. [[1]](diffhunk://#diff-bbe0ea4198edee9c33046d51779723a011313795f878b9024299fcaccbcabb85R1) [[2]](diffhunk://#diff-a83a3fa9f2f9212bf0a2fee252f4f9f53914984d459dfb511bc8c439ead8c09fR1)
* Removed the `backgroundColor` style from the main container in both `App.tsx` (React) and `App.vue` (Vue), delegating background color responsibility to the new global CSS. [[1]](diffhunk://#diff-589d71d4d6cef85ddba5a370f68aee16c3e14e0e5d4f069bad962291a6e91858L16) [[2]](diffhunk://#diff-e18222c4ca426a541303c6e3a5a19750bd53c43454726844a47958033de9e621L19)

**Plugin behavior refinement:**

* Updated the `generateBundle` hook in `packages/unplugin/src/index.ts` to replace only the virtual CSS marker within the output CSS file, preserving any other CSS content instead of overwriting the entire file.
* Minor parameter renaming in the same hook for clarity (`options` → `_options`).

## Fixes 

(Optional) Fixes #602

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
