### PR TITLE
chore(rust): upgrade to 1.90.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
       "pnpmVersion": "9.15.4"
     },
     "ghcr.io/devcontainers/features/rust:1": {
-      "version": "1.89.0",
+      "version": "1.90.0",
       "targets": [
         "wasm32-wasip1",
         "x86_64-apple-darwin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/stylex-*"]
 [workspace.package]
 version = "0.11.3-rc.1"
 edition = "2024"
-rust-version = "1.89.0"
+rust-version = "1.90.0"
 license = "MIT"
 repository = "https://github.com/Dwlad90/stylex-swc-plugin.git"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -22,5 +22,5 @@ ignore-interior-mutability = [
   "swc_atoms::JsWord",
   "swc_ecma_ast::Id",
 ]
-msrv = "1.89.0"
+msrv = "1.90.0"
 type-complexity-threshold = 25000

--- a/crates/stylex-css-parser/Cargo.toml
+++ b/crates/stylex-css-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stylex_css_parser"
 version = "0.11.3-rc.1"
 edition = "2024"
-rust-version = "1.89.0"
+rust-version = "1.90.0"
 description = "CSS value parser"
 license = "MIT"
 repository = "https://github.com/Dwlad90/stylex-swc-plugin.git"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 components = ["rustfmt", "clippy"]
 targets = [
   "wasm32-wasip1",

--- a/turbo.json
+++ b/turbo.json
@@ -48,6 +48,13 @@
         "clean"
       ]
     },
+    "@stylexswc/rs-compiler#test": {
+      "dependsOn": [
+        "^build",
+        "build",
+        "clean"
+      ]
+    },
     "@stylexswc/path-resolver#lint:check": {
       "dependsOn": [
         "^build",


### PR DESCRIPTION
## Description

This pull request primarily upgrades the Rust toolchain version from 1.89.0 to 1.90.0 across the repository, ensuring consistency and compatibility with the latest Rust features. Additionally, it introduces a new test dependency configuration for the `@stylexswc/rs-compiler` package in the build system.

**Rust toolchain and configuration updates:**

* Updated the Rust toolchain version to 1.90.0 in `.devcontainer/devcontainer.json`, `rust-toolchain.toml`, workspace `Cargo.toml`, `crates/stylex-css-parser/Cargo.toml`, and `clippy.toml` to ensure all tooling and dependencies use the latest stable Rust release. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L10-R10) [[2]](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL2-R2) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L9-R9) [[4]](diffhunk://#diff-f2bbbc98b184aa1b316db5b1847d5d3b31fc7aca7c5ca57b056d87cba1a16bcaL5-R5) [[5]](diffhunk://#diff-f3dbfb2563c3490394f44c26b51837018e79a79e75fd31e89b19e943a38317eaL25-R25)

**Build system improvements:**

* Added a new test dependency configuration for `@stylexswc/rs-compiler` in `turbo.json`, making sure its tests depend on both build and clean steps for improved reliability.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
