### PR TITLE
feat(stylex_compiler_rs): add support to SWC plugins

### DIFF
--- a/crates/stylex-rs-compiler/README.md
+++ b/crates/stylex-rs-compiler/README.md
@@ -160,6 +160,86 @@ shouldTransformFile(
 );
 ```
 
+### SWC Plugin Support
+
+> [!NOTE]
+> **New Feature:** The compiler now supports running SWC WASM plugins before StyleX transformation. This allows you to chain transformations and integrate custom SWC plugins seamlessly.
+
+The `transform` function accepts an optional `swcPlugins` array in the options object, allowing you to run SWC WASM plugins before the StyleX transformation:
+
+```ts
+const { transform } = require('@stylexswc/rs-compiler');
+
+const { code, metadata, map } = transform(
+  'Button.tsx',
+  sourceCode,
+  {
+    dev: true,
+    // Other StyleX options...
+
+    // SWC plugins to run before StyleX transformation
+    swcPlugins: [
+      // Plugin as [pluginPath, config]
+      [
+        '/path/to/swc_plugin_theme.wasm',
+        {
+          themeName: 'my-theme',
+          customOption: 'value'
+        }
+      ],
+      // You can chain multiple plugins
+      [
+        '@swc/plugin-emotion',
+        {
+          sourceMap: true
+        }
+      ]
+    ]
+  }
+);
+```
+
+#### How It Works
+
+1. **Plugin Execution Phase**: If `swcPlugins` are provided, the source code is first transformed using `@swc/core`'s `transformSync` with the specified WASM plugins
+2. **StyleX Transformation Phase**: The plugin-transformed code is then passed to the StyleX compiler
+
+#### Plugin Configuration
+
+Each plugin in the `swcPlugins` array is a tuple of:
+- **Plugin Path** (string): Can be:
+  - An absolute path to a `.wasm` file: `/path/to/plugin.wasm`
+  - An npm package name: `@swc/plugin-emotion`
+- **Plugin Config** (object): Plugin-specific configuration options
+
+#### Example: Custom Theme Plugin
+
+```ts
+transform(filename, code, {
+  dev: true,
+  swcPlugins: [
+    [
+      '/Users/me/plugins/swc_plugin_theme.wasm',
+      {
+        themeName: 'theme-name',
+        themeConfig: {
+          primaryColor: 'blue',
+          spacing: 8
+        }
+      }
+    ]
+  ]
+});
+```
+
+#### Benefits
+
+- ✅ Chain multiple transformations seamlessly
+- ✅ Leverage the SWC plugin ecosystem
+- ✅ Custom preprocessing before StyleX transformation
+- ✅ Full compatibility with SWC WASM plugins
+- ✅ No additional build configuration needed
+
 ### Output
 
 The output from the compiler includes the transformed code, metadata about the

--- a/crates/stylex-rs-compiler/__test__/normalizeRsOptions.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/normalizeRsOptions.spec.ts
@@ -16,6 +16,7 @@ const defaultResult: StyleXOptions = {
   enableLogicalStylesPolyfill: false,
   enableMinifiedKeys: true,
   styleResolution: 'property-specificity',
+  swcPlugins: [],
   enableLTRRTLComments: false,
   legacyDisableLayers: false,
 };

--- a/crates/stylex-rs-compiler/package.json
+++ b/crates/stylex-rs-compiler/package.json
@@ -17,8 +17,10 @@
   "scripts": {
     "artifacts": "napi artifacts",
     "bench": "node --import @swc-node/register/esm-register benchmark/bench.ts",
-    "build": "napi build --platform --release dist",
+    "build": "npm run build:napi && npm run build:swc",
     "build:debug": "napi build --platform",
+    "build:napi": "napi build --platform --release dist",
+    "build:swc": "node scripts/inject-swc-plugins.mjs",
     "check:artifacts": "scripty ./dist/rs-compiler.*.node",
     "format": "run-p format:prettier format:rs format:toml",
     "format:check": "run-p format:rs:check format:toml:check",
@@ -40,13 +42,15 @@
       "path": "../../scripts/packages"
     }
   },
+  "dependencies": {
+    "@swc/core": "^1.13.3"
+  },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "@stylexjs/open-props": "^0.11.1",
     "@stylexjs/stylex": "^0.16.2",
     "@stylexswc/shared": "0.13.0-rc.1",
     "@swc-node/register": "^1.11.1",
-    "@swc/core": "^1.13.3",
     "@taplo/cli": "^0.7.0",
     "@types/node": "^24.7.2",
     "ava": "^6.4.1",

--- a/crates/stylex-rs-compiler/scripts/inject-swc-plugins.mjs
+++ b/crates/stylex-rs-compiler/scripts/inject-swc-plugins.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Post-build script to inject SWC plugin wrapper into dist/index.js
+ */
+
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import fs from 'node:fs'
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const indexJsPath = path.join(__dirname, '../dist/index.js');
+
+console.log('Injecting SWC plugin wrapper into dist/index.js...');
+
+// === Update index.js ===
+let jsContent = fs.readFileSync(indexJsPath, 'utf8');
+
+// Find the exports section (allow variable whitespace and any order)
+const exportsRegex = /const\s*\{\s*([^}]+)\s*\}\s*=\s*nativeBinding/;
+const exportsMatch = jsContent.match(exportsRegex);
+if (!exportsMatch) {
+  console.error('Could not find exports section in index.js');
+  process.exit(1);
+}
+// Check that all required exports are present
+const requiredExports = ['SourceMaps', 'transform', 'shouldTransformFile', 'normalizeRsOptions'];
+const foundExports = exportsMatch[1].split(',').map(e => e.trim());
+const missingExports = requiredExports.filter(e => !foundExports.includes(e));
+if (missingExports.length > 0) {
+  console.error('Missing required exports in index.js:', missingExports.join(', '));
+  process.exit(1);
+}
+
+// Wrapper code to inject
+const wrapperCode = `
+// === SWC Plugin Wrapper (injected by scripts/inject-swc-plugins.mjs) ===
+
+const nativeTransform = transform;
+
+/**
+ * Wrapper around transform that supports SWC plugins
+ * If options.swcPlugins is provided, runs SWC plugins first, then StyleX transform
+ */
+function transformWithPlugins(filename, code, options) {
+  let transformedCode = code;
+
+  if (options.swcPlugins && Array.isArray(options.swcPlugins) && options.swcPlugins.length > 0) {
+    try {
+      // Lazy-load @swc/core only if plugins are used
+      const swc = require('@swc/core');
+
+      const swcOptions = {
+        filename,
+        sourceMaps: options.sourceMap === 'Inline' ? 'inline' : Boolean(options.sourceMap),
+        jsc: {
+          parser: {
+            syntax: 'typescript',
+            tsx: true,
+          },
+          target: 'es2022',
+          experimental: {
+            plugins: options.swcPlugins,
+          },
+        },
+      };
+
+      const result = swc.transformSync(transformedCode, swcOptions);
+      transformedCode = result.code;
+    } catch (error) {
+      console.error(\`✗ SWC plugin execution failed for \${filename}:\`, error);
+      throw error;
+    }
+  }
+
+  const { swcPlugins: _removed, ...stylexOptions } = options;
+
+  return nativeTransform(filename, transformedCode, stylexOptions);
+}
+
+// Replace the transform export with our wrapper
+module.exports.transform = transformWithPlugins;
+
+// === End SWC Plugin Wrapper ===
+`;
+
+// Replace the module.exports section
+// Replace only the transform export line with our wrapper
+const transformExportRegex = /^module\.exports\.transform\s*=\s*transform\s*;?/m;
+if (!transformExportRegex.test(jsContent)) {
+  console.error('Could not find "module.exports.transform = transform" in index.js');
+  process.exit(1);
+}
+jsContent = jsContent.replace(transformExportRegex, wrapperCode + '\nmodule.exports.transform = transformWithPlugins;');
+// Validate that the wrapper was injected
+if (!jsContent.includes('transformWithPlugins')) {
+  console.error('Failed to inject SWC plugin wrapper into index.js');
+  process.exit(1);
+}
+
+// Write back
+fs.writeFileSync(indexJsPath, jsContent, 'utf8');
+console.log('✓ Successfully injected SWC plugin wrapper into dist/index.js');
+
+console.log('\n✅ SWC plugin injection complete!');

--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -263,6 +263,7 @@ pub fn normalize_rs_options(options: StyleXOptions) -> Result<StyleXOptions> {
       .style_resolution
       .or(Some("property-specificity".to_string())),
     legacy_disable_layers: options.legacy_disable_layers.or(Some(false)),
+    swc_plugins: options.swc_plugins.or(Some(vec![])),
     ..options
   };
 

--- a/crates/stylex-rs-compiler/src/structs/mod.rs
+++ b/crates/stylex-rs-compiler/src/structs/mod.rs
@@ -43,6 +43,8 @@ pub struct StyleXOptions {
   pub include: Option<Vec<JsUnknown>>,
   #[napi(ts_type = "Array<string | RegExp>")]
   pub exclude: Option<Vec<JsUnknown>>,
+  #[napi(ts_type = "Array<[string, Record<string, any>]>")]
+  pub swc_plugins: Option<Vec<JsUnknown>>,
 }
 
 #[napi(object)]

--- a/crates/stylex-shared/src/shared/utils/core/add_source_map_data.rs
+++ b/crates/stylex-shared/src/shared/utils/core/add_source_map_data.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexMap;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use once_cell::sync::Lazy;
 use std::{env, path::Path, rc::Rc};
 use swc_core::{
@@ -78,7 +78,7 @@ pub(crate) fn add_source_map_data(
                       &*NEXTJS_HYDRATION_WARNING
                     );
                   } else {
-                    warn!(
+                    info!(
                       "Could not find span for style node path. File: {}. For more information enable debug logging.{}",
                       state.get_filename(),
                       &*NEXTJS_HYDRATION_WARNING

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1181,6 +1181,10 @@ importers:
         version: 3.6.2
 
   crates/stylex-rs-compiler:
+    dependencies:
+      '@swc/core':
+        specifier: ^1.13.3
+        version: 1.13.3(@swc/helpers@0.5.17)
     devDependencies:
       '@napi-rs/cli':
         specifier: ^2.18.4
@@ -1197,9 +1201,6 @@ importers:
       '@swc-node/register':
         specifier: ^1.11.1
         version: 1.11.1(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3)
-      '@swc/core':
-        specifier: ^1.13.3
-        version: 1.13.3(@swc/helpers@0.5.17)
       '@taplo/cli':
         specifier: ^0.7.0
         version: 0.7.0


### PR DESCRIPTION
## Description

This pull request introduces support for chaining SWC WASM plugins before StyleX transformation in the `stylex-rs-compiler` package, allowing users to preprocess code with SWC plugins seamlessly. It also updates the build process and TypeScript types to reflect this new capability. The most important changes are grouped below:

### SWC Plugin Integration

* Added support for running SWC WASM plugins before StyleX transformation via a new `swcPlugins` option in the `transform` function. This is documented in `README.md` with usage examples and benefits.
* Injected a wrapper into `dist/index.js` via a new post-build script (`scripts/inject-swc-plugins.mjs`) that runs SWC plugins (using `@swc/core`) before invoking the native StyleX transform, handling plugin configuration and chaining.
* Updated the TypeScript type for `StyleXOptions` to include an optional `swc_plugins` array, allowing typed plugin configuration.

### Build & Dependency Management

* Modified the build process in `package.json` to include a new script for injecting the SWC plugin wrapper and separated native and SWC build steps. Also moved `@swc/core` from devDependencies to dependencies to support runtime plugin execution. [[1]](diffhunk://#diff-f156afdf6246ccb2a97ca19963838efdd319ebeb6db6e8cdbd455f4c749ae29dR10) [[2]](diffhunk://#diff-f156afdf6246ccb2a97ca19963838efdd319ebeb6db6e8cdbd455f4c749ae29dL20-R24) [[3]](diffhunk://#diff-f156afdf6246ccb2a97ca19963838efdd319ebeb6db6e8cdbd455f4c749ae29dR46-L49) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1184-R1187) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1200-L1202)

### Internal Options Handling

* Updated the Rust normalization logic to ensure `swc_plugins` is always present in `StyleXOptions`, defaulting to an empty array if not specified.

### Logging Improvements

* Changed logging in `add_source_map_data.rs` from `warn!` to `info!` for cases where a style node path span cannot be found, improving log clarity. [[1]](diffhunk://#diff-56c4ba74d21f34158602b2b5e8c591ecbc89f564b20eb10d1ad99bf53180d734L2-R2) [[2]](diffhunk://#diff-56c4ba74d21f34158602b2b5e8c591ecbc89f564b20eb10d1ad99bf53180d734L81-R81)

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
