### PR TITLE
fix(stylex_shared): evaluate optional chaining

### DIFF
--- a/crates/stylex-shared/src/shared/utils/js/mod.rs
+++ b/crates/stylex-shared/src/shared/utils/js/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod check_declaration;
 pub mod evaluate;
 pub(crate) mod native_functions;
+pub(crate) mod tests;

--- a/crates/stylex-shared/src/shared/utils/js/tests/evaluate_tests.rs
+++ b/crates/stylex-shared/src/shared/utils/js/tests/evaluate_tests.rs
@@ -1,0 +1,603 @@
+#[cfg(test)]
+mod tests {
+  use crate::shared::{
+    structures::{
+      functions::FunctionMap, state_manager::StateManager, stylex_options::StyleXOptions,
+    },
+    utils::{
+      ast::{
+        convertors::{
+          bool_to_expression, null_to_expression, number_to_expression, string_to_expression,
+        },
+        factories::ident_factory,
+      },
+      js::evaluate::evaluate,
+    },
+  };
+  use swc_core::{
+    common::DUMMY_SP,
+    ecma::ast::{
+      AwaitExpr, BinExpr, BinaryOp, ComputedPropName, Expr, IdentName, MemberExpr, MemberProp,
+      OptChainBase, OptChainExpr, UnaryExpr, UnaryOp,
+    },
+  };
+
+  // ==================== HELPER FUNCTIONS ====================
+
+  // Helper: Create undefined expression
+  fn make_undefined_expr() -> Expr {
+    Expr::Ident(ident_factory("undefined"))
+  }
+
+  // Helper: Create identifier expression
+  fn make_ident_expr(name: &str) -> Expr {
+    Expr::Ident(ident_factory(name))
+  }
+
+  // Helper: Create regular member expression
+  fn make_member_expr(obj: Expr, prop: &str) -> Expr {
+    Expr::Member(MemberExpr {
+      span: DUMMY_SP,
+      obj: Box::new(obj),
+      prop: MemberProp::Ident(IdentName::new(prop.into(), DUMMY_SP)),
+    })
+  }
+
+  // Helper: Create optional member expression
+  fn make_optional_member_expr(obj: Expr, prop: &str) -> Expr {
+    Expr::OptChain(OptChainExpr {
+      span: DUMMY_SP,
+      optional: true,
+      base: Box::new(OptChainBase::Member(MemberExpr {
+        span: DUMMY_SP,
+        obj: Box::new(obj),
+        prop: MemberProp::Ident(IdentName::new(prop.into(), DUMMY_SP)),
+      })),
+    })
+  }
+
+  // Helper: Create unary expression (e.g., -5, !true, +x)
+  fn make_unary_expr(op: UnaryOp, arg: Expr) -> Expr {
+    Expr::Unary(UnaryExpr {
+      span: DUMMY_SP,
+      op,
+      arg: Box::new(arg),
+    })
+  }
+
+  // Helper: Create binary expression (e.g., 5 + 3, x && y)
+  fn make_binary_expr(left: Expr, op: BinaryOp, right: Expr) -> Expr {
+    Expr::Bin(BinExpr {
+      span: DUMMY_SP,
+      left: Box::new(left),
+      op,
+      right: Box::new(right),
+    })
+  }
+
+  // Helper: Create await expression
+  fn make_await_expr(arg: Expr) -> Expr {
+    Expr::Await(AwaitExpr {
+      span: DUMMY_SP,
+      arg: Box::new(arg),
+    })
+  }
+
+  fn evaluate_expr(expr: &Expr) -> (bool, bool) {
+    let mut state_manager = StateManager::new(StyleXOptions::default());
+    let fns = FunctionMap::default();
+    let result = evaluate(expr, &mut state_manager, &fns);
+    (result.confident, result.value.is_some())
+  }
+
+  // ==================== OPTIONAL CHAINING TESTS ====================
+
+  #[test]
+  fn test_optional_chaining_with_null_returns_none() {
+    let opt_chain = make_optional_member_expr(null_to_expression(), "prop");
+    let (_confident, has_value) = evaluate_expr(&opt_chain);
+    assert!(!has_value, "Optional chaining with null should return None");
+  }
+
+  #[test]
+  fn test_optional_chaining_with_undefined_returns_none() {
+    let opt_chain = make_optional_member_expr(make_undefined_expr(), "prop");
+    let (_confident, has_value) = evaluate_expr(&opt_chain);
+    assert!(
+      !has_value,
+      "Optional chaining with undefined should return None"
+    );
+  }
+
+  #[test]
+  fn test_optional_chaining_with_variable_not_confident() {
+    let opt_chain = make_optional_member_expr(make_ident_expr("obj"), "prop");
+    let (confident, _has_value) = evaluate_expr(&opt_chain);
+    assert!(
+      !confident,
+      "Optional chaining with variable should not be confident"
+    );
+  }
+
+  #[test]
+  fn test_optional_chaining_null_no_panic() {
+    let opt_chain = make_optional_member_expr(null_to_expression(), "nonexistent");
+    let (_confident, has_value) = evaluate_expr(&opt_chain);
+    assert!(!has_value, "Should short-circuit without panic");
+  }
+
+  #[test]
+  fn test_optional_chaining_with_nested_member() {
+    let opt_chain = make_optional_member_expr(make_ident_expr("obj"), "nested");
+    let (confident, _has_value) = evaluate_expr(&opt_chain);
+    assert!(!confident, "Variable reference should not be confident");
+  }
+
+  #[test]
+  fn test_optional_chaining_null_short_circuit() {
+    let opt_chain = make_optional_member_expr(null_to_expression(), "complexProp");
+    let (_confident, has_value) = evaluate_expr(&opt_chain);
+    assert!(!has_value, "Should short-circuit on null");
+  }
+
+  #[test]
+  fn test_optional_chaining_multiple_levels() {
+    let chain = make_optional_member_expr(
+      make_optional_member_expr(make_optional_member_expr(make_ident_expr("obj"), "a"), "b"),
+      "c",
+    );
+    let (confident, _has_value) = evaluate_expr(&chain);
+    assert!(!confident, "Variable reference should not be confident");
+  }
+
+  #[test]
+  fn test_optional_chaining_undefined_short_circuits() {
+    let opt_chain = make_optional_member_expr(make_undefined_expr(), "prop");
+    let (_confident, has_value) = evaluate_expr(&opt_chain);
+    assert!(!has_value, "Should short-circuit on undefined");
+  }
+
+  #[test]
+  fn test_optional_chaining_computed_property() {
+    let opt_chain = Expr::OptChain(OptChainExpr {
+      span: DUMMY_SP,
+      optional: true,
+      base: Box::new(OptChainBase::Member(MemberExpr {
+        span: DUMMY_SP,
+        obj: Box::new(make_ident_expr("obj")),
+        prop: MemberProp::Computed(ComputedPropName {
+          span: DUMMY_SP,
+          expr: Box::new(string_to_expression("prop")),
+        }),
+      })),
+    });
+    let (confident, _has_value) = evaluate_expr(&opt_chain);
+    assert!(!confident, "Variable reference should not be confident");
+  }
+
+  #[test]
+  fn test_optional_vs_regular_member_access() {
+    let regular = make_member_expr(make_ident_expr("obj"), "prop");
+    let optional = make_optional_member_expr(make_ident_expr("obj"), "prop");
+
+    let (regular_confident, _) = evaluate_expr(&regular);
+    let (optional_confident, _) = evaluate_expr(&optional);
+
+    assert!(
+      !regular_confident,
+      "Regular member with variable should not be confident"
+    );
+    assert!(
+      !optional_confident,
+      "Optional member with variable should not be confident"
+    );
+  }
+
+  // ==================== AWAIT EXPRESSION TESTS ====================
+
+  #[test]
+  fn test_await_with_variable() {
+    let await_expr = make_await_expr(make_ident_expr("someVar"));
+    let (confident, _has_value) = evaluate_expr(&await_expr);
+    assert!(!confident, "Variable reference should not be confident");
+  }
+
+  #[test]
+  fn test_await_with_null() {
+    let await_expr = make_await_expr(null_to_expression());
+    let (_confident, has_value) = evaluate_expr(&await_expr);
+    assert!(has_value, "Null literal should evaluate to a value");
+  }
+
+  #[test]
+  fn test_await_with_number() {
+    let await_expr = make_await_expr(number_to_expression(42.0));
+    let (_confident, has_value) = evaluate_expr(&await_expr);
+    assert!(has_value, "Number literal should evaluate to a value");
+  }
+
+  #[test]
+  fn test_await_with_string() {
+    let await_expr = make_await_expr(string_to_expression("hello"));
+    let (_confident, has_value) = evaluate_expr(&await_expr);
+    assert!(has_value, "String literal should evaluate to a value");
+  }
+
+  #[test]
+  fn test_await_with_boolean() {
+    let await_expr = make_await_expr(bool_to_expression(true));
+    let (_confident, has_value) = evaluate_expr(&await_expr);
+    assert!(has_value, "Boolean literal should evaluate to a value");
+  }
+
+  #[test]
+  fn test_await_removes_await_keyword() {
+    // Test that await evaluates its argument (not the await keyword itself)
+    let await_expr = make_await_expr(number_to_expression(123.0));
+    let (_confident, has_value) = evaluate_expr(&await_expr);
+    // Should have a value since we evaluate the number
+    assert!(has_value, "Await should evaluate its argument");
+  }
+
+  #[test]
+  fn test_await_with_optional_chaining() {
+    // Test: await obj?.prop
+    let optional_member = make_optional_member_expr(make_ident_expr("obj"), "prop");
+    let await_expr = make_await_expr(optional_member);
+    let (confident, _has_value) = evaluate_expr(&await_expr);
+    assert!(!confident, "Variable in await should not be confident");
+  }
+
+  #[test]
+  fn test_await_with_null_optional_chaining() {
+    // Test: await null?.prop
+    let optional_member = make_optional_member_expr(null_to_expression(), "prop");
+    let await_expr = make_await_expr(optional_member);
+    let (_confident, has_value) = evaluate_expr(&await_expr);
+    assert!(!has_value, "Short-circuit should propagate through await");
+  }
+
+  // ==================== LITERAL EXPRESSION TESTS ====================
+
+  #[test]
+  fn test_null_literal_evaluation() {
+    let null_expr = null_to_expression();
+    let (confident, has_value) = evaluate_expr(&null_expr);
+    assert!(confident, "Null literal should be confident");
+    assert!(has_value, "Null literal should have a value");
+  }
+
+  #[test]
+  fn test_undefined_identifier_evaluation() {
+    let undef_expr = make_undefined_expr();
+    let (confident, has_value) = evaluate_expr(&undef_expr);
+    assert!(confident, "Undefined identifier should be confident");
+    assert!(has_value, "Undefined identifier should have a value");
+  }
+
+  #[test]
+  fn test_number_literal_evaluation() {
+    let num_expr = number_to_expression(42.0);
+    let (confident, has_value) = evaluate_expr(&num_expr);
+    assert!(confident, "Number literal should be confident");
+    assert!(has_value, "Number literal should have a value");
+  }
+
+  #[test]
+  fn test_string_literal_evaluation() {
+    let str_expr = string_to_expression("test");
+    let (confident, has_value) = evaluate_expr(&str_expr);
+    assert!(confident, "String literal should be confident");
+    assert!(has_value, "String literal should have a value");
+  }
+
+  #[test]
+  fn test_boolean_literal_evaluation() {
+    let bool_expr = bool_to_expression(true);
+    let (confident, has_value) = evaluate_expr(&bool_expr);
+    assert!(confident, "Boolean literal should be confident");
+    assert!(has_value, "Boolean literal should have a value");
+  }
+
+  #[test]
+  fn test_variable_reference_not_confident() {
+    let var_expr = make_ident_expr("myVar");
+    let (confident, _has_value) = evaluate_expr(&var_expr);
+    assert!(!confident, "Variable reference should not be confident");
+  }
+
+  // ==================== UNARY EXPRESSION TESTS ====================
+
+  #[test]
+  fn test_unary_minus_number() {
+    let unary_expr = make_unary_expr(UnaryOp::Minus, number_to_expression(5.0));
+    let (confident, has_value) = evaluate_expr(&unary_expr);
+    assert!(confident, "Unary minus on number should be confident");
+    assert!(has_value, "Unary minus should have a value");
+  }
+
+  #[test]
+  fn test_unary_plus_number() {
+    let unary_expr = make_unary_expr(UnaryOp::Plus, number_to_expression(5.0));
+    let (confident, has_value) = evaluate_expr(&unary_expr);
+    assert!(confident, "Unary plus on number should be confident");
+    assert!(has_value, "Unary plus should have a value");
+  }
+
+  #[test]
+  fn test_unary_not_boolean() {
+    let unary_expr = make_unary_expr(UnaryOp::Bang, bool_to_expression(true));
+    let (confident, has_value) = evaluate_expr(&unary_expr);
+    assert!(confident, "Unary not on boolean should be confident");
+    assert!(has_value, "Unary not should have a value");
+  }
+
+  #[test]
+  fn test_unary_minus_variable() {
+    let unary_expr = make_unary_expr(UnaryOp::Minus, make_ident_expr("x"));
+    let (confident, _has_value) = evaluate_expr(&unary_expr);
+    assert!(
+      !confident,
+      "Unary minus on variable should not be confident"
+    );
+  }
+
+  // ==================== BINARY EXPRESSION TESTS ====================
+
+  #[test]
+  fn test_binary_addition_numbers() {
+    let bin_expr = make_binary_expr(
+      number_to_expression(5.0),
+      BinaryOp::Add,
+      number_to_expression(3.0),
+    );
+    let (confident, has_value) = evaluate_expr(&bin_expr);
+    assert!(confident, "Binary addition of numbers should be confident");
+    assert!(has_value, "Binary addition should have a value");
+  }
+
+  #[test]
+  fn test_binary_subtraction_numbers() {
+    let bin_expr = make_binary_expr(
+      number_to_expression(5.0),
+      BinaryOp::Sub,
+      number_to_expression(3.0),
+    );
+    let (confident, has_value) = evaluate_expr(&bin_expr);
+    assert!(
+      confident,
+      "Binary subtraction of numbers should be confident"
+    );
+    assert!(has_value, "Binary subtraction should have a value");
+  }
+
+  #[test]
+  fn test_binary_multiplication_numbers() {
+    let bin_expr = make_binary_expr(
+      number_to_expression(5.0),
+      BinaryOp::Mul,
+      number_to_expression(3.0),
+    );
+    let (confident, has_value) = evaluate_expr(&bin_expr);
+    assert!(
+      confident,
+      "Binary multiplication of numbers should be confident"
+    );
+    assert!(has_value, "Binary multiplication should have a value");
+  }
+
+  #[test]
+  fn test_binary_with_variable() {
+    let bin_expr = make_binary_expr(
+      make_ident_expr("x"),
+      BinaryOp::Add,
+      number_to_expression(5.0),
+    );
+    let (confident, _has_value) = evaluate_expr(&bin_expr);
+    assert!(
+      !confident,
+      "Binary expression with variable should not be confident"
+    );
+  }
+
+  #[test]
+  fn test_binary_logical_and() {
+    let bin_expr = make_binary_expr(
+      bool_to_expression(true),
+      BinaryOp::LogicalAnd,
+      bool_to_expression(false),
+    );
+    let (_confident, has_value) = evaluate_expr(&bin_expr);
+    assert!(
+      has_value || !_confident,
+      "Logical AND should either have value or not be confident"
+    );
+  }
+
+  #[test]
+  fn test_binary_logical_or() {
+    let bin_expr = make_binary_expr(
+      bool_to_expression(true),
+      BinaryOp::LogicalOr,
+      bool_to_expression(false),
+    );
+    let (_confident, has_value) = evaluate_expr(&bin_expr);
+    assert!(
+      has_value || !_confident,
+      "Logical OR should either have value or not be confident"
+    );
+  }
+
+  // ==================== MEMBER EXPRESSION TESTS ====================
+
+  #[test]
+  fn test_member_access_with_variable() {
+    let member_expr = make_member_expr(make_ident_expr("obj"), "prop");
+    let (confident, _has_value) = evaluate_expr(&member_expr);
+    assert!(
+      !confident,
+      "Member access on variable should not be confident"
+    );
+  }
+
+  #[test]
+  fn test_member_access_nested() {
+    let nested = make_member_expr(make_member_expr(make_ident_expr("obj"), "a"), "b");
+    let (confident, _has_value) = evaluate_expr(&nested);
+    assert!(
+      !confident,
+      "Nested member access on variable should not be confident"
+    );
+  }
+
+  // ==================== COMPOSITE TESTS ====================
+
+  #[test]
+  fn test_nested_optional_chaining() {
+    let nested = make_optional_member_expr(
+      make_optional_member_expr(make_ident_expr("obj"), "prop1"),
+      "prop2",
+    );
+    let (confident, _has_value) = evaluate_expr(&nested);
+    assert!(
+      !confident,
+      "Nested optional chains should not be confident with variables"
+    );
+  }
+
+  #[test]
+  fn test_await_then_optional_chain() {
+    let optional = make_optional_member_expr(null_to_expression(), "prop");
+    let await_expr = make_await_expr(optional);
+    let (_confident, has_value) = evaluate_expr(&await_expr);
+    assert!(
+      !has_value,
+      "Optional chain short-circuit should propagate through await"
+    );
+  }
+
+  #[test]
+  fn test_unary_on_optional_chain() {
+    let optional = make_optional_member_expr(make_ident_expr("obj"), "prop");
+    let unary = make_unary_expr(UnaryOp::Bang, optional);
+    let (confident, _has_value) = evaluate_expr(&unary);
+    assert!(
+      !confident,
+      "Unary on optional chain should not be confident with variable"
+    );
+  }
+
+  #[test]
+  fn test_binary_on_optional_chains() {
+    let opt1 = make_optional_member_expr(make_ident_expr("a"), "x");
+    let opt2 = make_optional_member_expr(make_ident_expr("b"), "y");
+    let binary = make_binary_expr(opt1, BinaryOp::Add, opt2);
+    let (confident, _has_value) = evaluate_expr(&binary);
+    assert!(
+      !confident,
+      "Binary on optional chains should not be confident with variables"
+    );
+  }
+
+  #[test]
+  fn test_multiple_levels_of_optional_chaining_with_null_at_end() {
+    let null_at_end = make_optional_member_expr(null_to_expression(), "prop");
+    let (_confident, has_value) = evaluate_expr(&null_at_end);
+    assert!(!has_value, "Should handle null at any level");
+  }
+
+  #[test]
+  fn test_await_with_multiple_chained_operations() {
+    // await (await someVar)
+    let inner_await = make_await_expr(make_ident_expr("someVar"));
+    let outer_await = make_await_expr(inner_await);
+    let (confident, _has_value) = evaluate_expr(&outer_await);
+    assert!(
+      !confident,
+      "Nested awaits with variables should not be confident"
+    );
+  }
+
+  #[test]
+  fn test_complex_expression_await_optional_unary() {
+    // Complex: await !(obj?.prop)
+    let optional = make_optional_member_expr(make_ident_expr("obj"), "prop");
+    let unary = make_unary_expr(UnaryOp::Bang, optional);
+    let await_expr = make_await_expr(unary);
+    let (confident, _has_value) = evaluate_expr(&await_expr);
+    assert!(
+      !confident,
+      "Complex expression should not be confident with variables"
+    );
+  }
+
+  #[test]
+  fn test_null_coalescing_like_pattern() {
+    // Pattern: null?.prop (similar to nullish coalescing behavior)
+    let optional = make_optional_member_expr(null_to_expression(), "prop");
+    let (_confident, has_value) = evaluate_expr(&optional);
+    assert!(!has_value, "Null coalescing pattern should short-circuit");
+  }
+
+  // ==================== LITERAL MEMBER ACCESS TESTS ====================
+
+  #[test]
+  fn test_null_literal_member_access() {
+    // When accessing a member on a literal, the literal itself is evaluated
+    let member_expr = make_member_expr(null_to_expression(), "prop");
+    let (_confident, has_value) = evaluate_expr(&member_expr);
+    // The literal is evaluable, so has_value should be true (the literal value)
+    assert!(
+      has_value,
+      "Member access on null literal should return the literal value"
+    );
+  }
+
+  #[test]
+  fn test_number_literal_member_access() {
+    // When accessing a member on a number literal, the number itself is returned
+    let member_expr = make_member_expr(number_to_expression(42.0), "prop");
+    let (_confident, has_value) = evaluate_expr(&member_expr);
+    // The literal is evaluable
+    assert!(
+      has_value,
+      "Member access on number literal should return the literal value"
+    );
+  }
+
+  #[test]
+  fn test_boolean_literal_member_access() {
+    // When accessing a member on a boolean literal, the boolean itself is returned
+    let member_expr = make_member_expr(bool_to_expression(true), "prop");
+    let (_confident, has_value) = evaluate_expr(&member_expr);
+    // The literal is evaluable
+    assert!(
+      has_value,
+      "Member access on boolean literal should return the literal value"
+    );
+  }
+
+  #[test]
+  fn test_string_literal_member_access() {
+    // When accessing a member on a string literal, the string itself is returned
+    let member_expr = make_member_expr(string_to_expression("test"), "prop");
+    let (_confident, has_value) = evaluate_expr(&member_expr);
+    // The literal is evaluable
+    assert!(
+      has_value,
+      "Member access on string literal should return the literal value"
+    );
+  }
+
+  #[test]
+  fn test_literal_with_optional_chaining() {
+    // Optional chaining on a literal number: the number literal is returned
+    let opt_chain = make_optional_member_expr(number_to_expression(5.0), "prop");
+    let (_confident, has_value) = evaluate_expr(&opt_chain);
+    // The number is a literal so it can be evaluated
+    assert!(
+      has_value,
+      "Optional member access on number literal should return the literal value"
+    );
+  }
+}

--- a/crates/stylex-shared/src/shared/utils/js/tests/mod.rs
+++ b/crates/stylex-shared/src/shared/utils/js/tests/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod evaluate_tests;

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/transform_style_extend_with_optional_chaining.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/transform_style_extend_with_optional_chaining.js
@@ -1,0 +1,20 @@
+import * as sx from '@stylexjs/stylex';
+import * as React from 'react';
+const c = {
+    base: {
+        k1xSpc: "xrvj5dj",
+        $$css: true
+    }
+};
+export default function CommentField({ type }) {
+    const result = useHook();
+    const nullable = null;
+    const undef = undefined;
+    return <div {...sx.props(nullable?.test && c.base, undef?.test && c.base, (()=>{
+        const implementation = {
+            foo: ()=>null,
+            bar: ()=>c.base
+        };
+        return implementation[result?.value !== 'test' ? "foo" : result?.test] || implementation.foo;
+    })()())}/>;
+}

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/transform_style_extend_with_promise.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/transform_style_extend_with_promise.js
@@ -1,0 +1,12 @@
+import * as sx from '@stylexjs/stylex';
+import * as React from 'react';
+export default async function CommentField({ type }) {
+    const resultPromise = promise();
+    const result = await resultPromise;
+    return <div {...{
+        0: {},
+        1: {
+            className: "xrvj5dj"
+        }
+    }[!!result << 0]}/>;
+}

--- a/crates/stylex-shared/tests/transform_misc_test/react.rs
+++ b/crates/stylex-shared/tests/transform_misc_test/react.rs
@@ -166,3 +166,90 @@ test!(
     }
 "#
 );
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| StyleXTransform::new_test_with_pass(
+    tr.comments.clone(),
+    PluginPass::default(),
+    Some(&mut StyleXOptionsParams {
+      enable_inlined_conditional_merge: Some(true),
+      style_resolution: Some(StyleResolution::ApplicationOrder),
+      ..StyleXOptionsParams::default()
+    })
+  ),
+  transform_style_extend_with_optional_chaining,
+  r#"
+    import * as sx from '@stylexjs/stylex';
+    import * as React from 'react';
+
+
+    const c = sx.create({
+      base: {
+        display: 'grid',
+      },
+    });
+
+
+    export default function CommentField({ type }) {
+      const result = useHook();
+      const nullable = null;
+      const undef = undefined;
+
+      return (
+        <div {...sx.props(
+        nullable?.test && c.base,
+        undef?.test && c.base,
+        (()=>{
+                    const implementation = {
+                        foo: ()=>null,
+                        bar: ()=>c.base
+                    };
+                    return implementation[result?.value !== 'test' ? "foo" : result?.test] || implementation.foo;
+                })()())} />
+      );
+    }
+"#
+);
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| StyleXTransform::new_test_with_pass(
+    tr.comments.clone(),
+    PluginPass::default(),
+    Some(&mut StyleXOptionsParams {
+      enable_inlined_conditional_merge: Some(true),
+      style_resolution: Some(StyleResolution::ApplicationOrder),
+      ..StyleXOptionsParams::default()
+    })
+  ),
+  transform_style_extend_with_promise,
+  r#"
+    import * as sx from '@stylexjs/stylex';
+    import * as React from 'react';
+
+
+    const c = sx.create({
+      base: {
+        display: 'grid',
+      },
+    });
+
+
+    export default async function CommentField({ type }) {
+      const resultPromise = promise();
+
+      const result = await resultPromise;
+
+      return (
+        <div {...sx.props(result && c.base)} />
+      );
+    }
+"#
+);


### PR DESCRIPTION
## Description

This pull request introduces support for evaluating optional chaining expressions and improves handling of promise-based expressions in the StyleX JS evaluation logic. It also adds new tests to ensure correct behavior for these cases.

### Expression Evaluation Enhancements

* Added support for `Expr::OptChain` (optional chaining) in the JS evaluator. The evaluation now correctly short-circuits when the base is `null`, `undefined`, or fails to evaluate, and otherwise continues evaluating the chain.
* Improved handling for nested expressions (`Expr::Member`, `Expr::Lit`, `Expr::Ident`) by recursively calling `evaluate_cached`, ensuring more robust evaluation of complex JS ASTs.
* Updated imports to include `OptChainBase` for optional chaining support in the evaluator.

### Testing Improvements

* Added new test modules for JS evaluation logic, including tests for optional chaining and promise-based expressions. [[1]](diffhunk://#diff-c78a8088c5b091b46f8c9e64d88c8ce2fc9aca73f5f362fa2c4b7a05f67a11b0R4) [[2]](diffhunk://#diff-fed782703898d0155b6ec62fdf2c4e4867f23466ac1a35e0eddaa72b175e7e10R1)
* Added snapshot test files and test cases for React components using optional chaining and async/await patterns, verifying correct transformation and evaluation. [[1]](diffhunk://#diff-93af0064d7c647a221c9f90c9f6b6a005b0697018a7a316d3168ecd82007b5b1R1-R20) [[2]](diffhunk://#diff-7e4ca18be6e08e400810531e61a83a88040ba92cfebca56bb388c3c2996d4e07R1-R12) [[3]](diffhunk://#diff-16ed618c270cc1533d84bb1d97f1ccf7bf12797956f5482cb1c14291784ef5ffR169-R255)

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
