### PR TITLE
feat(stylexswc/webpack-plugin): export loader

### DIFF
--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -247,4 +247,6 @@ export type { StyleXPluginOption } from './types';
 
 module.exports = StyleXPlugin;
 module.exports.default = StyleXPlugin;
+module.exports.loader = stylexLoaderPath;
+module.exports.virtualLoader = stylexVirtualLoaderPath;
 module.exports.VIRTUAL_CSS_PATTERN = VIRTUAL_CSS_PATTERN;


### PR DESCRIPTION
## Description

This pull request adds two new exports to the `packages/webpack-plugin/src/index.ts` file, making the `stylexLoaderPath` and `stylexVirtualLoaderPath` available as properties on the module. This allows consumers of the plugin to access these loader paths directly, improving flexibility when integrating with Webpack.

Exports enhancement:

* Exposed `stylexLoaderPath` as `loader` and `stylexVirtualLoaderPath` as `stylexVirtualLoader` on the module exports in `index.ts`.


## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
