### PR TITLE
fix(stylex_shared): allow evaluate theme ref as object value

### DIFF
--- a/crates/stylex-shared/src/shared/utils/core/evaluate_stylex_create_arg.rs
+++ b/crates/stylex-shared/src/shared/utils/core/evaluate_stylex_create_arg.rs
@@ -133,7 +133,16 @@ pub fn evaluate_stylex_create_arg(
                         }
                       }
                       _ => {
-                        unimplemented!("Block statement")
+                        return Box::new(EvaluateResult {
+                          confident: false,
+                          deopt: None,
+                          reason: Some(
+                            "Block statement is not allowed in Dynamic Style functions".to_string(),
+                          ),
+                          value: None,
+                          inline_styles: None,
+                          fns: None,
+                        });
                       }
                     }
                   }

--- a/crates/stylex-shared/src/shared/utils/js/evaluate.rs
+++ b/crates/stylex-shared/src/shared/utils/js/evaluate.rs
@@ -485,7 +485,7 @@ fn _evaluate(
                   EvaluateResultValue::ThemeRef(theme) => {
                     // NOTE: it's a very edge case, but it's possible to have a theme ref as a key
                     // in an object, when theme import key is same as other variable name.
-                    // One of reasons is code minification or obfuscation,
+                    // One of the reasons is code minification or obfuscation,
                     // when theme import key is renamed to a shorter name.
                     // Also it may be a result of a bug in the code.
 
@@ -903,6 +903,7 @@ fn _evaluate(
                     Expr::Arrow(arrow_func_expr) => Some(Expr::Arrow(arrow_func_expr.clone())),
                     _ => panic_with_context!(path, traversal_state, "Callback type not supported"),
                   },
+                  EvaluateResultValue::ThemeRef(_) => None,
                   _ => panic_with_context!(
                     path,
                     traversal_state,

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/transform_style_extend_with_theme_record.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/transform_style_extend_with_theme_record.js
@@ -1,0 +1,11 @@
+import { BUTTON_PRIMARY, BUTTON_SECONDARY } from 'styles/themes/button.stylex';
+import * as stylex from '@stylexjs/stylex';
+const buttonTheme = {
+    primary: BUTTON_PRIMARY,
+    secondary: BUTTON_SECONDARY
+};
+export function Button_Record_From_Import() {
+    return <button {...stylex.props(buttonTheme[state.theme])}>
+        Click Me!
+      </button>;
+}

--- a/crates/stylex-shared/tests/transform_misc_test/react.rs
+++ b/crates/stylex-shared/tests/transform_misc_test/react.rs
@@ -253,3 +253,40 @@ test!(
     }
 "#
 );
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| StyleXTransform::new_test_with_pass(
+    tr.comments.clone(),
+    PluginPass::default(),
+    Some(&mut StyleXOptionsParams {
+      enable_inlined_conditional_merge: Some(true),
+      style_resolution: Some(StyleResolution::ApplicationOrder),
+      ..StyleXOptionsParams::default()
+    })
+  ),
+  transform_style_extend_with_theme_record,
+  r#"
+    import { BUTTON_PRIMARY, BUTTON_SECONDARY } from 'styles/themes/button.stylex';
+    import * as stylex from '@stylexjs/stylex';
+
+    const buttonTheme = {
+      primary: BUTTON_PRIMARY,
+      secondary: BUTTON_SECONDARY
+    };
+
+    export function Button_Record_From_Import ()  {
+
+      return <button
+        {...stylex.props(
+          buttonTheme[state.theme],
+        )}
+      >
+        Click Me!
+      </button>
+    };
+"#
+);

--- a/crates/stylex-shared/tests/validation_stylex_create_test/style_rules.rs
+++ b/crates/stylex-shared/tests/validation_stylex_create_test/style_rules.rs
@@ -248,3 +248,34 @@ test!(
           });
         "#
 );
+
+#[test]
+#[should_panic(expected = "Block statement is not allowed in Dynamic Style functions")]
+fn invalid_dynamic_rule_with_block_body() {
+  test_transform(
+    Syntax::Typescript(TsSyntax {
+      tsx: true,
+      ..Default::default()
+    }),
+    Option::None,
+    |tr| {
+      StyleXTransform::new_test_force_runtime_injection_with_pass(
+        tr.comments.clone(),
+        PluginPass::default(),
+        None,
+      )
+    },
+    r#"
+          import * as stylex from '@stylexjs/stylex';
+
+          export const styles = stylex.create({
+            button: () => {
+              return {
+                  justifyContent: 'center',
+              };
+            },
+          });
+        "#,
+    r#""#,
+  )
+}


### PR DESCRIPTION
## Description

This pull request introduces improvements to the handling of dynamic style functions and theme references in StyleX, as well as adds new tests for validation and transformation scenarios. The most important changes include stricter error handling for block statements in dynamic style functions, adjustments in the evaluation logic for theme references, and expanded test coverage for both valid and invalid cases.

### Error handling and validation improvements
* Block statements in dynamic style functions now return a non-confident `EvaluateResult` with a clear error message, instead of using `unimplemented!`, providing better diagnostics and preventing panics.
* A new test (`invalid_dynamic_rule_with_block_body`) ensures that using a block statement in a dynamic style function triggers the expected error, improving validation coverage.

### Theme reference evaluation logic
* The evaluator now explicitly returns `None` for theme references in certain callback scenarios, preventing unsupported callback types from causing runtime errors.
* Minor wording correction in a comment clarifies the reasoning behind theme reference edge cases.

### Test coverage expansion
* Added a new test and snapshot for transforming style extensions with theme records, verifying proper handling of theme imports and dynamic theme selection in React components. [[1]](diffhunk://#diff-16ed618c270cc1533d84bb1d97f1ccf7bf12797956f5482cb1c14291784ef5ffR256-R292) [[2]](diffhunk://#diff-cafdb577021d5d95bf1dc7e5a6e83d4707d762f7b3fad3448828c490db502b9aR1-R11)

## Fixes

Fixes #605 

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
