### PR TITLE
fix(typescript): strip TS annotations before StyleX transformations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,6 +2322,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,6 +2698,7 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_testing",
+ "swc_ecma_transforms_typescript",
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_plugin",
@@ -2972,6 +2984,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_transforms_react"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad0d635cd9bd795e600190b80c51e6eb60d99300691d4389115d3c143357f77"
+dependencies = [
+ "base64",
+ "bytes-str",
+ "indexmap",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "sha1",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+ "swc_config",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+]
+
+[[package]]
 name = "swc_ecma_transforms_testing"
 version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,6 +3031,24 @@ dependencies = [
  "swc_sourcemap",
  "tempfile",
  "testing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_typescript"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714f792aca48d58906f17cf613c75d7dfa4bb12f367a1e04e07b59a8d1b36690"
+dependencies = [
+ "bytes-str",
+ "rustc-hash",
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_react",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]

--- a/crates/stylex-shared/Cargo.toml
+++ b/crates/stylex-shared/Cargo.toml
@@ -24,6 +24,7 @@ swc_core = { workspace = true, features = [
   "css_visit",
   "css_parser",
   "css_ast",
+  "ecma_transforms_typescript",
 ] }
 
 swc_config.workspace = true
@@ -60,7 +61,7 @@ stylex_css_parser = { path = "../stylex-css-parser" }
 swc_core = { workspace = true, features = [
   "testing_transform",
   "ecma_parser",
-  'ecma_utils',
+  "ecma_utils",
 ] }
 testing.workspace = true
 insta = { workspace = true, features = ["yaml"] }

--- a/crates/stylex-shared/src/transform/mod.rs
+++ b/crates/stylex-shared/src/transform/mod.rs
@@ -4,7 +4,7 @@ use swc_core::{
   common::{Mark, comments::Comments},
   ecma::{
     ast::{CallExpr, Callee, Expr, Id, MemberProp, Pass, VarDeclarator},
-    transforms::base::resolver,
+    transforms::{base::resolver, typescript::strip},
     utils::drop_span,
     visit::fold_pass,
   },
@@ -103,8 +103,12 @@ where
     plugin_pass: PluginPass,
     config: Option<&mut StyleXOptionsParams>,
   ) -> impl Pass + use<C> {
+    let unresolved_mark = Mark::new();
+    let top_level_mark = Mark::new();
+
     (
-      resolve_factory(),
+      resolve_factory(unresolved_mark, top_level_mark),
+      // typescript_factory(unresolved_mark, top_level_mark),
       fold_pass(Self::new_test_force_runtime_injection(
         comments,
         plugin_pass,
@@ -152,8 +156,12 @@ where
     plugin_pass: PluginPass,
     config: Option<&mut StyleXOptionsParams>,
   ) -> impl Pass + use<C> {
+    let unresolved_mark = Mark::new();
+    let top_level_mark = Mark::new();
+
     (
-      resolve_factory(),
+      resolve_factory(unresolved_mark, top_level_mark),
+      // typescript_factory(unresolved_mark, top_level_mark),
       fold_pass(Self::new_test(comments, plugin_pass, config)),
     )
   }
@@ -264,9 +272,11 @@ fn fill_stylex_imports(config: &Option<&mut StyleXOptionsParams>) -> FxHashSet<I
 }
 
 #[warn(clippy::extra_unused_type_parameters)]
-fn resolve_factory() -> impl Pass {
-  let unresolved_mark = Mark::new();
-  let top_level_mark = Mark::new();
-
+fn resolve_factory(unresolved_mark: Mark, top_level_mark: Mark) -> impl Pass {
   resolver(unresolved_mark, top_level_mark, true)
+}
+
+#[warn(clippy::extra_unused_type_parameters)]
+fn _typescript_factory(unresolved_mark: Mark, top_level_mark: Mark) -> impl Pass {
+  strip(unresolved_mark, top_level_mark)
 }


### PR DESCRIPTION
## Description

This pull request enhances the `stylex-rs-compiler` and shared transformation logic to properly handle TypeScript code by integrating SWC's TypeScript resolver and stripper passes. It ensures that TypeScript-specific syntax is stripped and scope resolution is performed before running the StyleX transformation, improving compatibility and correctness when processing TypeScript/TSX files.

**TypeScript support and transformation improvements:**

* In `stylex-rs-compiler`, the main `transform` function now wraps transformation passes in a `GLOBALS` context and applies SWC's `resolver`, `typescript_strip`, and `hygiene` passes before running the StyleX transform and fixer. This ensures proper handling of TypeScript features and variable scoping. [[1]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32L27-R34) [[2]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R130-R143) [[3]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R167)
* In `stylex-shared`, the transformation pipeline is updated to accept and pass along `unresolved_mark` and `top_level_mark` for the resolver and (optionally) TypeScript stripper. The `resolve_factory` function now receives these marks as arguments, and a `typescript_factory` function is added for future use. [[1]](diffhunk://#diff-7904f12679a679f720e0c3e437e1502c0bf43ceb852ffe6e08f20aeafa7d8070L7-R10) [[2]](diffhunk://#diff-7904f12679a679f720e0c3e437e1502c0bf43ceb852ffe6e08f20aeafa7d8070R109-R114) [[3]](diffhunk://#diff-7904f12679a679f720e0c3e437e1502c0bf43ceb852ffe6e08f20aeafa7d8070R162-R167) [[4]](diffhunk://#diff-7904f12679a679f720e0c3e437e1502c0bf43ceb852ffe6e08f20aeafa7d8070L267-R285)

**Dependency updates:**

* The `Cargo.toml` files for both `stylex-shared` and `stylex-rs-compiler` now enable the `ecma_transforms_typescript` feature for `swc_core`, ensuring the necessary SWC passes for TypeScript are available. [[1]](diffhunk://#diff-2742514c0ea61a1b2472ac4e8f740931f20b9de0273a6d7d6815d203b92a8414R27) [[2]](diffhunk://#diff-2742514c0ea61a1b2472ac4e8f740931f20b9de0273a6d7d6815d203b92a8414L63-R65)
## Fixes

(Optional) Fixes #664 

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
