### PR TITLE
fix(path-resolver): update resolve_file_path to handle absolute import paths correctly

### DIFF
--- a/crates/stylex-path-resolver/src/resolvers/mod.rs
+++ b/crates/stylex-path-resolver/src/resolvers/mod.rs
@@ -411,15 +411,15 @@ pub fn resolve_file_path(
         })
         .collect()
     }
-  } else if import_path_str.starts_with('/') {
-    vec![root_path.join(import_path_str)]
   } else {
     let mut possible_file_paths = possible_aliased_paths(import_path_str, aliases)
       .iter()
       .map(PathBuf::from)
       .collect::<IndexSet<PathBuf>>();
 
-    if !import_path_str.is_empty() {
+    if import_path_str.starts_with('/') {
+      possible_file_paths.insert(root_path.join(import_path_str.trim_start_matches('/')));
+    } else if !import_path_str.is_empty() {
       possible_file_paths.insert(Path::new("node_modules").join(import_path_str));
 
       let closest_node_modules_paths = recursive_find_node_modules(source_file_dir, None);

--- a/crates/stylex-path-resolver/src/resolvers/tests.rs
+++ b/crates/stylex-path-resolver/src/resolvers/tests.rs
@@ -986,6 +986,94 @@ mod resolve_path_application_pnpm_tests {
   }
 
   #[test]
+  fn resolve_regular_local_import_from_root_no_alias() {
+    let test_path = PathBuf::from("application-pnpm");
+
+    let import_path_str = "/src/colors.stylex.js";
+    let source_file_path = format!(
+      "{}/src/pages/home.js",
+      get_root_dir(&test_path).as_path().display()
+    );
+    let root_path = get_root_dir(&test_path).display().to_string();
+    let aliases = Default::default();
+    let expected_result = format!("{root_path}/src/colors.stylex.js");
+
+    assert_eq!(
+      resolve_file_path(
+        import_path_str,
+        source_file_path.as_str(),
+        root_path.as_str(),
+        &aliases,
+        &mut HashMap::default(),
+      )
+      .unwrap_or_default()
+      .display()
+      .to_string(),
+      expected_result
+    );
+  }
+
+  #[test]
+  fn resolve_regular_local_import_from_root_with_alias() {
+    let test_path = PathBuf::from("application-pnpm");
+
+    let import_path_str = "/src/colors.stylex.js";
+    let source_file_path = format!(
+      "{}/src/pages/home.js",
+      get_root_dir(&test_path).as_path().display()
+    );
+    let root_path = get_root_dir(&test_path).display().to_string();
+    let mut aliases = FxHashMap::default();
+    aliases.insert("/*".to_string(), vec![format!("{root_path}/*")]);
+
+    let expected_result = format!("{root_path}/src/colors.stylex.js");
+
+    assert_eq!(
+      resolve_file_path(
+        import_path_str,
+        source_file_path.as_str(),
+        root_path.as_str(),
+        &aliases,
+        &mut HashMap::default(),
+      )
+      .unwrap_or_default()
+      .display()
+      .to_string(),
+      expected_result
+    );
+  }
+
+  #[test]
+  fn resolve_regular_local_import_from_src_alias() {
+    let test_path = PathBuf::from("application-pnpm");
+
+    let import_path_str = "/colors.stylex.js";
+    let source_file_path = format!(
+      "{}/src/pages/home.js",
+      get_root_dir(&test_path).as_path().display()
+    );
+    let root_path = get_root_dir(&test_path).display().to_string();
+    let mut aliases = FxHashMap::default();
+    aliases.insert("/*".to_string(), vec![format!("{root_path}/src/*")]);
+
+    let expected_result = format!("{root_path}/src/colors.stylex.js");
+
+    assert_eq!(
+      resolve_file_path(
+        import_path_str,
+        source_file_path.as_str(),
+        root_path.as_str(),
+        &aliases,
+        &mut HashMap::default(),
+      )
+      .unwrap_or_default()
+      .display()
+      .to_string(),
+      expected_result
+    );
+  }
+
+  #[test]
   fn resolve_regular_local_import_from_workspace_alias() {
     let test_path = PathBuf::from("workspace-pnpm");
 


### PR DESCRIPTION
## Description

This PR addresses the following issues related to path handling:

**1. Fixed incorrect path concatenation for absolute-like import paths.**

- According to the Rust standard library documentation for [Path::join](https://doc.rust-lang.org/std/path/struct.Path.html#method.join) (If path is absolute, it replaces the current path.), calling `root_path.join(import_path_str)` will **replace** the entire path if `import_path_str` starts with `/`.
- The fix ensures that when an `import_path_str` begins with `/`, the prefix is **removed** before joining, allowing it to be correctly resolved relative to the `root_path`.

**2. Fixed resolution for user-configured root directory aliases.**

- Previously, when users configured an alias like `/` to point to a specific directory (e.g., `/src/`), the resolution logic did not handle this mapping correctly.
- The changes ensure that such root aliases are now properly resolved according to the user's configuration.

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
