### PR TITLE
fix(stylex_rs_compiler): allow to change useRealFileForSource to false

### DIFF
--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -324,7 +324,7 @@ pub fn normalize_rs_options(options: StyleXOptions) -> Result<StyleXOptions> {
       .or(Some("property-specificity".to_string())),
     legacy_disable_layers: options.legacy_disable_layers.or(Some(false)),
     swc_plugins: options.swc_plugins.or(Some(vec![])),
-    use_real_file_for_source: Some(true),
+    use_real_file_for_source: options.use_real_file_for_source.or(Some(true)),
     enable_media_query_order: options.enable_media_query_order.or(Some(true)),
     enable_debug_class_names: options.enable_debug_class_names.or(Some(false)),
     ..options

--- a/crates/stylex-shared/src/shared/structures/stylex_state_options.rs
+++ b/crates/stylex-shared/src/shared/structures/stylex_state_options.rs
@@ -107,7 +107,7 @@ impl From<StyleXOptions> for StyleXStateOptions {
       enable_logical_styles_polyfill: options.enable_logical_styles_polyfill,
       enable_legacy_value_flipping: options.enable_legacy_value_flipping,
       enable_minified_keys: options.enable_minified_keys,
-      use_real_file_for_source: true,
+      use_real_file_for_source: options.use_real_file_for_source,
       treeshake_compensation: options.treeshake_compensation,
       inject_stylex_side_effects: options.inject_stylex_side_effects,
       aliases: options.aliases,


### PR DESCRIPTION
## Description

This pull request updates how the `use_real_file_for_source` option is handled in the StyleX compiler and shared structures. Instead of always defaulting this option to `true`, the code now respects the value provided in the incoming options, allowing for more flexible configuration.

**Options handling improvements:**

* In `normalize_rs_options`, the `use_real_file_for_source` field now uses the value from `options` if provided, defaulting to `true` only if not set.
* In the conversion from `StyleXOptions` to `StyleXStateOptions`, the `use_real_file_for_source` field now takes its value from the provided options, instead of always being set to `true`.

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
