### PR TITLE
fix(packagejsonextended): remove unused extends field

### DIFF
--- a/crates/stylex-path-resolver/src/enums/mod.rs
+++ b/crates/stylex-path-resolver/src/enums/mod.rs
@@ -1,9 +1,0 @@
-use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum ExportsType {
-  Simple(String),
-  Complex(FxHashMap<String, String>),
-}

--- a/crates/stylex-path-resolver/src/lib.rs
+++ b/crates/stylex-path-resolver/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod enums;
 mod file_system;
 pub mod package_json;
 pub mod resolvers;

--- a/crates/stylex-path-resolver/src/package_json/mod.rs
+++ b/crates/stylex-path-resolver/src/package_json/mod.rs
@@ -7,7 +7,7 @@ use std::{default::Default, fs::read_to_string};
 use package_json::{PackageDependencies, PackageJsonManager};
 use std::path::{Path, PathBuf};
 
-use crate::{enums::ExportsType, file_system::find_closest_path};
+use crate::file_system::find_closest_path;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -18,8 +18,6 @@ pub struct PackageJsonExtended {
   pub main: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub module: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub exports: Option<FxHashMap<String, ExportsType>>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub dependencies: Option<PackageDependencies>,
   #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Description

This pull request removes the unused `ExportsType` enum and related code from the `stylex-path-resolver` crate, simplifying the codebase and cleaning up imports and struct definitions.

Code cleanup and simplification:

* Removed the `ExportsType` enum and its dependencies from `enums/mod.rs` as it is no longer used anywhere in the codebase.
* Removed the `enums` module from `lib.rs` since it is now empty and unused.
* Updated imports in `package_json/mod.rs` to remove references to the deleted `ExportsType` and the `enums` module.
* Removed the `exports` field from the `PackageJsonExtended` struct, as it depended on the now-removed `ExportsType`.

## Fixes

(Optional) Fixes #759 

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
