### PR TITLE
fix(stylex_compiler_rs): fix build on arch64-unknown-linux-gnu

### DIFF
--- a/crates/stylex-rs-compiler/src/utils/fn_parser.rs
+++ b/crates/stylex-rs-compiler/src/utils/fn_parser.rs
@@ -150,7 +150,7 @@ fn parse_env_function(env: &napi::Env, js_fn_raw: napi::sys::napi_value) -> napi
         napi::sys::napi_get_value_string_utf8(
           raw_env,
           str_result,
-          buf.as_mut_ptr() as *mut i8,
+          buf.as_mut_ptr() as *mut _,
           len + 1,
           &mut written,
         );
@@ -170,7 +170,7 @@ fn env_value_to_napi_value(
     EnvValue::String(s) => unsafe {
       napi::sys::napi_create_string_utf8(
         raw_env,
-        s.as_ptr() as *const i8,
+        s.as_ptr() as *const _,
         s.len() as isize,
         &mut result,
       );
@@ -215,7 +215,7 @@ pub(crate) fn parse_debug_file_path(
         napi::sys::napi_get_value_string_utf8(
           raw_env,
           raw_val,
-          buf.as_mut_ptr() as *mut i8,
+          buf.as_mut_ptr() as *mut _,
           len + 1,
           &mut written,
         );


### PR DESCRIPTION
## Description

This pull request makes a minor improvement to the way pointers are cast in the `fn_parser.rs` utility, updating the pointer casts to be more idiomatic and less type-specific. This change enhances code clarity and portability without affecting functionality.

* Updated pointer casting in two locations to use `as *mut _` instead of `as *mut i8` when calling `napi_get_value_string_utf8`, making the code less type-dependent and more idiomatic. (`crates/stylex-rs-compiler/src/utils/fn_parser.rs`) [[1]](diffhunk://#diff-c6f76ba930db34088a4e2641fb384a53d70f73f820982df7afbebe9411224d9eL153-R153) [[2]](diffhunk://#diff-c6f76ba930db34088a4e2641fb384a53d70f73f820982df7afbebe9411224d9eL218-R218)

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
