### PR TITLE
fix(stylex_shared): update state manager and transform functions for improved stylex handling

### DIFF
--- a/crates/stylex-shared/src/transform/fold/fold_jsx_opening_element_impl.rs
+++ b/crates/stylex-shared/src/transform/fold/fold_jsx_opening_element_impl.rs
@@ -74,10 +74,15 @@ where
           if let JSXExpr::Expr(expr) = &container.expr {
             let value_expr = *expr.clone();
             let stylex_ident_name = self.get_stylex_ident_name();
+            let props_ident_name = self.get_props_ident_name();
 
             // sx={[styles.a, styles.b]} → {...stylex.props(styles.a, styles.b)}
             let args = sx_value_to_props_args(value_expr);
-            let call = Expr::Call(build_stylex_props_call(stylex_ident_name, args));
+            let call = Expr::Call(build_stylex_props_call(
+              stylex_ident_name,
+              props_ident_name,
+              args,
+            ));
 
             Some(jsx_attr_or_spread_spread_factory(call))
           } else {
@@ -143,11 +148,16 @@ where
     // Extract the sx value and build args
     let sx_value = extract_prop_value(&obj_lit.props[sx_prop_idx])?;
     let stylex_ident_name = self.get_stylex_ident_name();
+    let props_ident_name = self.get_props_ident_name();
     let args = sx_value_to_props_args(sx_value);
 
     // Replace the sx prop with: ...stylex.props(...args)
     let mut new_props = obj_lit.props.clone();
-    let call_expr = Expr::Call(build_stylex_props_call(stylex_ident_name, args));
+    let call_expr = Expr::Call(build_stylex_props_call(
+      stylex_ident_name,
+      props_ident_name,
+      args,
+    ));
     new_props[sx_prop_idx] = prop_or_spread_spread_factory(call_expr);
 
     let mut new_call = call.clone();
@@ -201,10 +211,15 @@ where
     let value_expr = *call.args[2].expr.clone();
 
     let stylex_ident_name = self.get_stylex_ident_name();
+    let props_ident_name = self.get_props_ident_name();
     let args = sx_value_to_props_args(value_expr);
 
     // Build: () => stylex.props(args...)
-    let props_call = Expr::Call(build_stylex_props_call(stylex_ident_name, args));
+    let props_call = Expr::Call(build_stylex_props_call(
+      stylex_ident_name,
+      props_ident_name,
+      args,
+    ));
     let arrow_fn = arrow_expr_factory(props_call);
 
     // Build: _$mergeProps(() => stylex.props(...))
@@ -235,13 +250,21 @@ where
     )))
   }
 
-  fn get_stylex_ident_name(&self) -> String {
+  /// Get the stylex ident name from the import paths.
+  /// Returns the first stylex import name from the import paths.
+  fn get_stylex_ident_name(&self) -> Option<String> {
+    self.state.stylex_import_stringified().into_iter().next()
+  }
+
+  /// Get the props ident name from the import paths.
+  /// Returns the first props import name from the import paths.
+  fn get_props_ident_name(&self) -> Option<String> {
     self
       .state
-      .stylex_import_stringified()
-      .into_iter()
+      .stylex_props_import
+      .iter()
       .next()
-      .unwrap_or_else(|| "stylex".to_string())
+      .map(|ident| ident.to_string())
   }
 }
 
@@ -262,14 +285,26 @@ fn sx_value_to_props_args(value_expr: Expr) -> Vec<ExprOrSpread> {
   }
 }
 
-/// Build `stylex.props(args...)` call expression.
-fn build_stylex_props_call(stylex_ident_name: String, args: Vec<ExprOrSpread>) -> CallExpr {
-  let member = MemberExpr {
-    span: DUMMY_SP,
-    obj: Box::new(Expr::Ident(ident_factory(&stylex_ident_name))),
-    prop: MemberProp::Ident(ident_name_factory("props")),
-  };
-  call_expr_member_factory(member, args)
+/// Build a call expression for stylex props:
+/// - `stylex.props(args...)` when `stylex_ident_name` is available
+/// - `<props_ident_name>(args...)` (e.g. `props(args...)` or `sx(args...)`) otherwise
+fn build_stylex_props_call(
+  stylex_ident_name: Option<String>,
+  props_ident_name: Option<String>,
+  args: Vec<ExprOrSpread>,
+) -> CallExpr {
+  if let Some(stylex_ident_name) = stylex_ident_name {
+    let member = MemberExpr {
+      span: DUMMY_SP,
+      obj: Box::new(Expr::Ident(ident_factory(&stylex_ident_name))),
+      prop: MemberProp::Ident(ident_name_factory("props")),
+    };
+    call_expr_member_factory(member, args)
+  } else if let Some(props_ident_name) = props_ident_name {
+    call_expr_ident_factory(&props_ident_name, args)
+  } else {
+    panic!("Check if you have imported stylex or props");
+  }
 }
 
 /// Find the index of the prop with key matching `sx_prop_name` in a props list.

--- a/crates/stylex-shared/src/transform/mod.rs
+++ b/crates/stylex-shared/src/transform/mod.rs
@@ -46,8 +46,6 @@ where
 
     let mut state = StateManager::new(config.clone().into());
 
-    state.stylex_import.clone_from(&stylex_imports);
-
     state.options.import_sources = stylex_imports.into_iter().collect();
 
     state._state = plugin_pass;

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/legacy/transform_call/stylex_transform_call_common_test.rs/stylex_call_with_computed_number_without_declaration.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/legacy/transform_call/stylex_transform_call_common_test.rs/stylex_call_with_computed_number_without_declaration.js
@@ -1,6 +1,6 @@
 import _inject from "@stylexjs/stylex/lib/stylex-inject";
 var _inject2 = _inject;
-import { create } from '@stylexjs/stylex';
+import stylex from 'stylex';
 _inject2({
     ltr: ".x1e2nbdu{color:red}",
     priority: 3000
@@ -9,14 +9,4 @@ _inject2({
     ltr: ".x1t391ir{background-color:blue}",
     priority: 3000
 });
-const styles = {
-    "0": {
-        kMwMTN: "x1e2nbdu",
-        $$css: true
-    },
-    "1": {
-        kWkggS: "x1t391ir",
-        $$css: true
-    }
-};
-stylex(styles[0], styles[1]);
+export default "x1e2nbdu x1t391ir";

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_default.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_default.js
@@ -1,0 +1,16 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import sx from '@stylexjs/stylex';
+_inject2({
+    ltr: ".color-x1e2nbdu{color:red}",
+    priority: 3000
+});
+const styles = {
+    red: {
+        "color-kMwMTN": "color-x1e2nbdu",
+        $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
+    }
+};
+function Foo({ overrideProps = [] }) {
+    return <div {...sx.props(styles.red, ...overrideProps)}>Hello World</div>;
+}

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_named.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_named.js
@@ -1,0 +1,16 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import { create, props as sx } from '@stylexjs/stylex';
+_inject2({
+    ltr: ".color-x1e2nbdu{color:red}",
+    priority: 3000
+});
+const styles = {
+    red: {
+        "color-kMwMTN": "color-x1e2nbdu",
+        $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
+    }
+};
+function Foo({ overrideProps = [] }) {
+    return <div {...sx(styles.red, ...overrideProps)}>Hello World</div>;
+}

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_namespace.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_namespace.js
@@ -1,0 +1,16 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as sx from '@stylexjs/stylex';
+_inject2({
+    ltr: ".color-x1e2nbdu{color:red}",
+    priority: 3000
+});
+const styles = {
+    red: {
+        "color-kMwMTN": "color-x1e2nbdu",
+        $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
+    }
+};
+function Foo({ overrideProps = [] }) {
+    return <div {...sx.props(styles.red, ...overrideProps)}>Hello World</div>;
+}

--- a/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_props.js
+++ b/crates/stylex-shared/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_props.js
@@ -1,0 +1,16 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import { create, props } from '@stylexjs/stylex';
+_inject2({
+    ltr: ".color-x1e2nbdu{color:red}",
+    priority: 3000
+});
+const styles = {
+    red: {
+        "color-kMwMTN": "color-x1e2nbdu",
+        $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
+    }
+};
+function Foo({ overrideProps = [] }) {
+    return <div {...props(styles.red, ...overrideProps)}>Hello World</div>;
+}

--- a/crates/stylex-shared/tests/legacy/transform_call/stylex_transform_call_common_test.rs
+++ b/crates/stylex-shared/tests/legacy/transform_call/stylex_transform_call_common_test.rs
@@ -126,8 +126,8 @@ test!(
   ),
   stylex_call_with_computed_number_without_declaration,
   r#"
-      import {create} from '@stylexjs/stylex';
-      const styles = create({
+      import stylex from 'stylex';
+      const styles = stylex.create({
         [0]: {
           color: 'red',
         },
@@ -135,7 +135,7 @@ test!(
           backgroundColor: 'blue',
         }
       });
-      stylex(styles[0], styles[1]);
+      export default stylex(styles[0], styles[1]);
 "#
 );
 

--- a/crates/stylex-shared/tests/transform_stylex_stylex_props_test/sx_attribute.rs
+++ b/crates/stylex-shared/tests/transform_stylex_stylex_props_test/sx_attribute.rs
@@ -541,3 +541,143 @@ function Foo() {
 }
   "#
 );
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| StyleXTransform::new_test_force_runtime_injection_with_pass(
+    tr.comments.clone(),
+    PluginPass {
+      cwd: None,
+      filename: FileName::Real("/js/node_modules/npm-package/dist/components/Foo.react.js".into()),
+    },
+    Some(&mut StyleXOptionsParams {
+      debug: Some(true),
+      dev: Some(true),
+      enable_debug_class_names: Some(true),
+      unstable_module_resolution: Some(StyleXOptions::get_common_js_module_resolution(Some(
+        "/js".to_string()
+      ))),
+      ..StyleXOptionsParams::default()
+    })
+  ),
+  sx_attr_import_name_as_default,
+  r#"
+  import sx from '@stylexjs/stylex';
+  const styles = sx.create({
+    red: {
+      color: 'red',
+    }
+  });
+  function Foo({overrideProps= []}) {
+    return <div sx={[styles.red, ...overrideProps]}>Hello World</div>;
+  }
+  "#
+);
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| StyleXTransform::new_test_force_runtime_injection_with_pass(
+    tr.comments.clone(),
+    PluginPass {
+      cwd: None,
+      filename: FileName::Real("/js/node_modules/npm-package/dist/components/Foo.react.js".into()),
+    },
+    Some(&mut StyleXOptionsParams {
+      debug: Some(true),
+      dev: Some(true),
+      enable_debug_class_names: Some(true),
+      unstable_module_resolution: Some(StyleXOptions::get_common_js_module_resolution(Some(
+        "/js".to_string()
+      ))),
+      ..StyleXOptionsParams::default()
+    })
+  ),
+  sx_attr_import_name_as_namespace,
+  r#"
+  import * as sx from '@stylexjs/stylex';
+  const styles = sx.create({
+    red: {
+      color: 'red',
+    }
+  });
+  function Foo({overrideProps= []}) {
+    return <div sx={[styles.red, ...overrideProps]}>Hello World</div>;
+  }
+  "#
+);
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| StyleXTransform::new_test_force_runtime_injection_with_pass(
+    tr.comments.clone(),
+    PluginPass {
+      cwd: None,
+      filename: FileName::Real("/js/node_modules/npm-package/dist/components/Foo.react.js".into()),
+    },
+    Some(&mut StyleXOptionsParams {
+      debug: Some(true),
+      dev: Some(true),
+      enable_debug_class_names: Some(true),
+      unstable_module_resolution: Some(StyleXOptions::get_common_js_module_resolution(Some(
+        "/js".to_string()
+      ))),
+      ..StyleXOptionsParams::default()
+    })
+  ),
+  sx_attr_import_name_as_named,
+  r#"
+  import {create, props as sx} from '@stylexjs/stylex';
+  const styles = create({
+    red: {
+      color: 'red',
+    }
+  });
+  function Foo({overrideProps= []}) {
+    return <div sx={[styles.red, ...overrideProps]}>Hello World</div>;
+  }
+  "#
+);
+
+test!(
+  Syntax::Typescript(TsSyntax {
+    tsx: true,
+    ..Default::default()
+  }),
+  |tr| StyleXTransform::new_test_force_runtime_injection_with_pass(
+    tr.comments.clone(),
+    PluginPass {
+      cwd: None,
+      filename: FileName::Real("/js/node_modules/npm-package/dist/components/Foo.react.js".into()),
+    },
+    Some(&mut StyleXOptionsParams {
+      debug: Some(true),
+      dev: Some(true),
+      enable_debug_class_names: Some(true),
+      unstable_module_resolution: Some(StyleXOptions::get_common_js_module_resolution(Some(
+        "/js".to_string()
+      ))),
+      ..StyleXOptionsParams::default()
+    })
+  ),
+  sx_attr_import_name_as_props,
+  r#"
+  import {create, props} from '@stylexjs/stylex';
+  const styles = create({
+    red: {
+      color: 'red',
+    }
+  });
+  function Foo({overrideProps= []}) {
+    return <div sx={[styles.red, ...overrideProps]}>Hello World</div>;
+  }
+  "#
+);


### PR DESCRIPTION
- Removed unnecessary cloning of `stylex_imports` in `mod.rs`.
- Updated `build_stylex_props_call` to accept optional stylex and props identifiers, enhancing flexibility in JSX transformations.
- Added new test cases for various import styles in `sx_attribute.rs`, ensuring compatibility with default, named, and namespace imports.

## Description

This pull request improves the handling of `sx` props and `stylex.props` calls in JSX transformation, making the code more robust to different import patterns for the StyleX library. It introduces better detection and use of import names (default, named, namespace, or direct `props` import) and adds comprehensive tests to ensure correct transformation across various import scenarios.

Key changes include:

### Transformation Logic Improvements

* Refactored the logic in `fold_jsx_opening_element_impl.rs` to detect and use both the main StyleX import and the `props` import, enabling correct transformation for all supported import styles (default, named, namespace, or direct props). The new logic tries to use the main StyleX import for `stylex.props`, falling back to the `props` import if necessary. [[1]](diffhunk://#diff-cb3e51d32a2d23906995155cdb9f3cce83a6b92f46fb7f07bb31784a3477d8cfR77-R85) [[2]](diffhunk://#diff-cb3e51d32a2d23906995155cdb9f3cce83a6b92f46fb7f07bb31784a3477d8cfR151-R160) [[3]](diffhunk://#diff-cb3e51d32a2d23906995155cdb9f3cce83a6b92f46fb7f07bb31784a3477d8cfR214-R222) [[4]](diffhunk://#diff-cb3e51d32a2d23906995155cdb9f3cce83a6b92f46fb7f07bb31784a3477d8cfL238-R267) [[5]](diffhunk://#diff-cb3e51d32a2d23906995155cdb9f3cce83a6b92f46fb7f07bb31784a3477d8cfL266-R307)

### Test Coverage Expansion

* Added new tests in `sx_attribute.rs` to cover all supported import styles: default import (`import sx from ...`), namespace import (`import * as sx from ...`), named import with alias (`import { props as sx } from ...`), and direct props import (`import { props } from ...`). These tests ensure that the transformation works correctly for each import pattern. [[1]](diffhunk://#diff-3a82436e71445aa2d98ac9f651111edd9754b1c7c0a584c7f9afd08d181ce554R545-R700) [[2]](diffhunk://#diff-1a8012e2ac1786f9328ea20d68fbc13826fea55958411420216d6a68af801982R1-R16) [[3]](diffhunk://#diff-c3065555d63c070744854b28090960b35d3dbd70759795131fe68f3aaab9a79bR1-R16) [[4]](diffhunk://#diff-5cee13a98f83fa942c65391f4e83e1deb698b724ee8078fc7f46e2b97537d4f7R1-R16) [[5]](diffhunk://#diff-dd3e8aacde85db848d76fc83a1d3223afaeba9a1a4bfc6ff3137ed9e316afd89R1-R16)

### Legacy and Snapshot Test Updates

* Updated legacy and snapshot tests to match the new transformation output, including changes to default exports and import patterns in generated code. [[1]](diffhunk://#diff-24a9170c70d4bf0f583926c2bc86ac8aaf0b0ef4a7b11ca17f04445dd4a35416L3-R3) [[2]](diffhunk://#diff-24a9170c70d4bf0f583926c2bc86ac8aaf0b0ef4a7b11ca17f04445dd4a35416L12-R12) [[3]](diffhunk://#diff-cf75c39b8d124feedcae92aa112fe3eb117741cc52b50b29cc61e217803bdb10L129-R138)

### Internal Refactoring

* Improved the way import sources are managed and detected, cleaning up state handling and import source assignment in the transform module. [[1]](diffhunk://#diff-7904f12679a679f720e0c3e437e1502c0bf43ceb852ffe6e08f20aeafa7d8070L49-L50) [[2]](diffhunk://#diff-3a82436e71445aa2d98ac9f651111edd9754b1c7c0a584c7f9afd08d181ce554R4)

These changes make the StyleX JSX transform more resilient and predictable across different ways users might import and use the library.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
