### PR TITLE
refactor(postcss-plugin): improve import source transformation logic in bundler

### DIFF
--- a/packages/postcss-plugin/src/bundler.ts
+++ b/packages/postcss-plugin/src/bundler.ts
@@ -9,37 +9,47 @@ export default function createBundler() {
   const styleXRulesMap = new Map();
 
   // Determines if the source code should be transformed based on the presence of StyleX imports.
-  function shouldTransform(sourceCode: string, rsOptions?: StyleXPluginOption['rsOptions']) {
-    const { importSources } = rsOptions ?? {};
+  function shouldTransform(
+    sourceCode: string,
+    rsOptions?: StyleXPluginOption['rsOptions']
+  ): boolean {
+    const importSources = rsOptions?.importSources;
 
-    let parsedImportSources: StyleXOptions['importSources'] | undefined;
+    if (!importSources) return false;
 
-    try {
-      parsedImportSources = importSources?.map(importSource => {
-        return typeof importSource === 'string' ? JSON.parse(importSource) : importSource;
-      });
-    } catch (error) {
-      parsedImportSources = importSources;
-    }
+    return importSources.some(importSource => {
+      // Already an object (e.g., { from: '@stylexjs/stylex' })
+      if (typeof importSource !== 'string') {
+        const fromTrimmed = importSource.from?.trim();
 
-    const shouldTransform = parsedImportSources?.some(importSource => {
-      if (typeof importSource === 'string') {
-        return sourceCode.includes(importSource);
+        if (!fromTrimmed) return false;
+
+        return sourceCode.includes(importSource.from);
       }
-      return sourceCode.includes(importSource.from);
+
+      const importSourceTrimmed = importSource.trimStart();
+
+      if (!importSourceTrimmed) return false;
+
+      // JSON string edge-case: only attempt parse if it looks like a JSON object
+      if (importSourceTrimmed[0] === '{') {
+        try {
+          const parsed = JSON.parse(importSourceTrimmed);
+          if (typeof parsed.from === 'string') {
+            const fromTrimmed = parsed.from.trim();
+
+            if (!fromTrimmed) return false;
+
+            return sourceCode.includes(fromTrimmed);
+          }
+        } catch {
+          // Not valid JSON — fall through to plain string check
+        }
+      }
+
+      // Standard string case, e.g. '@stylexjs/stylex'
+      return sourceCode.includes(importSource);
     });
-
-    // if (importSourcesExtend != null) {
-    //   shouldTransform ||= importSourcesExtend.some(importSource => {
-    //     if (typeof importSource === 'string') {
-    //       return sourceCode.includes(importSource);
-    //     }
-
-    //     return sourceCode.includes(importSource.from);
-    //   });
-    // }
-
-    return shouldTransform;
   }
 
   // Transforms the source code using Babel, extracting StyleX rules and storing them.


### PR DESCRIPTION
## Description

This pull request refactors the `shouldTransform` function in `bundler.ts` to improve its reliability and clarity when determining if a source file should be transformed based on StyleX import sources. The new implementation simplifies logic, handles edge cases more robustly, and avoids unnecessary parsing errors.

Key improvements to import source detection:

* Refactored the `shouldTransform` function to:
  - Return early if no `importSources` are provided.
  - Handle both object and string forms of `importSources` more robustly, including whitespace trimming and JSON edge cases.
  - Avoids unnecessary try/catch blocks and only attempts JSON parsing when the string looks like a JSON object.
  - Ensures that only valid, non-empty import sources are checked against the source code.

## Fixes

(Optional) Fixes #880 

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
