### PR TITLE
fix(unplugin): filter non-JS files in handleHotUpdate before parsing

### DIFF
--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -480,6 +480,19 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         );
       },
       async handleHotUpdate({ file: id, file, server, read, modules }) {
+        // Skip files that wouldn't pass transformInclude (e.g. package.json, .css, images)
+        // to avoid parsing non-JS/TS files with SWC
+        const extensionName = path.extname(file);
+        const questionSignIndex = extensionName.indexOf('?');
+        let cleanedExtensionName =
+          questionSignIndex > -1 ? extensionName.slice(0, questionSignIndex) : extensionName;
+        if (cleanedExtensionName.startsWith('.')) {
+          cleanedExtensionName = cleanedExtensionName.slice(1);
+        }
+        if (!normalizedOptions.pageExtensions.includes(cleanedExtensionName)) {
+          return;
+        }
+
         // For Vue files, include CSS module but don't transform
         // (raw .vue files have <template>, <style> sections that SWC can't parse)
         // The transform hook will update stylexRules when Vue plugin converts it to JS

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -18,6 +18,20 @@ import type { HotPayload, UserConfig, ViteDevServer } from 'vite';
 
 type StyleXRules = Record<string, StyleXMetadata['stylex']>;
 
+function hasValidExtension(filePath: string, pageExtensions: string[]): boolean {
+  const extensionName = path.extname(filePath);
+  const questionSignIndex = extensionName.indexOf('?');
+
+  let cleanedExtensionName =
+    questionSignIndex > -1 ? extensionName.slice(0, questionSignIndex) : extensionName;
+
+  if (cleanedExtensionName.startsWith('.')) {
+    cleanedExtensionName = cleanedExtensionName.slice(1);
+  }
+
+  return pageExtensions.includes(cleanedExtensionName);
+}
+
 // Use the normalized options type from utils
 import type { NormalizedOptions as NormalizedOptionsType } from './utils/normalizeOptions';
 type NormalizedOptions = NormalizedOptionsType;
@@ -196,21 +210,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
     },
 
     transformInclude(id) {
-      const pageExtensions = normalizedOptions.pageExtensions;
-
-      const extensionName = path.extname(id);
-
-      // Specific for Vite support
-      const questionSignIndex = extensionName.indexOf('?');
-
-      let cleanedExtensionName =
-        questionSignIndex > -1 ? extensionName.slice(0, questionSignIndex) : extensionName;
-
-      if (cleanedExtensionName.startsWith('.')) {
-        cleanedExtensionName = cleanedExtensionName.slice(1);
-      }
-
-      if (!pageExtensions.includes(cleanedExtensionName)) {
+      if (!hasValidExtension(id, normalizedOptions.pageExtensions)) {
         return false;
       }
 
@@ -480,19 +480,6 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         );
       },
       async handleHotUpdate({ file: id, file, server, read, modules }) {
-        // Skip files that wouldn't pass transformInclude (e.g. package.json, .css, images)
-        // to avoid parsing non-JS/TS files with SWC
-        const extensionName = path.extname(file);
-        const questionSignIndex = extensionName.indexOf('?');
-        let cleanedExtensionName =
-          questionSignIndex > -1 ? extensionName.slice(0, questionSignIndex) : extensionName;
-        if (cleanedExtensionName.startsWith('.')) {
-          cleanedExtensionName = cleanedExtensionName.slice(1);
-        }
-        if (!normalizedOptions.pageExtensions.includes(cleanedExtensionName)) {
-          return;
-        }
-
         // For Vue files, include CSS module but don't transform
         // (raw .vue files have <template>, <style> sections that SWC can't parse)
         // The transform hook will update stylexRules when Vue plugin converts it to JS
@@ -511,6 +498,12 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
             }
           }
 
+          return;
+        }
+
+        // Skip files that wouldn't pass transformInclude (e.g. package.json, .css, images)
+        // to avoid parsing non-JS/TS files with SWC
+        if (!hasValidExtension(file, normalizedOptions.pageExtensions)) {
           return;
         }
 


### PR DESCRIPTION
Hello there! 

I was noticing that when I had a change which included a package json, it was triggering a HMR issue:

```
Failed to parse file `/Users/orta/dev/app/apps/studio/package.json`: Error { error: (11..12, ExpectedSemiForExprStmt { expr: 5..11 }) }
    at Object.transformWithPlugins [as transform] (/Users/orta/dev/app/node_modules/@stylexswc/rs-compiler/dist/index.js:621:10)
    at transformStyleXCode (/Users/orta/dev/app/node_modules/@stylexswc/unplugin/dist/chunk-OZS2ZFJR.cjs:616:39)
    at BasicMinimalPluginContext.handleHotUpdate (/Users/orta/dev/app/node_modules/@stylexswc/unplugin/dist/chunk-OZS2ZFJR.cjs:386:9)
    at async handleHMRUpdate (file:///Users/orta/dev/app/node_modules/vite/dist/node/chunks/node.js:26537:28)
    at async onHMRUpdate (file:///Users/orta/dev/app/node_modules/vite/dist/node/chunks/node.js:26066:35)
```

This was because the package.json was being passed to the stylex compiler and as it has 'stylex' in the content, he stylex compile would treat it as though it were a JS file

This PR replicates the checks which exist on build files, for HMR files too

---

AI Generated Summary

## Summary

The `handleHotUpdate` Vite hook doesn't check file extensions before attempting to parse files with SWC. This causes crashes when non-JS files (like `package.json`) are modified during development.

**Root cause:** `hasStyleXCode()` does a substring match on file content for import source names. When a `package.json` contains `@stylexswc` or `@stylexjs` in its dependencies, the check passes, and SWC then tries to parse JSON as JavaScript:

```
Failed to parse file `/path/to/package.json`: Error { error: (11..12, ExpectedSemiForExprStmt { expr: 5..11 }) }
    at Object.transformWithPlugins [as transform] (.../dist/index.js:621:10)
    at transformStyleXCode (.../dist/chunk-OZS2ZFJR.cjs:616:39)
    at BasicMinimalPluginContext.handleHotUpdate (.../dist/chunk-OZS2ZFJR.cjs:386:9)
```

**Fix:** Add the same `pageExtensions` check that `transformInclude` already uses at the top of `handleHotUpdate`, so non-JS/TS files are skipped before any content reading or parsing happens.

## Test plan

- [ ] Verify HMR still works for `.ts`/`.tsx`/`.js`/`.jsx` files with StyleX imports
- [ ] Verify modifying `package.json` during dev no longer causes a parse error
- [ ] Verify Vue files still take the existing `.vue`-specific code path