### PR TITLE
Refactor TransformationCycle pipeline and consolidate phases

### DIFF
--- a/crates/stylex-enums/src/core.rs
+++ b/crates/stylex-enums/src/core.rs
@@ -13,6 +13,4 @@ pub enum TransformationCycle {
   Initializing,
   // Fill the state with expressions data before transformation
   StateFilling,
-  // Inject styles metadata to the file
-  InjectStyles,
 }

--- a/crates/stylex-enums/src/core.rs
+++ b/crates/stylex-enums/src/core.rs
@@ -9,8 +9,8 @@ pub enum TransformationCycle {
   PreCleaning,
   // The file is being cleaned
   Cleaning,
-  // The file has been processed and the plugin is skipped
-  Initializing,
-  // Fill the state with expressions data before transformation
-  StateFilling,
+  // Discover stylex imports and fill the state with reference-count data in
+  // a single AST walk (replaces the legacy `Initializing` + `StateFilling`
+  // two-pass split).
+  Discover,
 }

--- a/crates/stylex-enums/src/core.rs
+++ b/crates/stylex-enums/src/core.rs
@@ -13,8 +13,6 @@ pub enum TransformationCycle {
   Initializing,
   // Fill the state with expressions data before transformation
   StateFilling,
-  // Skip the plugin if import does not exist
-  Skip,
   // Inject styles metadata to the file
   InjectStyles,
 }

--- a/crates/stylex-enums/src/core.rs
+++ b/crates/stylex-enums/src/core.rs
@@ -9,8 +9,6 @@ pub enum TransformationCycle {
   PreCleaning,
   // The file is being cleaned
   Cleaning,
-  // Recounting variable links
-  Recounting,
   // The file has been processed and the plugin is skipped
   Initializing,
   // Fill the state with expressions data before transformation

--- a/crates/stylex-enums/src/core.rs
+++ b/crates/stylex-enums/src/core.rs
@@ -1,16 +1,20 @@
-// Represents the current state of a plugin for a file.
+// Represents the current phase of the StyleX visitor pipeline for a file.
+//
+// The pipeline runs in this fixed order:
+//   1. `Discover` — gather imports, transform compiled-JSX `sx`, count
+//      references, pre-fill declarations.
+//   2. `TransformProducers` — transform `stylex.create` / `defineVars` /
+//      `keyframes` / etc.
+//   3. `TransformConsumers` — transform `stylex.props` / `stylex.attrs` and
+//      flush runtime style-injection items.
+//   4. `Finalize` — sweep unused declarations and prune surviving style
+//      objects to the keys actually used. The mark step that decides what
+//      survives runs as a free-standing helper before this phase rather
+//      than as its own cycle, so this enum has only four variants.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Copy)]
 pub enum TransformationCycle {
-  // The plugin is being processed
-  TransformEnter,
-  // The plugin has been processed
-  TransformExit,
-  // The plugin has been processed and the file is being cleaned
-  PreCleaning,
-  // The file is being cleaned
-  Cleaning,
-  // Discover stylex imports and fill the state with reference-count data in
-  // a single AST walk (replaces the legacy `Initializing` + `StateFilling`
-  // two-pass split).
   Discover,
+  TransformProducers,
+  TransformConsumers,
+  Finalize,
 }

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -380,6 +380,16 @@ pub struct StateManager {
   pub(crate) top_imports: Vec<ImportDecl>,
   pub(crate) named_exports: FxHashSet<NamedExport>,
 
+  /// When `true`, the expression evaluator preserves variable binding
+  /// counts (returns `VarDeclAction::None`) instead of decrementing them.
+  ///
+  /// Set by the driver around the consumer transformation walk so that
+  /// arguments to `stylex.props` / `stylex.attrs` retain their references
+  /// for codegen. Replaces the legacy `cycle == TransformExit` check in
+  /// `shared/utils/js/evaluate/mod.rs`, decoupling the evaluator from the
+  /// pipeline state machine.
+  pub(crate) evaluate_preserve_bindings: bool,
+
   pub cycle: TransformationCycle,
 }
 
@@ -425,6 +435,8 @@ impl StateManager {
       hoisted_module_items: vec![],
 
       other_injected_css_rules: IndexMap::new(),
+
+      evaluate_preserve_bindings: false,
 
       cycle: TransformationCycle::Initializing,
     }

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1144,12 +1144,9 @@ impl StateManager {
   /// Decrement reference counts for every ident and member-expr access inside
   /// the given declarator.
   ///
-  /// Mirrors what the legacy `TransformationCycle::Recounting` pass did when it
-  /// re-traversed an unused declarator with the visitor's mutable hooks. The
-  /// read-only `Visit` walk used here avoids needing to set/reset cycle state
-  /// and lets cleanup code call this helper directly without piggybacking on the
-  /// driver.
-  #[allow(dead_code)] // wired up in a follow-up commit (eliminates Recounting cycle)
+  /// Used by the cleanup pass to keep `var_decl_count_map` and
+  /// `member_object_ident_count_map` symmetric when an unused declarator is
+  /// removed.
   pub(crate) fn decrement_decl_counts(&mut self, decl: &VarDeclarator) {
     let mut visitor = DecrementCountVisitor { state: self };
     decl.visit_with(&mut visitor);
@@ -1210,12 +1207,6 @@ impl StateManager {
 
 /// Read-only visitor used by [`StateManager::decrement_decl_counts`] to undo
 /// the increments produced during the discovery walk for an unused declarator.
-///
-/// Mirrors the legacy `TransformationCycle::Recounting` arms in
-/// `visit_mut_ident.rs`, `visit_mut_member_expr.rs`, `visit_mut_member_prop.rs`
-/// and `visit_mut_prop_name.rs` so reference counts stay symmetric without
-/// piggybacking on the cycle field.
-#[allow(dead_code)] // wired up in a follow-up commit (eliminates Recounting cycle)
 struct DecrementCountVisitor<'a> {
   state: &'a mut StateManager,
 }

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1118,6 +1118,17 @@ impl StateManager {
     self.options.treeshake_compensation
   }
 
+  /// `true` when the file imports stylex and the visitor pipeline should run.
+  ///
+  /// During the cycle-state cleanup, this replaces the scattered
+  /// `if cycle == Skip { return; }` early-returns in individual visitors so
+  /// the driver can short-circuit a single time after discovery instead of
+  /// every visitor checking the cycle on every node.
+  #[allow(dead_code)] // wired up in a follow-up commit (eliminates Skip cycle)
+  pub(crate) fn is_active(&self) -> bool {
+    self.cycle != TransformationCycle::Skip
+  }
+
   /// Decrement reference counts for every ident and member-expr access inside
   /// the given declarator.
   ///

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -438,7 +438,7 @@ impl StateManager {
 
       evaluate_preserve_bindings: false,
 
-      cycle: TransformationCycle::Initializing,
+      cycle: TransformationCycle::Discover,
     }
   }
 

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1280,7 +1280,7 @@ impl VisitMut for MarkStyleVarsVisitor<'_> {
           let expr = drop_span(spread.expr.as_ref().clone());
           if let Some(updated_exprs) = self.state.jsx_spread_attr_exprs_map.get(&expr).cloned() {
             if updated_exprs.is_empty() {
-              // If the spread was resolved to nothing, keep the original
+              // If no replacement JSX attrs were recorded for this spread, keep the original
               vec![jsx_attr.clone()]
             } else {
               // Replace the spread with the updated expressions

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -20,7 +20,7 @@ use swc_core::{
       Str, VarDecl, VarDeclKind, VarDeclarator,
     },
     utils::drop_span,
-    visit::{Visit, VisitWith},
+    visit::{Visit, VisitMut, VisitMutWith, VisitWith},
   },
 };
 
@@ -30,13 +30,14 @@ use crate::shared::{
     ast::convertors::create_number_expr,
     common::{
       extract_filename_from_path, extract_filename_with_ext_from_path, extract_path,
-      reduce_ident_count, reduce_member_ident_count,
+      increase_ident_count, reduce_ident_count, reduce_member_ident_count,
     },
   },
 };
 use stylex_ast::ast::factories::{
-  create_binding_ident, create_expr_or_spread, create_key_value_prop, create_number_expr_or_spread,
-  create_object_expression, create_string_expr_or_spread, create_string_key_value_prop,
+  create_binding_ident, create_expr_or_spread, create_jsx_attr_or_spread, create_jsx_spread_attr,
+  create_key_value_prop, create_number_expr_or_spread, create_object_expression,
+  create_string_expr_or_spread, create_string_key_value_prop,
 };
 use stylex_constants::constants::{
   api_names::{
@@ -47,6 +48,7 @@ use stylex_constants::constants::{
   },
   common::{CONSTS_FILE_EXTENSION, DEFAULT_INJECT_PATH},
 };
+use stylex_enums::style_vars_to_keep::{NonNullProp, NonNullProps};
 use stylex_enums::{
   core::TransformationCycle, counter_mode::CounterMode,
   import_path_resolution::ImportPathResolution, top_level_expression::TopLevelExpressionKind,
@@ -550,7 +552,7 @@ impl StateManager {
 
   pub(crate) fn is_stylex_import_for_current_cycle(&self, ident_sym: &str) -> bool {
     match self.cycle {
-      TransformationCycle::TransformEnter => {
+      TransformationCycle::TransformProducers => {
         use ImportKind::*;
         self.is_stylex_import_for_kinds(
           ident_sym,
@@ -569,7 +571,7 @@ impl StateManager {
           ],
         )
       },
-      TransformationCycle::TransformExit => {
+      TransformationCycle::TransformConsumers => {
         self.is_stylex_import_for_kinds(ident_sym, &[ImportKind::Attrs, ImportKind::Props])
       },
       _ => self.is_stylex_namespace_import(ident_sym),
@@ -1223,6 +1225,91 @@ impl Visit for DecrementCountVisitor<'_> {
       prop_name.visit_children_with(self);
     }
   }
+}
+
+/// Visitor used by [`mark_style_vars_to_keep`] to populate
+/// `state.style_vars_to_keep` from the surviving member-expression accesses
+/// on style namespaces and to materialize any JSX-spread replacements
+/// recorded during the discovery phase.
+///
+/// Replaces what the legacy `TransformationCycle::PreCleaning` arms in
+/// `visit_mut_member_expr.rs` and `visit_mut_jsx_attr_or_spread.rs` did,
+/// so the finalize phase can collapse to a single sweep cycle.
+struct MarkStyleVarsVisitor<'a> {
+  state: &'a mut StateManager,
+}
+
+impl VisitMut for MarkStyleVarsVisitor<'_> {
+  fn visit_mut_member_expr(&mut self, member_expression: &mut MemberExpr) {
+    if let Expr::Ident(ident) = member_expression.obj.as_ref()
+      && self.state.style_map.contains_key(ident.sym.as_ref())
+    {
+      if let MemberProp::Ident(prop_ident) = &member_expression.prop
+        && self
+          .state
+          .member_object_ident_count_map
+          .get(&ident.sym)
+          .is_some_and(|&c| c > 0)
+      {
+        increase_ident_count(self.state, ident);
+        self.state.style_vars_to_keep.insert(StyleVarsToKeep(
+          ident.sym.clone(),
+          NonNullProp::Atom(prop_ident.sym.clone()),
+          NonNullProps::True,
+        ));
+      };
+
+      if let MemberProp::Computed(_) = &member_expression.prop {
+        increase_ident_count(self.state, ident);
+        self.state.style_vars_to_keep.insert(StyleVarsToKeep(
+          ident.sym.clone(),
+          NonNullProp::True,
+          NonNullProps::True,
+        ));
+      }
+    }
+
+    member_expression.visit_mut_children_with(self);
+  }
+
+  fn visit_mut_jsx_attr_or_spreads(&mut self, jsx_attrs: &mut Vec<JSXAttrOrSpread>) {
+    let mut result: Vec<JSXAttrOrSpread> = jsx_attrs
+      .iter()
+      .flat_map(|jsx_attr| match jsx_attr {
+        JSXAttrOrSpread::SpreadElement(spread) => {
+          let expr = drop_span(spread.expr.as_ref().clone());
+          if let Some(updated_exprs) = self.state.jsx_spread_attr_exprs_map.get(&expr).cloned() {
+            if updated_exprs.is_empty() {
+              // If the spread was resolved to nothing, keep the original
+              vec![jsx_attr.clone()]
+            } else {
+              // Replace the spread with the updated expressions
+              updated_exprs
+            }
+          } else {
+            // If no replacement found, keep the original spread element
+            vec![create_jsx_spread_attr(*spread.expr.clone())]
+          }
+        },
+        JSXAttrOrSpread::JSXAttr(attr) => vec![create_jsx_attr_or_spread(attr.clone())],
+      })
+      .collect();
+
+    result.visit_mut_children_with(self);
+    *jsx_attrs = result;
+  }
+}
+
+/// Walk the module to populate `state.style_vars_to_keep` from surviving
+/// member-expr accesses on style namespaces, and to apply any deferred
+/// JSX-spread replacements collected during discovery.
+///
+/// This is the "mark" step of the finalize phase. The "sweep" step that
+/// actually deletes unused declarations runs afterwards under
+/// `TransformationCycle::Finalize` with `module.body` reversed.
+pub(crate) fn mark_style_vars_to_keep(module: &mut Module, state: &mut StateManager) {
+  let mut visitor = MarkStyleVarsVisitor { state };
+  module.visit_mut_with(&mut visitor);
 }
 
 fn add_inject_default_import_expression(ident: &Ident, inject_path: Option<&str>) -> ModuleItem {

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -15,11 +15,12 @@ use swc_core::{
   ecma::{
     ast::{
       CallExpr, Callee, Decl, Expr, ExprStmt, Ident, ImportDecl, ImportDefaultSpecifier,
-      ImportNamedSpecifier, ImportPhase, ImportSpecifier, JSXAttrOrSpread, MemberExpr, Module,
-      ModuleDecl, ModuleExportName, ModuleItem, NamedExport, Pat, Program, Stmt, Str, VarDecl,
-      VarDeclKind, VarDeclarator,
+      ImportNamedSpecifier, ImportPhase, ImportSpecifier, JSXAttrOrSpread, MemberExpr, MemberProp,
+      Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport, Pat, Program, PropName, Stmt,
+      Str, VarDecl, VarDeclKind, VarDeclarator,
     },
     utils::drop_span,
+    visit::{Visit, VisitWith},
   },
 };
 
@@ -27,7 +28,10 @@ use crate::shared::{
   structures::types::InjectableStylesMap,
   utils::{
     ast::convertors::create_number_expr,
-    common::{extract_filename_from_path, extract_filename_with_ext_from_path, extract_path},
+    common::{
+      extract_filename_from_path, extract_filename_with_ext_from_path, extract_path,
+      reduce_ident_count, reduce_member_ident_count,
+    },
   },
 };
 use stylex_ast::ast::factories::{
@@ -1114,6 +1118,20 @@ impl StateManager {
     self.options.treeshake_compensation
   }
 
+  /// Decrement reference counts for every ident and member-expr access inside
+  /// the given declarator.
+  ///
+  /// Mirrors what the legacy `TransformationCycle::Recounting` pass did when it
+  /// re-traversed an unused declarator with the visitor's mutable hooks. The
+  /// read-only `Visit` walk used here avoids needing to set/reset cycle state
+  /// and lets cleanup code call this helper directly without piggybacking on the
+  /// driver.
+  #[allow(dead_code)] // wired up in a follow-up commit (eliminates Recounting cycle)
+  pub(crate) fn decrement_decl_counts(&mut self, decl: &VarDeclarator) {
+    let mut visitor = DecrementCountVisitor { state: self };
+    decl.visit_with(&mut visitor);
+  }
+
   // Now you can use these helper functions to simplify your function
   pub fn combine(&mut self, other: &Self) {
     self.imports.combine(&other.imports);
@@ -1164,6 +1182,43 @@ impl StateManager {
       &other.other_injected_css_rules,
     );
     chain_collect_in_place(&mut self.top_imports, &other.top_imports);
+  }
+}
+
+/// Read-only visitor used by [`StateManager::decrement_decl_counts`] to undo
+/// the increments produced during the discovery walk for an unused declarator.
+///
+/// Mirrors the legacy `TransformationCycle::Recounting` arms in
+/// `visit_mut_ident.rs`, `visit_mut_member_expr.rs`, `visit_mut_member_prop.rs`
+/// and `visit_mut_prop_name.rs` so reference counts stay symmetric without
+/// piggybacking on the cycle field.
+#[allow(dead_code)] // wired up in a follow-up commit (eliminates Recounting cycle)
+struct DecrementCountVisitor<'a> {
+  state: &'a mut StateManager,
+}
+
+impl Visit for DecrementCountVisitor<'_> {
+  fn visit_ident(&mut self, ident: &Ident) {
+    reduce_ident_count(self.state, ident);
+  }
+
+  fn visit_member_expr(&mut self, member_expr: &MemberExpr) {
+    if let Some(obj_ident) = member_expr.obj.as_ident() {
+      reduce_member_ident_count(self.state, &obj_ident.sym);
+    }
+    member_expr.visit_children_with(self);
+  }
+
+  fn visit_member_prop(&mut self, member_prop: &MemberProp) {
+    if !member_prop.is_ident() {
+      member_prop.visit_children_with(self);
+    }
+  }
+
+  fn visit_prop_name(&mut self, prop_name: &PropName) {
+    if !prop_name.is_ident() {
+      prop_name.visit_children_with(self);
+    }
   }
 }
 

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1130,17 +1130,6 @@ impl StateManager {
     self.options.treeshake_compensation
   }
 
-  /// `true` when the file imports stylex and the visitor pipeline should run.
-  ///
-  /// During the cycle-state cleanup, this replaces the scattered
-  /// `if cycle == Skip { return; }` early-returns in individual visitors so
-  /// the driver can short-circuit a single time after discovery instead of
-  /// every visitor checking the cycle on every node.
-  #[allow(dead_code)] // wired up in a follow-up commit (eliminates Skip cycle)
-  pub(crate) fn is_active(&self) -> bool {
-    self.cycle != TransformationCycle::Skip
-  }
-
   /// Decrement reference counts for every ident and member-expr access inside
   /// the given declarator.
   ///

--- a/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
+++ b/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
@@ -77,7 +77,6 @@ use stylex_constants::constants::{
   },
 };
 use stylex_enums::{
-  core::TransformationCycle,
   import_path_resolution::ImportPathResolution,
   js::{ArrayJS, MathJS, ObjectJS, StringJS},
   misc::{BinaryExprType, VarDeclAction},
@@ -386,7 +385,7 @@ fn _evaluate(
       ident,
       traversal_state,
       &state.functions,
-      if traversal_state.cycle == TransformationCycle::TransformExit {
+      if traversal_state.evaluate_preserve_bindings {
         // NOTE: We don't want to reduce the binding count of stylex.props arguments
         VarDeclAction::None
       } else {

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_calls.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_calls.rs
@@ -11,7 +11,7 @@ where
   C: Comments,
 {
   pub(crate) fn transform_stylex_fns(&mut self, call_expr: &mut CallExpr) -> Option<Expr> {
-    if self.state.cycle == TransformationCycle::TransformEnter {
+    if self.state.cycle == TransformationCycle::TransformProducers {
       let (_, parent_var_decl) = &self.get_call_var_name(call_expr);
 
       if let Some(parent_var_decl) = parent_var_decl {
@@ -53,7 +53,7 @@ where
       }
     }
 
-    if self.state.cycle == TransformationCycle::TransformExit {
+    if self.state.cycle == TransformationCycle::TransformConsumers {
       if let Some(value) = self.transform_stylex_attrs_call(call_expr) {
         return Some(value);
       }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_computed_prop_name.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_computed_prop_name.rs
@@ -22,7 +22,7 @@ where
     &mut self,
     computed_prop_name: &mut ComputedPropName,
   ) {
-    if self.state.cycle == TransformationCycle::StateFilling && computed_prop_name.expr.is_lit() {
+    if self.state.cycle == TransformationCycle::Discover && computed_prop_name.expr.is_lit() {
       let expt_str = convert_expr_to_str(
         &computed_prop_name.expr,
         &mut self.state,

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_computed_prop_name.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_computed_prop_name.rs
@@ -22,10 +22,6 @@ where
     &mut self,
     computed_prop_name: &mut ComputedPropName,
   ) {
-    if self.state.cycle == TransformationCycle::Skip {
-      return;
-    }
-
     if self.state.cycle == TransformationCycle::StateFilling && computed_prop_name.expr.is_lit() {
       let expt_str = convert_expr_to_str(
         &computed_prop_name.expr,

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_decl.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_decl.rs
@@ -14,7 +14,7 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_export_decl_impl(&mut self, export_decl: &mut ExportDecl) {
-    if self.state.cycle == TransformationCycle::StateFilling
+    if self.state.cycle == TransformationCycle::Discover
       && let Decl::Var(var_decl) = &export_decl.decl
     {
       for decl in &var_decl.decls {

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_decl.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_decl.rs
@@ -14,10 +14,6 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_export_decl_impl(&mut self, export_decl: &mut ExportDecl) {
-    if self.state.cycle == TransformationCycle::Skip {
-      return;
-    }
-
     if self.state.cycle == TransformationCycle::StateFilling
       && let Decl::Var(var_decl) = &export_decl.decl
     {

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_default_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_default_expr.rs
@@ -14,10 +14,6 @@ where
     &mut self,
     export_default_expr: &mut ExportDefaultExpr,
   ) {
-    if self.state.cycle == TransformationCycle::Skip {
-      return;
-    }
-
     if self.state.cycle == TransformationCycle::StateFilling {
       export_default_expr.visit_mut_children_with(self);
       return;

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_default_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_default_expr.rs
@@ -14,7 +14,7 @@ where
     &mut self,
     export_default_expr: &mut ExportDefaultExpr,
   ) {
-    if self.state.cycle == TransformationCycle::StateFilling {
+    if self.state.cycle == TransformationCycle::Discover {
       export_default_expr.visit_mut_children_with(self);
       return;
     }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_default_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_export_default_expr.rs
@@ -19,8 +19,8 @@ where
       return;
     }
 
-    if self.state.cycle == TransformationCycle::TransformEnter
-      || self.state.cycle == TransformationCycle::TransformExit
+    if self.state.cycle == TransformationCycle::TransformProducers
+      || self.state.cycle == TransformationCycle::TransformConsumers
     {
       let normalized_expr = normalize_expr(&mut export_default_expr.expr);
 

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_expr.rs
@@ -13,11 +13,12 @@ where
   pub(crate) fn visit_mut_expr_impl(&mut self, expr: &mut Expr) {
     let normalized_expr = normalize_expr(expr);
 
-    // During Initializing, transform compiled JSX/VDOM calls with sx prop:
+    // During Discover, transform compiled JSX/VDOM calls with sx prop and
+    // register call expressions for downstream lookup:
     // React/Vue: _jsx("div", { sx: expr }) → _jsx("div", { ...stylex.props(expr) })
     // Solid.js:  _$setAttribute(el, "sx", expr) → _$spread(el, _$mergeProps(() =>
     // stylex.props(expr)), false, true)
-    if self.state.cycle == TransformationCycle::Initializing {
+    if self.state.cycle == TransformationCycle::Discover {
       if let Some(transformed) = self.transform_sx_in_compiled_jsx(normalized_expr) {
         *expr = transformed;
         expr.visit_mut_children_with(self);
@@ -28,12 +29,10 @@ where
         expr.visit_mut_children_with(self);
         return;
       }
-    }
 
-    if self.state.cycle == TransformationCycle::StateFilling
-      && let Some(call_expr) = normalized_expr.as_call()
-    {
-      self.state.add_call_expression(call_expr);
+      if let Some(call_expr) = normalized_expr.as_call() {
+        self.state.add_call_expression(call_expr);
+      }
     }
 
     if (self.state.cycle == TransformationCycle::TransformEnter

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_expr.rs
@@ -35,8 +35,8 @@ where
       }
     }
 
-    if (self.state.cycle == TransformationCycle::TransformEnter
-      || self.state.cycle == TransformationCycle::TransformExit)
+    if (self.state.cycle == TransformationCycle::TransformProducers
+      || self.state.cycle == TransformationCycle::TransformConsumers)
       && let Some(value) = self.transform_call_expression(normalized_expr)
     {
       *expr = value;

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_expr.rs
@@ -11,10 +11,6 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_expr_impl(&mut self, expr: &mut Expr) {
-    if self.state.cycle == TransformationCycle::Skip {
-      return;
-    }
-
     let normalized_expr = normalize_expr(expr);
 
     // During Initializing, transform compiled JSX/VDOM calls with sx prop:

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_ident.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_ident.rs
@@ -1,9 +1,6 @@
 use swc_core::{common::comments::Comments, ecma::ast::Ident};
 
-use crate::{
-  StyleXTransform,
-  shared::utils::common::{increase_ident_count, reduce_ident_count},
-};
+use crate::{StyleXTransform, shared::utils::common::increase_ident_count};
 use stylex_enums::core::TransformationCycle;
 
 impl<C> StyleXTransform<C>
@@ -11,14 +8,8 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_ident_impl(&mut self, ident: &mut Ident) {
-    match self.state.cycle {
-      TransformationCycle::StateFilling => {
-        increase_ident_count(&mut self.state, ident);
-      },
-      TransformationCycle::Recounting => {
-        reduce_ident_count(&mut self.state, ident);
-      },
-      _ => {},
-    };
+    if self.state.cycle == TransformationCycle::StateFilling {
+      increase_ident_count(&mut self.state, ident);
+    }
   }
 }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_ident.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_ident.rs
@@ -8,7 +8,7 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_ident_impl(&mut self, ident: &mut Ident) {
-    if self.state.cycle == TransformationCycle::StateFilling {
+    if self.state.cycle == TransformationCycle::Discover {
       increase_ident_count(&mut self.state, ident);
     }
   }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_import_decl.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_import_decl.rs
@@ -18,7 +18,7 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_import_decl_impl(&mut self, import_decl: &mut ImportDecl) {
-    if self.state.cycle == TransformationCycle::Initializing {
+    if self.state.cycle == TransformationCycle::Discover {
       if import_decl.type_only {
         return;
       }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_import_decl.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_import_decl.rs
@@ -18,10 +18,6 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_import_decl_impl(&mut self, import_decl: &mut ImportDecl) {
-    if self.state.cycle == TransformationCycle::Skip {
-      return;
-    }
-
     if self.state.cycle == TransformationCycle::Initializing {
       if import_decl.type_only {
         return;

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_jsx_attr_or_spread.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_jsx_attr_or_spread.rs
@@ -27,10 +27,10 @@ where
       }
     }
 
-    // The JSX-spread replacement that used to live in the `PreCleaning` arm
-    // now happens in the `mark_style_vars_to_keep` helper that runs at the
-    // start of the finalize phase, so this hook only needs to descend in
-    // every other cycle.
+    // JSX-spread replacement no longer happens in this hook; it now runs in
+    // `mark_style_vars_to_keep` at the start of the finalize phase. The
+    // cycle-specific work here is only collecting spread expressions during
+    // `Discover`; traversal still descends into children on every cycle.
     jsx_attrs.visit_mut_children_with(self);
   }
 }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_jsx_attr_or_spread.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_jsx_attr_or_spread.rs
@@ -16,7 +16,7 @@ where
     jsx_attrs: &mut Vec<JSXAttrOrSpread>,
   ) {
     match self.state.cycle {
-      TransformationCycle::Initializing => {
+      TransformationCycle::Discover => {
         for jsx_attr in jsx_attrs.iter() {
           if let JSXAttrOrSpread::SpreadElement(spread) = jsx_attr {
             let expr = drop_span(spread.expr.as_ref().clone());

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_jsx_attr_or_spread.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_jsx_attr_or_spread.rs
@@ -4,7 +4,6 @@ use swc_core::{
 };
 
 use crate::StyleXTransform;
-use stylex_ast::ast::factories::{create_jsx_attr_or_spread, create_jsx_spread_attr};
 use stylex_enums::core::TransformationCycle;
 
 impl<C> StyleXTransform<C>
@@ -15,51 +14,23 @@ where
     &mut self,
     jsx_attrs: &mut Vec<JSXAttrOrSpread>,
   ) {
-    match self.state.cycle {
-      TransformationCycle::Discover => {
-        for jsx_attr in jsx_attrs.iter() {
-          if let JSXAttrOrSpread::SpreadElement(spread) = jsx_attr {
-            let expr = drop_span(spread.expr.as_ref().clone());
-            self
-              .state
-              .jsx_spread_attr_exprs_map
-              .entry(expr)
-              .or_default();
-          }
+    if self.state.cycle == TransformationCycle::Discover {
+      for jsx_attr in jsx_attrs.iter() {
+        if let JSXAttrOrSpread::SpreadElement(spread) = jsx_attr {
+          let expr = drop_span(spread.expr.as_ref().clone());
+          self
+            .state
+            .jsx_spread_attr_exprs_map
+            .entry(expr)
+            .or_default();
         }
-        jsx_attrs.visit_mut_children_with(self);
-      },
-      TransformationCycle::PreCleaning => {
-        let mut result: Vec<JSXAttrOrSpread> = jsx_attrs
-          .iter()
-          .flat_map(|jsx_attr| match jsx_attr {
-            JSXAttrOrSpread::SpreadElement(spread) => {
-              let expr = drop_span(spread.expr.as_ref().clone());
-              if let Some(updated_exprs) = self.state.jsx_spread_attr_exprs_map.get(&expr).cloned()
-              {
-                if updated_exprs.is_empty() {
-                  // If the spread was resolved to nothing, remove it
-                  vec![jsx_attr.clone()]
-                } else {
-                  // Replace the spread with the updated expressions
-                  updated_exprs
-                }
-              } else {
-                // If no replacement found, keep the original spread element
-                vec![create_jsx_spread_attr(*spread.expr.clone())]
-              }
-            },
-            JSXAttrOrSpread::JSXAttr(attr) => {
-              // Keep regular attributes as-is (wrapped in vec for flat_map)
-              vec![create_jsx_attr_or_spread(attr.clone())]
-            },
-          })
-          .collect();
-
-        result.visit_mut_children_with(self);
-        *jsx_attrs = result;
-      },
-      _ => jsx_attrs.visit_mut_children_with(self),
+      }
     }
+
+    // The JSX-spread replacement that used to live in the `PreCleaning` arm
+    // now happens in the `mark_style_vars_to_keep` helper that runs at the
+    // start of the finalize phase, so this hook only needs to descend in
+    // every other cycle.
+    jsx_attrs.visit_mut_children_with(self);
   }
 }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_jsx_opening_element.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_jsx_opening_element.rs
@@ -27,8 +27,8 @@ where
     &mut self,
     jsx_opening_element: &mut JSXOpeningElement,
   ) {
-    // Only transform during Initializing cycle
-    if self.state.cycle != TransformationCycle::Initializing {
+    // Only transform during Discover cycle
+    if self.state.cycle != TransformationCycle::Discover {
       jsx_opening_element.visit_mut_children_with(self);
       return;
     }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_expr.rs
@@ -23,7 +23,7 @@ where
 {
   pub(crate) fn visit_mut_member_expr_impl(&mut self, member_expression: &mut MemberExpr) {
     match self.state.cycle {
-      TransformationCycle::StateFilling => {
+      TransformationCycle::Discover => {
         if let Some(obj_ident) = member_expression.obj.as_ident() {
           increase_member_ident_count(&mut self.state, &obj_ident.sym);
         }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_expr.rs
@@ -23,7 +23,6 @@ where
 {
   pub(crate) fn visit_mut_member_expr_impl(&mut self, member_expression: &mut MemberExpr) {
     match self.state.cycle {
-      TransformationCycle::Skip => {},
       TransformationCycle::StateFilling => {
         if let Some(obj_ident) = member_expression.obj.as_ident() {
           increase_member_ident_count(&mut self.state, &obj_ident.sym);

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_expr.rs
@@ -14,9 +14,7 @@ use stylex_structures::style_vars_to_keep::StyleVarsToKeep;
 
 use crate::{
   StyleXTransform,
-  shared::utils::common::{
-    increase_ident_count, increase_member_ident_count, reduce_member_ident_count,
-  },
+  shared::utils::common::{increase_ident_count, increase_member_ident_count},
 };
 
 impl<C> StyleXTransform<C>
@@ -29,12 +27,6 @@ where
       TransformationCycle::StateFilling => {
         if let Some(obj_ident) = member_expression.obj.as_ident() {
           increase_member_ident_count(&mut self.state, &obj_ident.sym);
-        }
-        member_expression.visit_mut_children_with(self);
-      },
-      TransformationCycle::Recounting => {
-        if let Some(obj_ident) = member_expression.obj.as_ident() {
-          reduce_member_ident_count(&mut self.state, &obj_ident.sym);
         }
         member_expression.visit_mut_children_with(self);
       },

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_expr.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_expr.rs
@@ -1,66 +1,23 @@
 use swc_core::{
   common::comments::Comments,
-  ecma::{
-    ast::{Expr, MemberExpr, MemberProp},
-    visit::VisitMutWith,
-  },
+  ecma::{ast::MemberExpr, visit::VisitMutWith},
 };
 
-use stylex_enums::{
-  core::TransformationCycle,
-  style_vars_to_keep::{NonNullProp, NonNullProps},
-};
-use stylex_structures::style_vars_to_keep::StyleVarsToKeep;
+use stylex_enums::core::TransformationCycle;
 
-use crate::{
-  StyleXTransform,
-  shared::utils::common::{increase_ident_count, increase_member_ident_count},
-};
+use crate::{StyleXTransform, shared::utils::common::increase_member_ident_count};
 
 impl<C> StyleXTransform<C>
 where
   C: Comments,
 {
   pub(crate) fn visit_mut_member_expr_impl(&mut self, member_expression: &mut MemberExpr) {
-    match self.state.cycle {
-      TransformationCycle::Discover => {
-        if let Some(obj_ident) = member_expression.obj.as_ident() {
-          increase_member_ident_count(&mut self.state, &obj_ident.sym);
-        }
-        member_expression.visit_mut_children_with(self);
-      },
-      TransformationCycle::PreCleaning => {
-        if let Expr::Ident(ident) = member_expression.obj.as_ref()
-          && self.state.style_map.contains_key(ident.sym.as_ref())
-        {
-          if let MemberProp::Ident(prop_ident) = &member_expression.prop
-            && self
-              .state
-              .member_object_ident_count_map
-              .get(&ident.sym)
-              .is_some_and(|&c| c > 0)
-          {
-            increase_ident_count(&mut self.state, ident);
-            self.state.style_vars_to_keep.insert(StyleVarsToKeep(
-              ident.sym.clone(),
-              NonNullProp::Atom(prop_ident.sym.clone()),
-              NonNullProps::True,
-            ));
-          };
-
-          if let MemberProp::Computed(_) = &member_expression.prop {
-            increase_ident_count(&mut self.state, ident);
-            self.state.style_vars_to_keep.insert(StyleVarsToKeep(
-              ident.sym.clone(),
-              NonNullProp::True,
-              NonNullProps::True,
-            ));
-          }
-        }
-
-        member_expression.visit_mut_children_with(self);
-      },
-      _ => member_expression.visit_mut_children_with(self),
+    if self.state.cycle == TransformationCycle::Discover
+      && let Some(obj_ident) = member_expression.obj.as_ident()
+    {
+      increase_member_ident_count(&mut self.state, &obj_ident.sym);
     }
+
+    member_expression.visit_mut_children_with(self);
   }
 }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_prop.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_prop.rs
@@ -13,8 +13,7 @@ where
   pub(crate) fn visit_mut_member_prop_impl(&mut self, member_prop: &mut MemberProp) {
     match self.state.cycle {
       TransformationCycle::Skip => {},
-      TransformationCycle::StateFilling | TransformationCycle::Recounting
-        if member_prop.is_ident() => {},
+      TransformationCycle::StateFilling if member_prop.is_ident() => {},
       _ => member_prop.visit_mut_children_with(self),
     }
   }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_prop.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_prop.rs
@@ -12,7 +12,7 @@ where
 {
   pub(crate) fn visit_mut_member_prop_impl(&mut self, member_prop: &mut MemberProp) {
     match self.state.cycle {
-      TransformationCycle::StateFilling if member_prop.is_ident() => {},
+      TransformationCycle::Discover if member_prop.is_ident() => {},
       _ => member_prop.visit_mut_children_with(self),
     }
   }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_prop.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_member_prop.rs
@@ -12,7 +12,6 @@ where
 {
   pub(crate) fn visit_mut_member_prop_impl(&mut self, member_prop: &mut MemberProp) {
     match self.state.cycle {
-      TransformationCycle::Skip => {},
       TransformationCycle::StateFilling if member_prop.is_ident() => {},
       _ => member_prop.visit_mut_children_with(self),
     }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -27,7 +27,9 @@ where
       module.visit_mut_children_with(self);
 
       self.state.cycle = TransformationCycle::TransformExit;
+      self.state.evaluate_preserve_bindings = true;
       module.visit_mut_children_with(self);
+      self.state.evaluate_preserve_bindings = false;
 
       if self.state.options.runtime_injection.is_some() {
         self.state.cycle = TransformationCycle::InjectStyles;

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -3,7 +3,11 @@ use swc_core::{
   ecma::{ast::Module, visit::VisitMutWith},
 };
 
-use crate::{StyleXTransform, shared::utils::common::fill_top_level_expressions};
+use crate::{
+  StyleXTransform,
+  shared::utils::common::fill_top_level_expressions,
+  transform::visit_mut::visit_mut_module_items::inject_runtime_styles,
+};
 use stylex_enums::core::TransformationCycle;
 
 impl<C> StyleXTransform<C>
@@ -66,8 +70,7 @@ where
     self.state.evaluate_preserve_bindings = false;
 
     if self.state.options.runtime_injection.is_some() {
-      self.state.cycle = TransformationCycle::InjectStyles;
-      module.visit_mut_children_with(self);
+      inject_runtime_styles(&self.state, &mut module.body);
     }
   }
 

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -5,7 +5,9 @@ use swc_core::{
 
 use crate::{
   StyleXTransform,
-  shared::utils::common::fill_top_level_expressions,
+  shared::{
+    structures::state_manager::mark_style_vars_to_keep, utils::common::fill_top_level_expressions,
+  },
   transform::visit_mut::visit_mut_module_items::inject_runtime_styles,
 };
 use stylex_enums::core::TransformationCycle;
@@ -47,24 +49,25 @@ where
     }
   }
 
-  /// Run the producer transformation pass (`TransformEnter`).
+  /// Run the producer transformation pass.
   ///
   /// Transforms `stylex.create` / `defineVars` / `keyframes` / etc. — the calls
   /// that *produce* style namespaces consumed by later phases.
   pub(crate) fn transform_producers(&mut self, module: &mut Module) {
-    self.state.cycle = TransformationCycle::TransformEnter;
+    self.state.cycle = TransformationCycle::TransformProducers;
     module.visit_mut_children_with(self);
   }
 
   /// Run the consumer transformation pass plus runtime style injection.
   ///
   /// Transforms `stylex.props` / `stylex.attrs` (which consume the style
-  /// namespaces produced by the prior phase) under `TransformExit`, with the
+  /// namespaces produced by the prior phase) with the
   /// `evaluate_preserve_bindings` flag held for the duration of the walk so
   /// the evaluator does not decrement binding counts on call arguments. Then,
-  /// if runtime injection is enabled, runs the `InjectStyles` pass.
+  /// if runtime injection is enabled, prepends the accumulated style metadata
+  /// to the module body in place (no extra tree walk needed).
   pub(crate) fn transform_consumers(&mut self, module: &mut Module) {
-    self.state.cycle = TransformationCycle::TransformExit;
+    self.state.cycle = TransformationCycle::TransformConsumers;
     self.state.evaluate_preserve_bindings = true;
     module.visit_mut_children_with(self);
     self.state.evaluate_preserve_bindings = false;
@@ -74,23 +77,25 @@ where
     }
   }
 
-  /// Run the cleanup phases (`PreCleaning` + `Cleaning`).
+  /// Run the cleanup phase: mark surviving style accesses, then sweep
+  /// unused declarations.
   ///
-  /// First marks which style namespaces / object properties survive (member
-  /// accesses left after consumer transformation). Then runs the sweep with
-  /// the module body reversed so removing later declarations does not
-  /// invalidate the counts of earlier ones; the body is restored to original
-  /// order afterwards.
+  /// The mark step (formerly the `PreCleaning` cycle) is delegated to the
+  /// `mark_style_vars_to_keep` helper, which walks the module once and
+  /// populates `state.style_vars_to_keep` plus materializes any deferred
+  /// JSX-spread replacements. The sweep step then runs under
+  /// `TransformationCycle::Finalize` with `module.body` reversed so removing
+  /// later declarations does not invalidate the counts of earlier ones; the
+  /// body is restored to original order afterwards.
   pub(crate) fn finalize_module(&mut self, module: &mut Module) {
-    self.state.cycle = TransformationCycle::PreCleaning;
-    module.visit_mut_children_with(self);
+    mark_style_vars_to_keep(module, &mut self.state);
 
-    self.state.cycle = TransformationCycle::Cleaning;
+    self.state.cycle = TransformationCycle::Finalize;
 
     // NOTE: Reversing the module body to clean the module items in the correct
-    // order, so removing unused variable declarations will more efficient
-    // After cleaning the module items, the module body will be reversed back to
-    // its original order
+    // order, so removing unused variable declarations will more efficient.
+    // After cleaning the module items, the module body will be reversed back
+    // to its original order.
     module.body.reverse();
 
     module.visit_mut_children_with(self);

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -30,19 +30,19 @@ where
     self.finalize_module(module);
   }
 
-  /// Run the discovery pass (`Initializing` + `StateFilling`).
+  /// Run the discovery pass.
   ///
-  /// Walks the module once with the implicit `Initializing` cycle to populate
-  /// import/JSX-sx state, then — if stylex was actually imported — walks again
-  /// under `StateFilling` to fill var-decl counts, top-level expressions, and
-  /// related metadata.
+  /// Walks the module once under the `Discover` cycle, populating import
+  /// state, transforming compiled-JSX `sx` attributes, counting variable /
+  /// member-expression references, and pre-filling top-level declarations —
+  /// all the work the legacy `Initializing` + `StateFilling` two-pass split
+  /// used to do separately. Whenever stylex was imported, also captures the
+  /// top-level expressions consumed by later phases.
   pub(crate) fn discover_module(&mut self, module: &mut Module) {
+    self.state.cycle = TransformationCycle::Discover;
     module.visit_mut_children_with(self);
 
     if self.state.has_import_paths() {
-      self.state.cycle = TransformationCycle::StateFilling;
-      module.visit_mut_children_with(self);
-
       fill_top_level_expressions(module, &mut self.state);
     }
   }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -93,7 +93,7 @@ where
     self.state.cycle = TransformationCycle::Finalize;
 
     // NOTE: Reversing the module body to clean the module items in the correct
-    // order, so removing unused variable declarations will more efficient.
+    // order, so removing unused variable declarations will be more efficient.
     // After cleaning the module items, the module body will be reversed back
     // to its original order.
     module.body.reverse();

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -54,4 +54,80 @@ where
       self.state.cycle = TransformationCycle::Skip;
     }
   }
+
+  /// Run the discovery pass (`Initializing` + `StateFilling`).
+  ///
+  /// Walks the module once with the implicit `Initializing` cycle to populate
+  /// import/JSX-sx state, then — if stylex was actually imported — walks again
+  /// under `StateFilling` to fill var-decl counts, top-level expressions, and
+  /// related metadata.
+  ///
+  /// Wired up by a follow-up commit; behaviorally a thin extraction of the
+  /// existing driver logic.
+  #[allow(dead_code)]
+  pub(crate) fn discover_module(&mut self, module: &mut Module) {
+    module.visit_mut_children_with(self);
+
+    if self.state.has_import_paths() {
+      self.state.cycle = TransformationCycle::StateFilling;
+      module.visit_mut_children_with(self);
+
+      fill_top_level_expressions(module, &mut self.state);
+    }
+  }
+
+  /// Run the producer transformation pass (`TransformEnter`).
+  ///
+  /// Transforms `stylex.create` / `defineVars` / `keyframes` / etc. — the calls
+  /// that *produce* style namespaces consumed by later phases.
+  #[allow(dead_code)]
+  pub(crate) fn transform_producers(&mut self, module: &mut Module) {
+    self.state.cycle = TransformationCycle::TransformEnter;
+    module.visit_mut_children_with(self);
+  }
+
+  /// Run the consumer transformation pass plus runtime style injection.
+  ///
+  /// Transforms `stylex.props` / `stylex.attrs` (which consume the style
+  /// namespaces produced by the prior phase) under `TransformExit`, with the
+  /// `evaluate_preserve_bindings` flag held for the duration of the walk so
+  /// the evaluator does not decrement binding counts on call arguments. Then,
+  /// if runtime injection is enabled, runs the `InjectStyles` pass.
+  #[allow(dead_code)]
+  pub(crate) fn transform_consumers(&mut self, module: &mut Module) {
+    self.state.cycle = TransformationCycle::TransformExit;
+    self.state.evaluate_preserve_bindings = true;
+    module.visit_mut_children_with(self);
+    self.state.evaluate_preserve_bindings = false;
+
+    if self.state.options.runtime_injection.is_some() {
+      self.state.cycle = TransformationCycle::InjectStyles;
+      module.visit_mut_children_with(self);
+    }
+  }
+
+  /// Run the cleanup phases (`PreCleaning` + `Cleaning`).
+  ///
+  /// First marks which style namespaces / object properties survive (member
+  /// accesses left after consumer transformation). Then runs the sweep with
+  /// the module body reversed so removing later declarations does not
+  /// invalidate the counts of earlier ones; the body is restored to original
+  /// order afterwards.
+  #[allow(dead_code)]
+  pub(crate) fn finalize_module(&mut self, module: &mut Module) {
+    self.state.cycle = TransformationCycle::PreCleaning;
+    module.visit_mut_children_with(self);
+
+    self.state.cycle = TransformationCycle::Cleaning;
+
+    // NOTE: Reversing the module body to clean the module items in the correct
+    // order, so removing unused variable declarations will more efficient
+    // After cleaning the module items, the module body will be reversed back to
+    // its original order
+    module.body.reverse();
+
+    module.visit_mut_children_with(self);
+
+    module.body.reverse();
+  }
 }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -18,7 +18,6 @@ where
     self.discover_module(module);
 
     if !self.state.has_import_paths() {
-      self.state.cycle = TransformationCycle::Skip;
       return;
     }
 

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -15,44 +15,16 @@ where
       self.state.set_seen_module_source_code(module, None);
     }
 
-    module.visit_mut_children_with(self);
+    self.discover_module(module);
 
-    if self.state.has_import_paths() {
-      self.state.cycle = TransformationCycle::StateFilling;
-      module.visit_mut_children_with(self);
-
-      fill_top_level_expressions(module, &mut self.state);
-
-      self.state.cycle = TransformationCycle::TransformEnter;
-      module.visit_mut_children_with(self);
-
-      self.state.cycle = TransformationCycle::TransformExit;
-      self.state.evaluate_preserve_bindings = true;
-      module.visit_mut_children_with(self);
-      self.state.evaluate_preserve_bindings = false;
-
-      if self.state.options.runtime_injection.is_some() {
-        self.state.cycle = TransformationCycle::InjectStyles;
-        module.visit_mut_children_with(self);
-      }
-
-      self.state.cycle = TransformationCycle::PreCleaning;
-      module.visit_mut_children_with(self);
-
-      self.state.cycle = TransformationCycle::Cleaning;
-
-      // NOTE: Reversing the module body to clean the module items in the correct
-      // order, so removing unused variable declarations will more efficient
-      // After cleaning the module items, the module body will be reversed back to its
-      // original order
-      module.body.reverse();
-
-      module.visit_mut_children_with(self);
-
-      module.body.reverse();
-    } else {
+    if !self.state.has_import_paths() {
       self.state.cycle = TransformationCycle::Skip;
+      return;
     }
+
+    self.transform_producers(module);
+    self.transform_consumers(module);
+    self.finalize_module(module);
   }
 
   /// Run the discovery pass (`Initializing` + `StateFilling`).
@@ -61,10 +33,6 @@ where
   /// import/JSX-sx state, then — if stylex was actually imported — walks again
   /// under `StateFilling` to fill var-decl counts, top-level expressions, and
   /// related metadata.
-  ///
-  /// Wired up by a follow-up commit; behaviorally a thin extraction of the
-  /// existing driver logic.
-  #[allow(dead_code)]
   pub(crate) fn discover_module(&mut self, module: &mut Module) {
     module.visit_mut_children_with(self);
 
@@ -80,7 +48,6 @@ where
   ///
   /// Transforms `stylex.create` / `defineVars` / `keyframes` / etc. — the calls
   /// that *produce* style namespaces consumed by later phases.
-  #[allow(dead_code)]
   pub(crate) fn transform_producers(&mut self, module: &mut Module) {
     self.state.cycle = TransformationCycle::TransformEnter;
     module.visit_mut_children_with(self);
@@ -93,7 +60,6 @@ where
   /// `evaluate_preserve_bindings` flag held for the duration of the walk so
   /// the evaluator does not decrement binding counts on call arguments. Then,
   /// if runtime injection is enabled, runs the `InjectStyles` pass.
-  #[allow(dead_code)]
   pub(crate) fn transform_consumers(&mut self, module: &mut Module) {
     self.state.cycle = TransformationCycle::TransformExit;
     self.state.evaluate_preserve_bindings = true;
@@ -113,7 +79,6 @@ where
   /// the module body reversed so removing later declarations does not
   /// invalidate the counts of earlier ones; the body is restored to original
   /// order afterwards.
-  #[allow(dead_code)]
   pub(crate) fn finalize_module(&mut self, module: &mut Module) {
     self.state.cycle = TransformationCycle::PreCleaning;
     module.visit_mut_children_with(self);

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
@@ -84,10 +84,8 @@ where
           module_items.extend(side_effect_imports);
         }
       },
-      TransformationCycle::TransformEnter | TransformationCycle::PreCleaning => {
-        module_items.visit_mut_children_with(self)
-      },
-      TransformationCycle::TransformExit => {
+      TransformationCycle::TransformProducers => module_items.visit_mut_children_with(self),
+      TransformationCycle::TransformConsumers => {
         if self.state.hoisted_module_items.is_empty() {
           module_items.visit_mut_children_with(self);
           return;
@@ -112,7 +110,7 @@ where
 
         *module_items = result_module_items;
       },
-      TransformationCycle::Cleaning => {
+      TransformationCycle::Finalize => {
         // We need it twice for a clear dead code after declaration transforms
         module_items.visit_mut_children_with(self);
 

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
@@ -30,10 +30,10 @@ where
   pub(crate) fn visit_mut_module_items_impl(&mut self, module_items: &mut Vec<ModuleItem>) {
     match self.state.cycle {
       TransformationCycle::Discover => {
-        // Pre-fill `state.declarations` for top-level binding-pattern var
-        // decls so any subsequent lookup during the descent (or in later
-        // phases) can find them. The visit_mut_var_declarator hook will
-        // re-fill them per-decl, but `fill_state_declarations` is idempotent.
+        // Pre-fill `state.declarations` for top-level ident var decls so any
+        // subsequent lookup during the descent (or in later phases) can find
+        // them. The visit_mut_var_declarator hook will re-fill them
+        // per-decl, but `fill_state_declarations` is idempotent.
         module_items.iter().for_each(|module_item| {
           if let ModuleItem::Stmt(Stmt::Decl(Decl::Var(var_decl))) = module_item {
             var_decl.decls.iter().for_each(|decl| {

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
@@ -29,7 +29,23 @@ where
 {
   pub(crate) fn visit_mut_module_items_impl(&mut self, module_items: &mut Vec<ModuleItem>) {
     match self.state.cycle {
-      TransformationCycle::Initializing => {
+      TransformationCycle::Discover => {
+        // Pre-fill `state.declarations` for top-level binding-pattern var
+        // decls so any subsequent lookup during the descent (or in later
+        // phases) can find them. The visit_mut_var_declarator hook will
+        // re-fill them per-decl, but `fill_state_declarations` is idempotent.
+        module_items.iter().for_each(|module_item| {
+          if let ModuleItem::Stmt(Stmt::Decl(Decl::Var(var_decl))) = module_item {
+            var_decl.decls.iter().for_each(|decl| {
+              if let Pat::Ident(_) = &decl.name {
+                fill_state_declarations(&mut self.state, decl);
+              }
+            });
+          }
+        });
+
+        // Single descent: discovers stylex imports, transforms compiled-JSX
+        // sx attributes, and accumulates ident / member-expr counts.
         module_items.visit_mut_children_with(self);
 
         if !self.state.has_import_paths() {
@@ -67,19 +83,6 @@ where
 
           module_items.extend(side_effect_imports);
         }
-      },
-      TransformationCycle::StateFilling => {
-        module_items.iter().for_each(|module_item| {
-          if let ModuleItem::Stmt(Stmt::Decl(Decl::Var(var_decl))) = module_item {
-            var_decl.decls.iter().for_each(|decl| {
-              if let Pat::Ident(_) = &decl.name {
-                fill_state_declarations(&mut self.state, decl);
-              }
-            });
-          }
-        });
-
-        module_items.visit_mut_children_with(self);
       },
       TransformationCycle::TransformEnter | TransformationCycle::PreCleaning => {
         module_items.visit_mut_children_with(self)

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
@@ -26,12 +26,10 @@ where
 {
   pub(crate) fn visit_mut_module_items_impl(&mut self, module_items: &mut Vec<ModuleItem>) {
     match self.state.cycle {
-      TransformationCycle::Skip => {},
       TransformationCycle::Initializing => {
         module_items.visit_mut_children_with(self);
 
         if !self.state.has_import_paths() {
-          self.state.cycle = TransformationCycle::Skip;
           return;
         }
 

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
@@ -80,9 +80,9 @@ where
 
         module_items.visit_mut_children_with(self);
       },
-      TransformationCycle::TransformEnter
-      | TransformationCycle::PreCleaning
-      | TransformationCycle::Recounting => module_items.visit_mut_children_with(self),
+      TransformationCycle::TransformEnter | TransformationCycle::PreCleaning => {
+        module_items.visit_mut_children_with(self)
+      },
       TransformationCycle::TransformExit => {
         if self.state.hoisted_module_items.is_empty() {
           module_items.visit_mut_children_with(self);

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module_items.rs
@@ -12,7 +12,10 @@ use swc_core::{
 
 use crate::{
   StyleXTransform,
-  shared::utils::{ast::convertors::convert_atom_to_string, common::fill_state_declarations},
+  shared::{
+    structures::state_manager::StateManager,
+    utils::{ast::convertors::convert_atom_to_string, common::fill_state_declarations},
+  },
 };
 use stylex_ast::ast::factories::create_binding_ident;
 use stylex_constants::constants::messages::VAR_DECL_INIT_REQUIRED;
@@ -106,99 +109,6 @@ where
 
         *module_items = result_module_items;
       },
-      TransformationCycle::InjectStyles => {
-        // InjectStyles must run after import discovery because injected rules
-        // are keyed by declarations collected during earlier cycles.
-        debug_assert!(self.state.are_imports_resolved());
-
-        let mut result_module_items: Vec<ModuleItem> =
-          self.state.prepend_include_module_items.clone();
-
-        result_module_items.extend(self.state.prepend_import_module_items.clone());
-
-        let mut items_to_skip: usize = 0;
-
-        if let Some(first) = module_items
-          .first()
-          .and_then(|first| first.as_stmt())
-          .and_then(|stmp| stmp.as_expr())
-          && let Some(Lit::Str(_)) = first.expr.as_lit()
-        {
-          result_module_items.insert(
-            0,
-            match module_items.first() {
-              Some(item) => item.clone(),
-              #[cfg_attr(coverage_nightly, coverage(off))]
-              None => stylex_panic!("Module items list is unexpectedly empty."),
-            },
-          );
-          items_to_skip = 1;
-        }
-
-        for module_item in module_items.iter().skip(items_to_skip) {
-          if let Some(decls) = match &module_item {
-            ModuleItem::ModuleDecl(decl) => match decl {
-              ModuleDecl::ExportDecl(export_decl) => export_decl.decl.as_var().map(|var_decl| {
-                var_decl
-                  .decls
-                  .iter()
-                  .filter(|decl| {
-                    decl
-                      .init
-                      .as_ref()
-                      .is_some_and(|init| init.is_object() || init.is_lit())
-                  })
-                  .cloned()
-                  .collect::<Vec<VarDeclarator>>()
-              }),
-              ModuleDecl::ExportDefaultExpr(export_default_expr) => {
-                export_default_expr.expr.as_object().map(|obj| {
-                  vec![VarDeclarator {
-                    definite: true,
-                    span: DUMMY_SP,
-                    name: Pat::Ident(create_binding_ident(Ident::from("default"))),
-                    init: Some(Box::new(Expr::from(obj.clone()))),
-                  }]
-                })
-              },
-              _ => None,
-            },
-            ModuleItem::Stmt(Stmt::Decl(Decl::Var(var_decl))) => Some(
-              var_decl
-                .decls
-                .iter()
-                .filter(|decl| {
-                  decl
-                    .init
-                    .as_ref()
-                    .is_some_and(|init| init.is_object() || init.is_lit())
-                })
-                .cloned()
-                .collect::<Vec<VarDeclarator>>(),
-            ),
-            _ => None,
-          } {
-            for decl in decls {
-              let key = match decl.init.as_ref() {
-                Some(k) => k,
-                #[cfg_attr(coverage_nightly, coverage(off))]
-                None => stylex_panic!("{}", VAR_DECL_INIT_REQUIRED),
-              };
-
-              let key_hash = stable_hash(key.as_ref());
-
-              if let Some(metadata_items) = self.state.styles_to_inject_for(&key_hash) {
-                for module_item in metadata_items.iter() {
-                  result_module_items.push(module_item.clone());
-                }
-              }
-            }
-          }
-          result_module_items.push(module_item.clone());
-        }
-
-        *module_items = result_module_items;
-      },
       TransformationCycle::Cleaning => {
         // We need it twice for a clear dead code after declaration transforms
         module_items.visit_mut_children_with(self);
@@ -212,4 +122,105 @@ where
       },
     }
   }
+}
+
+/// Prepend the accumulated injection items and interleave per-decl style
+/// metadata into a module body.
+///
+/// Replaces the legacy `TransformationCycle::InjectStyles` walk: the work was
+/// always module-body-level (no per-node descent), so the plugin no longer
+/// needs a full `visit_mut_children_with` pass to do it. Called from
+/// `transform_consumers` after the consumer walk finishes when runtime
+/// injection is enabled.
+pub(crate) fn inject_runtime_styles(state: &StateManager, module_items: &mut Vec<ModuleItem>) {
+  // InjectStyles must run after import discovery because injected rules
+  // are keyed by declarations collected during earlier cycles.
+  debug_assert!(state.are_imports_resolved());
+
+  let mut result_module_items: Vec<ModuleItem> = state.prepend_include_module_items.clone();
+
+  result_module_items.extend(state.prepend_import_module_items.clone());
+
+  let mut items_to_skip: usize = 0;
+
+  if let Some(first) = module_items
+    .first()
+    .and_then(|first| first.as_stmt())
+    .and_then(|stmp| stmp.as_expr())
+    && let Some(Lit::Str(_)) = first.expr.as_lit()
+  {
+    result_module_items.insert(
+      0,
+      match module_items.first() {
+        Some(item) => item.clone(),
+        #[cfg_attr(coverage_nightly, coverage(off))]
+        None => stylex_panic!("Module items list is unexpectedly empty."),
+      },
+    );
+    items_to_skip = 1;
+  }
+
+  for module_item in module_items.iter().skip(items_to_skip) {
+    if let Some(decls) = match &module_item {
+      ModuleItem::ModuleDecl(decl) => match decl {
+        ModuleDecl::ExportDecl(export_decl) => export_decl.decl.as_var().map(|var_decl| {
+          var_decl
+            .decls
+            .iter()
+            .filter(|decl| {
+              decl
+                .init
+                .as_ref()
+                .is_some_and(|init| init.is_object() || init.is_lit())
+            })
+            .cloned()
+            .collect::<Vec<VarDeclarator>>()
+        }),
+        ModuleDecl::ExportDefaultExpr(export_default_expr) => {
+          export_default_expr.expr.as_object().map(|obj| {
+            vec![VarDeclarator {
+              definite: true,
+              span: DUMMY_SP,
+              name: Pat::Ident(create_binding_ident(Ident::from("default"))),
+              init: Some(Box::new(Expr::from(obj.clone()))),
+            }]
+          })
+        },
+        _ => None,
+      },
+      ModuleItem::Stmt(Stmt::Decl(Decl::Var(var_decl))) => Some(
+        var_decl
+          .decls
+          .iter()
+          .filter(|decl| {
+            decl
+              .init
+              .as_ref()
+              .is_some_and(|init| init.is_object() || init.is_lit())
+          })
+          .cloned()
+          .collect::<Vec<VarDeclarator>>(),
+      ),
+      _ => None,
+    } {
+      for decl in decls {
+        let key = match decl.init.as_ref() {
+          Some(k) => k,
+          #[cfg_attr(coverage_nightly, coverage(off))]
+          None => stylex_panic!("{}", VAR_DECL_INIT_REQUIRED),
+        };
+
+        let key_hash = stable_hash(key.as_ref());
+
+        if let Some(metadata_items) = state.styles_to_inject_for(&key_hash) {
+          for module_item in metadata_items.iter() {
+            result_module_items.push(module_item.clone());
+          }
+        }
+      }
+    }
+    result_module_items.push(module_item.clone());
+  }
+
+  *module_items = result_module_items;
 }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_named_export.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_named_export.rs
@@ -11,7 +11,7 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_named_export_impl(&mut self, named_export: &mut NamedExport) {
-    if self.state.cycle == TransformationCycle::StateFilling {
+    if self.state.cycle == TransformationCycle::Discover {
       self.state.named_exports.insert(named_export.clone());
     }
 

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_named_export.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_named_export.rs
@@ -11,10 +11,6 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_named_export_impl(&mut self, named_export: &mut NamedExport) {
-    if self.state.cycle == TransformationCycle::Skip {
-      return;
-    }
-
     if self.state.cycle == TransformationCycle::StateFilling {
       self.state.named_exports.insert(named_export.clone());
     }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_prop_name.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_prop_name.rs
@@ -13,8 +13,7 @@ where
   pub(crate) fn visit_mut_prop_name_impl(&mut self, prop_name: &mut PropName) {
     match self.state.cycle {
       TransformationCycle::Skip => {},
-      TransformationCycle::StateFilling | TransformationCycle::Recounting
-        if prop_name.is_ident() => {},
+      TransformationCycle::StateFilling if prop_name.is_ident() => {},
       _ => prop_name.visit_mut_children_with(self),
     }
   }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_prop_name.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_prop_name.rs
@@ -12,7 +12,7 @@ where
 {
   pub(crate) fn visit_mut_prop_name_impl(&mut self, prop_name: &mut PropName) {
     match self.state.cycle {
-      TransformationCycle::StateFilling if prop_name.is_ident() => {},
+      TransformationCycle::Discover if prop_name.is_ident() => {},
       _ => prop_name.visit_mut_children_with(self),
     }
   }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_prop_name.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_prop_name.rs
@@ -12,7 +12,6 @@ where
 {
   pub(crate) fn visit_mut_prop_name_impl(&mut self, prop_name: &mut PropName) {
     match self.state.cycle {
-      TransformationCycle::Skip => {},
       TransformationCycle::StateFilling if prop_name.is_ident() => {},
       _ => prop_name.visit_mut_children_with(self),
     }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_stmt.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_stmt.rs
@@ -15,10 +15,6 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_stmt_impl(&mut self, stmt: &mut Stmt) {
-    if self.state.cycle == TransformationCycle::Skip {
-      return;
-    }
-
     if self.state.cycle == TransformationCycle::Cleaning {
       stmt.visit_mut_children_with(self);
 

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_stmt.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_stmt.rs
@@ -15,7 +15,7 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_stmt_impl(&mut self, stmt: &mut Stmt) {
-    if self.state.cycle == TransformationCycle::Cleaning {
+    if self.state.cycle == TransformationCycle::Finalize {
       stmt.visit_mut_children_with(self);
 
       if let Some(Stmt::Decl(Decl::Var(var))) = stmt.as_ref()

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_stmts.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_stmts.rs
@@ -11,7 +11,7 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_stmts_impl(&mut self, stmts: &mut Vec<Stmt>) {
-    if self.state.cycle == TransformationCycle::Cleaning {
+    if self.state.cycle == TransformationCycle::Finalize {
       stmts.retain(|stmt| {
         // We use `matches` macro as this match is trivial.
         !matches!(stmt, Stmt::Empty(..))

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_stmts.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_stmts.rs
@@ -11,10 +11,6 @@ where
   C: Comments,
 {
   pub(crate) fn visit_mut_stmts_impl(&mut self, stmts: &mut Vec<Stmt>) {
-    if self.state.cycle == TransformationCycle::Skip {
-      return;
-    }
-
     if self.state.cycle == TransformationCycle::Cleaning {
       stmts.retain(|stmt| {
         // We use `matches` macro as this match is trivial.

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
@@ -38,7 +38,7 @@ where
 {
   pub(crate) fn visit_mut_var_declarator_impl(&mut self, var_declarator: &mut VarDeclarator) {
     match self.state.cycle {
-      TransformationCycle::StateFilling => {
+      TransformationCycle::Discover => {
         fill_state_declarations(&mut self.state, var_declarator);
 
         if let Some(Expr::Call(call)) = var_declarator.init.as_deref_mut()
@@ -49,7 +49,6 @@ where
           if self
             .state
             .is_stylex_import_for_kinds(declaration_name, &[ImportKind::Create])
-            && self.state.cycle == TransformationCycle::StateFilling
             && (member.as_str() == STYLEX_CREATE || member == declaration_name)
           {
             self.props_declaration = var_declarator.name.as_ident().map(|ident| ident.to_id());

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
@@ -129,7 +129,7 @@ where
           }
         }
       },
-      TransformationCycle::Skip | TransformationCycle::InjectStyles => {},
+      TransformationCycle::InjectStyles => {},
       _ => var_declarator.visit_mut_children_with(self),
     }
   }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
@@ -129,7 +129,6 @@ where
           }
         }
       },
-      TransformationCycle::InjectStyles => {},
       _ => var_declarator.visit_mut_children_with(self),
     }
   }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
@@ -57,7 +57,7 @@ where
 
         var_declarator.visit_mut_children_with(self);
       },
-      TransformationCycle::Cleaning => {
+      TransformationCycle::Finalize => {
         let mut vars_to_keep: FxHashMap<Atom, NonNullProps> = FxHashMap::default();
 
         for StyleVarsToKeep(var_name, namespace_name, _) in self.state.style_vars_to_keep.iter() {

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarators.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarators.rs
@@ -17,35 +17,31 @@ where
     &mut self,
     var_declarators: &mut Vec<VarDeclarator>,
   ) {
-    match self.state.cycle {
-      TransformationCycle::Skip => return,
-      TransformationCycle::Cleaning => {
-        var_declarators.retain_mut(|decl| {
-          if let Pat::Ident(bind_ident) = &decl.name {
-            let decl_id = &bind_ident.sym;
+    if self.state.cycle == TransformationCycle::Cleaning {
+      var_declarators.retain_mut(|decl| {
+        if let Pat::Ident(bind_ident) = &decl.name {
+          let decl_id = &bind_ident.sym;
 
-            if let Some(&count) = self.state.var_decl_count_map.get(decl_id) {
-              // Remove the variable declaration if it is used only once after transformation.
-              let is_used = count > 1
-                || self
-                  .state
-                  .style_vars_to_keep
-                  .iter()
-                  .any(|style_var| &style_var.0 == decl_id);
+          if let Some(&count) = self.state.var_decl_count_map.get(decl_id) {
+            // Remove the variable declaration if it is used only once after transformation.
+            let is_used = count > 1
+              || self
+                .state
+                .style_vars_to_keep
+                .iter()
+                .any(|style_var| &style_var.0 == decl_id);
 
-              if !is_used {
-                self.state.decrement_decl_counts(decl);
-              }
-
-              return is_used;
+            if !is_used {
+              self.state.decrement_decl_counts(decl);
             }
-          }
 
-          true
-        });
-      },
-      _ => {},
-    };
+            return is_used;
+          }
+        }
+
+        true
+      });
+    }
 
     var_declarators.visit_mut_children_with(self);
   }

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarators.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarators.rs
@@ -17,7 +17,7 @@ where
     &mut self,
     var_declarators: &mut Vec<VarDeclarator>,
   ) {
-    if self.state.cycle == TransformationCycle::Cleaning {
+    if self.state.cycle == TransformationCycle::Finalize {
       var_declarators.retain_mut(|decl| {
         if let Pat::Ident(bind_ident) = &decl.name {
           let decl_id = &bind_ident.sym;

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarators.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarators.rs
@@ -34,10 +34,7 @@ where
                   .any(|style_var| &style_var.0 == decl_id);
 
               if !is_used {
-                self.state.cycle = TransformationCycle::Recounting;
-                decl.visit_mut_children_with(self);
-
-                self.state.cycle = TransformationCycle::Cleaning;
+                self.state.decrement_decl_counts(decl);
               }
 
               return is_used;

--- a/crates/stylex-transform/tests/evaluation/evaluation_module_transform.rs
+++ b/crates/stylex-transform/tests/evaluation/evaluation_module_transform.rs
@@ -124,7 +124,7 @@ impl Default for EvaluationStyleXLastStatementTransform {
 
 impl Fold for EvaluationStyleXLastStatementTransform {
   fn fold_module(&mut self, module: Module) -> Module {
-    self.state.cycle = TransformationCycle::StateFilling;
+    self.state.cycle = TransformationCycle::Discover;
     let module = module.fold_children_with(self);
 
     fill_top_level_expressions(&module, &mut self.state);

--- a/crates/stylex-transform/tests/evaluation/evaluation_module_transform.rs
+++ b/crates/stylex-transform/tests/evaluation/evaluation_module_transform.rs
@@ -129,7 +129,7 @@ impl Fold for EvaluationStyleXLastStatementTransform {
 
     fill_top_level_expressions(&module, &mut self.state);
 
-    self.state.cycle = TransformationCycle::TransformEnter;
+    self.state.cycle = TransformationCycle::TransformProducers;
 
     module.fold_children_with(self)
   }
@@ -139,7 +139,7 @@ impl Fold for EvaluationStyleXLastStatementTransform {
       self.state.add_call_expression(call_expr);
     }
 
-    if self.state.cycle == TransformationCycle::TransformEnter {
+    if self.state.cycle == TransformationCycle::TransformProducers {
       return self.evaluate_expr(expr).fold_children_with(self);
     }
 


### PR DESCRIPTION
## Description

This pull request refactors the StyleX transformation pipeline by simplifying and clarifying the transformation phases, consolidating redundant states, and improving the management of variable binding and cleanup. The changes introduce a fixed four-phase pipeline, replace many legacy state checks with clearer logic, and improve the marking and sweeping of unused style variables.

**Pipeline and State Management Simplification:**

* The `TransformationCycle` enum in `core.rs` is reduced from many states to four clear phases: `Discover`, `TransformProducers`, `TransformConsumers`, and `Finalize`, each with detailed documentation on its responsibilities.
* All usages of the old states throughout the codebase are updated to use the new, simplified phases, resulting in clearer and more maintainable code. [[1]](diffhunk://#diff-ca0326a57e3f5a0fd666e4c7a70ba6af35187cf7aa93f257c7a113b61ca2a79cL14-R14) [[2]](diffhunk://#diff-ca0326a57e3f5a0fd666e4c7a70ba6af35187cf7aa93f257c7a113b61ca2a79cL56-R56) [[3]](diffhunk://#diff-5d4ae3b92b2d1ebc8855fc3ccdeac1a194c47a46587cb76849b3239c93fe7810L25-R25) [[4]](diffhunk://#diff-fb3fbeed78ebe7c8997432aa3e90d601c6999c1c51540cf36c39f0105a3e0c3dL17-R17) [[5]](diffhunk://#diff-f186d8943944673e91c79f5b8a2cb3fea821840336a894efe7739c2cdd09c57eL17-R23) [[6]](diffhunk://#diff-1d75678b98e490e6aedc283c188bffa97cd9667ed80f6716e332ebe04058786eL14-R21) [[7]](diffhunk://#diff-1d75678b98e490e6aedc283c188bffa97cd9667ed80f6716e332ebe04058786eL35-R39) [[8]](diffhunk://#diff-17ef0609ec647fb69cb5c78ddf09e1d3508e9bfb4ef23dbc6c972cb66a3f1076L21-R21) [[9]](diffhunk://#diff-499b964ceb56a796747bb27fb80a0a4824555e9ee42fc0f943bf1084a4e07b3dL3-R13)

**Variable Binding and Expression Evaluation Improvements:**

* The `StateManager` now has an `evaluate_preserve_bindings` flag to control when variable binding counts are preserved, decoupling this logic from the pipeline state and making the evaluator less error-prone. [[1]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805R385-R394) [[2]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805L425-R443) [[3]](diffhunk://#diff-584b001b50775da92ad0cdddf8f9f9b0d60b4813fa3477ccacad1aa97080d239L389-R388)
* The logic for incrementing and decrementing identifier counts is refactored, including a new `decrement_decl_counts` method and a `DecrementCountVisitor` for cleanup, ensuring symmetry and correctness when removing unused declarations. [[1]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805R1135-R1145) [[2]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805R1199-R1314)

**Style Variable Mark-and-Sweep Finalization:**

* Introduces a `MarkStyleVarsVisitor` and a `mark_style_vars_to_keep` function to perform the "mark" step of the finalize phase, collecting only the style variables that are actually used and applying any deferred JSX-spread replacements. This replaces several legacy cleanup steps and collapses the finalize phase to a single sweep.

**Imports and Utility Updates:**

* Updates imports to include only the necessary functions and types, removing unused ones and adding new helpers for identifier counting and JSX attribute manipulation. [[1]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805L18-R40) [[2]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805R51) [[3]](diffhunk://#diff-17bbcb76b33e9ea5842d4809ea0e95a8f5f485902d68f1f01ddf54034bcc1291L7)

**General Code Clean-up:**

* Removes legacy state checks and redundant code, simplifies match arms, and clarifies comments throughout the transformation passes. [[1]](diffhunk://#diff-499b964ceb56a796747bb27fb80a0a4824555e9ee42fc0f943bf1084a4e07b3dL3-R13) [[2]](diffhunk://#diff-17bbcb76b33e9ea5842d4809ea0e95a8f5f485902d68f1f01ddf54034bcc1291L18-R17)

These changes collectively make the StyleX transformation pipeline more robust, easier to follow, and better suited for future maintenance and enhancements.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
