### PR TITLE
chore(deps): update pnpm-workspace.yaml with emittery compatibility

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -141,9 +141,10 @@ jobs:
             target: x86_64-apple-darwin
             architecture: x64
         node:
-          - '20.18.1'
+          # - '20.18.1' #Emittery v2 is not compatible with Node.js 20.
           - '22.22.1'
           - '24.14.0'
+          #- '26.0.0' # Node.js 26 is not supported yet
     runs-on: ${{ matrix.settings.host }}
     steps:
       - name: Enable long path support
@@ -189,9 +190,10 @@ jobs:
         settings:
           - target: x86_64-unknown-linux-gnu
         node:
-          - '20.18.1'
+          # - '20.18.1' #Emittery v2 is not compatible with Node.js 20.
           - '22.22.1'
           - '24.14.0'
+          #- '26.0.0' # Node.js 26 is not supported yet
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
@@ -237,9 +239,10 @@ jobs:
         settings:
           - target: x86_64-unknown-linux-musl
         node:
-          - '20.18.1'
+          # - '20.18.1' #Emittery v2 is not compatible with Node.js 20.
           - '22.22.1'
           - '24.14.0'
+          #- '26.0.0' # Node.js 26 is not supported yet
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
- Updated .github/workflows/npm.yml to comment out Node.js 20.18.1 due to compatibility issues with Emittery v2.
- Added comments for Node.js 26.0.0 indicating it is not yet supported.
- Ensured that the CI configuration remains aligned with the current compatibility requirements.

## Description
This pull request updates the Node.js versions used in the GitHub Actions workflow for npm builds. Node.js 20 is now commented out due to incompatibility with Emittery v2, and Node.js 26 is also commented out since it is not yet supported. The workflow now tests against Node.js 22 and 24.

Node.js version compatibility updates:

* [`.github/workflows/npm.yml`](diffhunk://#diff-8369a85f6d69dea9f5c38438cfcca793a8ee5aa308219e2d1a38f868b236f09aL144-R147): Commented out Node.js 20 in all build matrix targets with a note that Emittery v2 is not compatible with Node.js 20. [[1]](diffhunk://#diff-8369a85f6d69dea9f5c38438cfcca793a8ee5aa308219e2d1a38f868b236f09aL144-R147) [[2]](diffhunk://#diff-8369a85f6d69dea9f5c38438cfcca793a8ee5aa308219e2d1a38f868b236f09aL192-R196) [[3]](diffhunk://#diff-8369a85f6d69dea9f5c38438cfcca793a8ee5aa308219e2d1a38f868b236f09aL240-R245)
* [`.github/workflows/npm.yml`](diffhunk://#diff-8369a85f6d69dea9f5c38438cfcca793a8ee5aa308219e2d1a38f868b236f09aL144-R147): Added Node.js 26 as a commented-out entry in all build matrix targets, noting that Node.js 26 is not supported yet. [[1]](diffhunk://#diff-8369a85f6d69dea9f5c38438cfcca793a8ee5aa308219e2d1a38f868b236f09aL144-R147) [[2]](diffhunk://#diff-8369a85f6d69dea9f5c38438cfcca793a8ee5aa308219e2d1a38f868b236f09aL192-R196) [[3]](diffhunk://#diff-8369a85f6d69dea9f5c38438cfcca793a8ee5aa308219e2d1a38f868b236f09aL240-R245)

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
