### PR TITLE
fix(stylex-css): improve whitespace normalization for CSS strings

### DIFF
--- a/crates/stylex-css/src/css/normalizers/tests/whitespace_normalizer.rs
+++ b/crates/stylex-css/src/css/normalizers/tests/whitespace_normalizer.rs
@@ -349,6 +349,11 @@ fn string_contents_preserved() {
   assert_eq!(normalize_spacing(r#""hello)world""#), r#""hello)world""#);
 }
 
+#[test]
+fn unicode_string_contents_preserved() {
+  assert_eq!(normalize_spacing(r#""•""#), r#""•""#);
+}
+
 // Multiple functions chained
 #[test]
 fn multiple_chained_functions() {

--- a/crates/stylex-css/src/css/normalizers/whitespace_normalizer.rs
+++ b/crates/stylex-css/src/css/normalizers/whitespace_normalizer.rs
@@ -110,42 +110,62 @@ pub fn normalize_spacing(css: &str) -> String {
     return css.to_string();
   }
 
-  let bytes = css.as_bytes();
-  let len = bytes.len();
-  if len == 0 {
+  let chars = css.chars().collect::<Vec<_>>();
+  if chars.is_empty() {
     return String::new();
   }
 
-  let mut result = String::with_capacity(len + 16);
-  // Track whether we're inside a `"`-delimited string so we skip spacing
-  // rules for string contents, and whether the previous `"` was a closing
-  // quote (used to detect adjacent strings like `"a""b"` → `"a" "b"`).
-  let mut in_string = bytes[0] == b'"';
+  let mut result = String::with_capacity(css.len() + 16);
+  // Track quoted strings so spacing rules are not applied to string contents.
+  let mut in_quote = if chars[0] == '"' || chars[0] == '\'' {
+    Some(chars[0])
+  } else {
+    None
+  };
+  let mut escaped = false;
   let mut after_closing_quote = false;
-  result.push(bytes[0] as char);
+  result.push(chars[0]);
 
   let mut i = 1;
-  while i < len {
-    let prev = bytes[i - 1];
-    let cur = bytes[i];
+  while i < chars.len() {
+    let prev = chars[i - 1];
+    let cur = chars[i];
 
-    // Handle quote tracking
-    if cur == b'"' {
-      if in_string {
-        // Closing quote
-        in_string = false;
-        after_closing_quote = true;
-        result.push(cur as char);
+    if let Some(quote) = in_quote {
+      if escaped {
+        escaped = false;
+        result.push(cur);
         i += 1;
         continue;
       }
-      // Opening quote: insert space if previous was a closing quote
+
+      if cur == '\\' {
+        escaped = true;
+        result.push(cur);
+        i += 1;
+        continue;
+      }
+
+      if cur == quote {
+        in_quote = None;
+        after_closing_quote = true;
+        result.push(cur);
+        i += 1;
+        continue;
+      }
+
+      result.push(cur);
+      i += 1;
+      continue;
+    }
+
+    if cur == '"' || cur == '\'' {
       if after_closing_quote {
         result.push(' ');
       }
-      in_string = true;
+      in_quote = Some(cur);
       after_closing_quote = false;
-      result.push(cur as char);
+      result.push(cur);
       i += 1;
       continue;
     }
@@ -153,40 +173,33 @@ pub fn normalize_spacing(css: &str) -> String {
     // Non-quote character clears the closing-quote flag
     after_closing_quote = false;
 
-    // Inside a string: no spacing rules apply
-    if in_string {
-      result.push(cur as char);
-      i += 1;
-      continue;
-    }
-
     let need_space = match (prev, cur) {
       // After `)` before a letter: space unless followed by a CSS unit
-      (b')', b'a'..=b'z' | b'A'..=b'Z') => {
-        let word_end = bytes[i..]
+      (')', 'a'..='z' | 'A'..='Z') => {
+        let word_end = chars[i..]
           .iter()
-          .position(|&b| !b.is_ascii_alphanumeric())
-          .unwrap_or(len - i);
-        let word = &css[i..i + word_end];
-        !is_css_unit(word)
+          .position(|c| !c.is_ascii_alphanumeric())
+          .unwrap_or(chars.len() - i);
+        let word = chars[i..i + word_end].iter().collect::<String>();
+        !is_css_unit(&word)
       },
       // After `)` before digit, `#`, or `(`
-      (b')', b'0'..=b'9' | b'#' | b'(') => true,
+      (')', '0'..='9' | '#' | '(') => true,
       // After `)` before `/` or `*` (calc operators)
-      (b')', b'/' | b'*') => true,
+      (')', '/' | '*') => true,
       // After alphanumeric or `%` before `#` (hex color)
-      (b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'%', b'#') => true,
+      ('a'..='z' | 'A'..='Z' | '0'..='9' | '%', '#') => true,
       // After `%` before a number (e.g. `40.101%.1147` → `40.101% .1147`)
-      (b'%', b'0'..=b'9' | b'.') => true,
+      ('%', '0'..='9' | '.') => true,
       // After `/` or `*` before operand (calc context)
-      (b'/' | b'*', b'0'..=b'9' | b'.' | b'(' | b'-') => true,
+      ('/' | '*', '0'..='9' | '.' | '(' | '-') => true,
       _ => false,
     };
 
     if need_space {
       result.push(' ');
     }
-    result.push(cur as char);
+    result.push(cur);
     i += 1;
   }
 

--- a/crates/stylex-css/src/css/normalizers/whitespace_normalizer.rs
+++ b/crates/stylex-css/src/css/normalizers/whitespace_normalizer.rs
@@ -110,39 +110,36 @@ pub fn normalize_spacing(css: &str) -> String {
     return css.to_string();
   }
 
-  let chars = css.chars().collect::<Vec<_>>();
-  if chars.is_empty() {
+  let mut chars = css.char_indices();
+  let Some((_, first)) = chars.next() else {
     return String::new();
-  }
+  };
 
   let mut result = String::with_capacity(css.len() + 16);
   // Track quoted strings so spacing rules are not applied to string contents.
-  let mut in_quote = if chars[0] == '"' || chars[0] == '\'' {
-    Some(chars[0])
+  let mut in_quote = if first == '"' || first == '\'' {
+    Some(first)
   } else {
     None
   };
   let mut escaped = false;
   let mut after_closing_quote = false;
-  result.push(chars[0]);
+  result.push(first);
 
-  let mut i = 1;
-  while i < chars.len() {
-    let prev = chars[i - 1];
-    let cur = chars[i];
-
+  let mut prev = first;
+  for (idx, cur) in chars {
     if let Some(quote) = in_quote {
       if escaped {
         escaped = false;
         result.push(cur);
-        i += 1;
+        prev = cur;
         continue;
       }
 
       if cur == '\\' {
         escaped = true;
         result.push(cur);
-        i += 1;
+        prev = cur;
         continue;
       }
 
@@ -150,12 +147,12 @@ pub fn normalize_spacing(css: &str) -> String {
         in_quote = None;
         after_closing_quote = true;
         result.push(cur);
-        i += 1;
+        prev = cur;
         continue;
       }
 
       result.push(cur);
-      i += 1;
+      prev = cur;
       continue;
     }
 
@@ -166,7 +163,7 @@ pub fn normalize_spacing(css: &str) -> String {
       in_quote = Some(cur);
       after_closing_quote = false;
       result.push(cur);
-      i += 1;
+      prev = cur;
       continue;
     }
 
@@ -175,20 +172,22 @@ pub fn normalize_spacing(css: &str) -> String {
 
     let need_space = match (prev, cur) {
       // After `)` before a letter: space unless followed by a CSS unit
-      (')', 'a'..='z' | 'A'..='Z') => {
-        let word_end = chars[i..]
-          .iter()
-          .position(|c| !c.is_ascii_alphanumeric())
-          .unwrap_or(chars.len() - i);
-        let word = chars[i..i + word_end].iter().collect::<String>();
-        !is_css_unit(&word)
+      (')', c) if c.is_alphabetic() => {
+        if !c.is_ascii_alphabetic() {
+          true
+        } else {
+          let word_end = css[idx..]
+            .find(|c: char| !c.is_ascii_alphanumeric())
+            .map_or(css.len(), |offset| idx + offset);
+          !is_css_unit(&css[idx..word_end])
+        }
       },
       // After `)` before digit, `#`, or `(`
       (')', '0'..='9' | '#' | '(') => true,
       // After `)` before `/` or `*` (calc operators)
       (')', '/' | '*') => true,
       // After alphanumeric or `%` before `#` (hex color)
-      ('a'..='z' | 'A'..='Z' | '0'..='9' | '%', '#') => true,
+      (c, '#') if c.is_alphanumeric() || c == '%' => true,
       // After `%` before a number (e.g. `40.101%.1147` → `40.101% .1147`)
       ('%', '0'..='9' | '.') => true,
       // After `/` or `*` before operand (calc context)
@@ -200,7 +199,7 @@ pub fn normalize_spacing(css: &str) -> String {
       result.push(' ');
     }
     result.push(cur);
-    i += 1;
+    prev = cur;
   }
 
   result

--- a/crates/stylex-css/src/tests/whitespace_normalizer_tests.rs
+++ b/crates/stylex-css/src/tests/whitespace_normalizer_tests.rs
@@ -105,3 +105,102 @@ fn normalize_spacing_opening_quote_after_non_quote_content() {
   let result = normalize_spacing(r#""a" x "b""#);
   assert_eq!(result, r#""a" x "b""#);
 }
+
+#[test]
+fn normalize_spacing_unicode_character() {
+  let result = normalize_spacing("•");
+  assert_eq!(result, "•");
+}
+
+#[test]
+fn normalize_spacing_preserves_multibyte_utf8_sequences() {
+  for value in ["•", "✓", "日本語", "привет", "שלום", "مرحبا", "😀"] {
+    assert_eq!(normalize_spacing(value), value);
+  }
+}
+
+#[test]
+fn normalize_spacing_preserves_utf8_inside_double_quoted_strings() {
+  let value = r#""•✓日本語😀""#;
+  assert_eq!(normalize_spacing(value), value);
+}
+
+#[test]
+fn normalize_spacing_preserves_utf8_inside_single_quoted_strings() {
+  let value = r#"'•✓日本語😀'"#;
+  assert_eq!(normalize_spacing(value), value);
+}
+
+#[test]
+fn normalize_spacing_does_not_apply_spacing_rules_inside_double_quotes() {
+  let value = r##""a)b#c%d.5/1*2(""##;
+  assert_eq!(normalize_spacing(value), value);
+}
+
+#[test]
+fn normalize_spacing_does_not_apply_spacing_rules_inside_single_quotes() {
+  let value = r##"'a)b#c%d.5/1*2('"##;
+  assert_eq!(normalize_spacing(value), value);
+}
+
+#[test]
+fn normalize_spacing_handles_escaped_double_quotes() {
+  let value = r##""a\"b#c""##;
+  assert_eq!(normalize_spacing(value), value);
+}
+
+#[test]
+fn normalize_spacing_handles_escaped_single_quotes() {
+  let value = r##"'a\'b#c'"##;
+  assert_eq!(normalize_spacing(value), value);
+}
+
+#[test]
+fn normalize_spacing_inserts_space_between_adjacent_quoted_strings() {
+  assert_eq!(normalize_spacing(r#""a""b""#), r#""a" "b""#);
+  assert_eq!(normalize_spacing(r#"'a''b'"#), r#"'a' 'b'"#);
+  assert_eq!(normalize_spacing(r#""a"'b'"#), r#""a" 'b'"#);
+}
+
+#[test]
+fn normalize_spacing_keeps_url_values_byte_for_byte() {
+  let value = r#"url("/icons/•#hash.svg")calc(1px)rgb(0,0,0)"#;
+  assert_eq!(normalize_spacing(value), value);
+}
+
+#[test]
+fn normalize_spacing_applies_all_spacing_rules_outside_quotes() {
+  let cases = [
+    (")a )Z )0 )# )(", ") a ) Z ) 0 ) # ) ("),
+    (")/1 )*.5", ") / 1 ) * .5"),
+    ("a#fff Z#fff 1#fff %#fff", "a #fff Z #fff 1 #fff % #fff"),
+    ("50%10 40%.5", "50% 10 40% .5"),
+    ("/.5 /-1 *( *3", "/ .5 / -1 * ( * 3"),
+  ];
+
+  for (input, expected) in cases {
+    assert_eq!(normalize_spacing(input), expected);
+  }
+}
+
+#[test]
+fn normalize_spacing_does_not_insert_space_before_css_units() {
+  for unit in [
+    "px", "cm", "mm", "in", "pt", "pc", "Q", "em", "rem", "ex", "ch", "lh", "rlh", "cap", "ic",
+    "vw", "vh", "vi", "vb", "vmin", "vmax", "dvw", "dvh", "lvw", "lvh", "svw", "svh", "cqw", "cqh",
+    "cqi", "cqb", "cqmin", "cqmax", "ms", "s", "deg", "rad", "grad", "turn", "dpi", "dpcm", "dppx",
+    "fr", "Hz", "kHz",
+  ] {
+    let value = format!("var(--x){unit}");
+    assert_eq!(normalize_spacing(&value), value);
+  }
+}
+
+#[test]
+fn normalize_spacing_inserts_space_before_non_unit_ascii_words() {
+  for word in ["auto", "calc", "rgb", "translate3d", "ABC"] {
+    let value = format!("var(--x){word}");
+    let expected = format!("var(--x) {word}");
+    assert_eq!(normalize_spacing(&value), expected);
+  }
+}

--- a/crates/stylex-css/src/tests/whitespace_normalizer_tests.rs
+++ b/crates/stylex-css/src/tests/whitespace_normalizer_tests.rs
@@ -204,3 +204,13 @@ fn normalize_spacing_inserts_space_before_non_unit_ascii_words() {
     assert_eq!(normalize_spacing(&value), expected);
   }
 }
+
+#[test]
+fn normalize_spacing_inserts_space_before_non_ascii_words() {
+  assert_eq!(normalize_spacing("var(--x)日本語"), "var(--x) 日本語");
+}
+
+#[test]
+fn normalize_spacing_inserts_space_between_non_ascii_word_and_hash() {
+  assert_eq!(normalize_spacing("日本語#fff"), "日本語 #fff");
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/transform_style_create_with_unicode.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/transform_style_create_with_unicode.js
@@ -1,0 +1,13 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as stylex from "@stylexjs/stylex";
+_inject2({
+    ltr: '.xobpzmr{--shape:"•"}',
+    priority: 1
+});
+export const styles = {
+    shape: {
+        "--shape": "xobpzmr",
+        $$css: true
+    }
+};

--- a/crates/stylex-transform/tests/transform_misc_test/react.rs
+++ b/crates/stylex-transform/tests/transform_misc_test/react.rs
@@ -279,3 +279,15 @@ stylex_test!(
     });
   "#
 );
+
+stylex_test!(
+  transform_style_create_with_unicode,
+  |tr| { build_test_transform(tr.comments.clone(), move |b| { b.with_runtime_injection() }) },
+  r#"
+    import * as stylex from "@stylexjs/stylex";
+
+    export const styles = stylex.create({
+      shape: { '--shape': `"•"` },
+    });
+  "#
+);


### PR DESCRIPTION
- Updated the `normalize_spacing` function to handle character-based processing instead of byte-based, enhancing support for Unicode characters.
- Added tests to ensure preservation of multibyte UTF-8 sequences and proper handling of escaped quotes within strings.
- Ensured spacing rules are correctly applied outside of quoted strings while maintaining the integrity of quoted content.

## Description

This pull request improves the handling of Unicode and UTF-8 characters in the CSS whitespace normalizer, ensuring that multibyte and non-ASCII characters are preserved both inside and outside of quoted strings. It also significantly expands test coverage to verify correct behavior with Unicode, quoted strings, escaped characters, and CSS spacing rules.

**Unicode and UTF-8 handling:**

- Refactored `normalize_spacing` to operate on Unicode scalar values (`char`s) instead of raw bytes, ensuring correct handling and preservation of all UTF-8 and multibyte characters in CSS input. This includes proper support for quoted strings, escaped quotes, and spacing logic outside of quotes.

**Test coverage improvements:**

- Added comprehensive tests to verify that Unicode and multibyte UTF-8 characters are preserved in both quoted and unquoted contexts, and that spacing rules are correctly applied only outside of quotes. Tests also cover escaped quotes, adjacent quoted strings, and correct handling of CSS units and keywords. [[1]](diffhunk://#diff-f1d22e734e33dba95de0af327f0a60ec6439d4b89900417265c661601798ce3cR108-R206) [[2]](diffhunk://#diff-8f8455f2e367bf5adee312832e0ab8fe8636d84eaafa8b0884937385ab8ae27fR352-R356)
- Added a specific test for preserving Unicode characters inside string literals in the whitespace normalizer tests.

**Integration and snapshot tests:**

- Added a new integration test to ensure that Unicode characters are correctly handled in style definitions when using the StyleX transform, including a snapshot of the expected transformed output. [[1]](diffhunk://#diff-c7edd725daa12f006e83e3f11d048b1c935eaa1c0013c08af6c1067fc1b51c28R282-R293) [[2]](diffhunk://#diff-3a399745b7260775c9bd21af9b2ffd6bae276a3baa80dcc522bc1dce1fc405d5R1-R13)

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
