### PR TITLE
feat(stylex-shared): Implement leading zero restoration for negative decimals in CSS normalization

### DIFF
--- a/apps/nextjs-example/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/nextjs-example/__tests__/__snapshots__/index.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`Home render styles successfully 1`] = `
       class="x78zum5 xdt5ytf xu949wy x6s0dn4 xl56j7k xh8yej3 x17fpy1y"
     >
       <h1
-        class="xwlf911 x1q0g3np x1jn5nl8 xtfxu01 x1xlr1w8 xo5v014 x2b8uid x18sf2q7 xuxw1ft"
+        class="xwlf911 x1q0g3np x1jn5nl8 xtfxu01 x1xlr1w8 xo5v014 x2b8uid x72az59 xuxw1ft"
       >
         Next.js 
         <span

--- a/apps/nextjs-postcss-example/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/nextjs-postcss-example/__tests__/__snapshots__/index.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`Home render styles successfully 1`] = `
       class="x78zum5 xdt5ytf x17e51qk x6s0dn4 xl56j7k xh8yej3 x17fpy1y"
     >
       <h1
-        class="xwlf911 x1q0g3np x1pmkfg8 xs4a3dk x1xlr1w8 xo5v014 x2b8uid x18sf2q7 xuxw1ft"
+        class="xwlf911 x1q0g3np x1pmkfg8 xs4a3dk x1xlr1w8 xo5v014 x2b8uid x72az59 xuxw1ft"
       >
         Next.js 
         <span

--- a/apps/nextjs-turbopack-example/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/nextjs-turbopack-example/__tests__/__snapshots__/index.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`Home render styles successfully 1`] = `
       class="x78zum5 xdt5ytf xl8h7iu x6s0dn4 xl56j7k xh8yej3 x17fpy1y"
     >
       <h1
-        class="xwlf911 x1q0g3np x1rnljn9 xuo8wet x1xlr1w8 xo5v014 x2b8uid x18sf2q7 xuxw1ft"
+        class="xwlf911 x1q0g3np x1rnljn9 xuo8wet x1xlr1w8 xo5v014 x2b8uid x72az59 xuxw1ft"
       >
         Next.js 
         <span

--- a/crates/stylex-css/src/css/common.rs
+++ b/crates/stylex-css/src/css/common.rs
@@ -711,10 +711,10 @@ pub fn normalize_css_property_value(
 
   let stringified = stringify(&parsed_ast);
   let value = extract_css_value(&stringified);
-  let normalized = normalize_spacing(value);
-  let normalized = restore_negative_leading_zero(&normalized);
+  let normalized_spacing = normalize_spacing(value);
+  let negative_leading_zero_restored = restore_negative_leading_zero(&normalized_spacing);
 
-  convert_css_function_to_camel_case(&normalized)
+  convert_css_function_to_camel_case(&negative_leading_zero_restored)
 }
 
 /// Returns the numeric suffix for a CSS property (`"px"`, `"ms"`, `""`, etc.).

--- a/crates/stylex-css/src/css/common.rs
+++ b/crates/stylex-css/src/css/common.rs
@@ -3,7 +3,10 @@ use std::borrow::Cow;
 use crate::css::{
   generate_ltr::generate_ltr,
   generate_rtl::generate_rtl,
-  normalizers::{base::base_normalizer, extract_css_value, normalize_spacing},
+  normalizers::{
+    base::{base_normalizer, restore_negative_leading_zero},
+    extract_css_value, normalize_spacing,
+  },
   validators::unprefixed_custom_properties::unprefixed_custom_properties_validator,
 };
 use stylex_constants::constants::{
@@ -709,6 +712,7 @@ pub fn normalize_css_property_value(
   let stringified = stringify(&parsed_ast);
   let value = extract_css_value(&stringified);
   let normalized = normalize_spacing(value);
+  let normalized = restore_negative_leading_zero(&normalized);
 
   convert_css_function_to_camel_case(&normalized)
 }

--- a/crates/stylex-css/src/css/normalizers/base.rs
+++ b/crates/stylex-css/src/css/normalizers/base.rs
@@ -239,3 +239,77 @@ fn zero_dimension_normalizer(
     },
   }
 }
+
+/// Returns `true` when `c` is part of a number or identifier, meaning a
+/// following `-` is an operator/suffix rather than the sign of a standalone
+/// negative number (e.g. the `-` in `1px-.5px` or `a-.5`).
+fn is_number_part(c: char) -> bool {
+  c.is_alphanumeric() || c == '_' || c == '.'
+}
+
+/// Restores the leading zero that SWC's CSS minifier strips from negative
+/// decimals (e.g. `-.24px` → `-0.24px`).
+///
+/// SWC's `minify_numeric` removes the leading zero from every decimal,
+/// including negative ones. Should only strip leading zeros from positive values
+/// in the `[0, 1)` range (via its `normalizeLeadingZero` normalizer) and leaves
+/// negative decimals untouched.
+/// Class names are hashed from the normalized value, so this divergence yields
+/// mismatched class names between the two compilers. Restoring the leading zero
+/// on negative decimals keeps them aligned.
+///
+/// Scans the string once over Unicode scalar values so multibyte characters
+/// (e.g. emoji inside `content`) are preserved. Quoted strings are skipped so
+/// values such as `content: "-.5"` are left untouched.
+pub(crate) fn restore_negative_leading_zero(value: &str) -> String {
+  if !value.contains("-.") {
+    return value.to_string();
+  }
+
+  let mut result = String::with_capacity(value.len() + 2);
+  let mut in_quote: Option<char> = None;
+  let mut escaped = false;
+  // The previous character, used to tell a sign `-` (start of a negative
+  // number) from a `-` that follows a number or identifier.
+  let mut prev: Option<char> = None;
+
+  for (idx, cur) in value.char_indices() {
+    if let Some(quote) = in_quote {
+      result.push(cur);
+      if escaped {
+        escaped = false;
+      } else if cur == '\\' {
+        escaped = true;
+      } else if cur == quote {
+        in_quote = None;
+      }
+      prev = Some(cur);
+      continue;
+    }
+
+    if cur == '"' || cur == '\'' {
+      in_quote = Some(cur);
+      result.push(cur);
+      prev = Some(cur);
+      continue;
+    }
+
+    // A sign-position `-` immediately followed by `.<digit>` lost its leading
+    // zero to the minifier; restore it. `.` and digits are single-byte ASCII,
+    // so inspecting the raw bytes after `-` is UTF-8 safe.
+    if cur == '-' && !prev.is_some_and(is_number_part) {
+      let rest = &value.as_bytes()[idx + 1..];
+      if rest.first() == Some(&b'.') && rest.get(1).is_some_and(u8::is_ascii_digit) {
+        result.push('-');
+        result.push('0');
+        prev = Some('-');
+        continue;
+      }
+    }
+
+    result.push(cur);
+    prev = Some(cur);
+  }
+
+  result
+}

--- a/crates/stylex-css/src/css/normalizers/base.rs
+++ b/crates/stylex-css/src/css/normalizers/base.rs
@@ -282,17 +282,19 @@ pub(crate) fn restore_negative_leading_zero(value: &str) -> Cow<'_, str> {
     return Cow::Borrowed(value);
   }
 
-  let mut result = String::with_capacity(value.len() + 2);
+  let mut result: Option<String> = None;
   let mut in_quote: Option<char> = None;
   let mut escaped = false;
   // The previous character, used to tell a sign `-` (start of a negative
   // number) from a `-` that follows a number or identifier.
   let mut prev: Option<char> = None;
-  let mut modified = false;
 
   for (idx, cur) in value.char_indices() {
     if let Some(quote) = in_quote {
-      result.push(cur);
+      if let Some(result) = result.as_mut() {
+        result.push(cur);
+      }
+
       if escaped {
         escaped = false;
       } else if cur == '\\' {
@@ -306,7 +308,11 @@ pub(crate) fn restore_negative_leading_zero(value: &str) -> Cow<'_, str> {
 
     if cur == '"' || cur == '\'' {
       in_quote = Some(cur);
-      result.push(cur);
+
+      if let Some(result) = result.as_mut() {
+        result.push(cur);
+      }
+
       prev = Some(cur);
       continue;
     }
@@ -317,23 +323,30 @@ pub(crate) fn restore_negative_leading_zero(value: &str) -> Cow<'_, str> {
     if cur == '-' && is_sign_position(prev) {
       let rest = &value.as_bytes()[idx + 1..];
       if rest.first() == Some(&b'.') && rest.get(1).is_some_and(u8::is_ascii_digit) {
+        let result = result.get_or_insert_with(|| {
+          let mut result = String::with_capacity(value.len() + 1);
+          result.push_str(&value[..idx]);
+          result
+        });
+
         result.push('-');
         result.push('0');
-        modified = true;
         prev = Some('-');
         continue;
       }
     }
 
-    result.push(cur);
+    if let Some(result) = result.as_mut() {
+      result.push(cur);
+    }
+
     prev = Some(cur);
   }
 
   // The `-.` substring may have been inside a quoted string or otherwise not a
   // sign position, in which case the scan produced an identical copy.
-  if modified {
-    Cow::Owned(result)
-  } else {
-    Cow::Borrowed(value)
+  match result {
+    Some(result) => Cow::Owned(result),
+    None => Cow::Borrowed(value),
   }
 }

--- a/crates/stylex-css/src/css/normalizers/base.rs
+++ b/crates/stylex-css/src/css/normalizers/base.rs
@@ -240,23 +240,32 @@ fn zero_dimension_normalizer(
   }
 }
 
-/// Returns `true` when `c` is part of a number or identifier, meaning a
-/// following `-` is an operator/suffix rather than the sign of a standalone
-/// negative number (e.g. the `-` in `1px-.5px` or `a-.5`).
-fn is_number_part(c: char) -> bool {
-  c.is_alphanumeric() || c == '_' || c == '.'
+/// Returns `true` when a `-` whose preceding character is `prev` starts a
+/// negative number (a sign) rather than acting as a subtraction operator or
+/// being part of an identifier/dimension.
+///
+/// A sign only appears at the very start of the value or right after an opening
+/// parenthesis, an argument/list separator, or a math operator. Anything else —
+/// a letter, digit, `%`, `)`, `.` … — means the `-` continues an existing token
+/// or subtracts from it, so e.g. `calc(var(--x)-.5px)` and `10%-.5px` are left
+/// untouched.
+fn is_sign_position(prev: Option<char>) -> bool {
+  match prev {
+    None => true,
+    Some(c) => c.is_whitespace() || matches!(c, '(' | ',' | '+' | '-' | '*' | '/'),
+  }
 }
 
 /// Restores the leading zero that SWC's CSS minifier strips from negative
 /// decimals (e.g. `-.24px` → `-0.24px`).
 ///
 /// SWC's `minify_numeric` removes the leading zero from every decimal,
-/// including negative ones. Should only strip leading zeros from positive values
-/// in the `[0, 1)` range (via its `normalizeLeadingZero` normalizer) and leaves
-/// negative decimals untouched.
-/// Class names are hashed from the normalized value, so this divergence yields
-/// mismatched class names between the two compilers. Restoring the leading zero
-/// on negative decimals keeps them aligned.
+/// including negative ones. The official StyleX `@stylexjs/babel-plugin`, by
+/// contrast, only strips leading zeros from positive values in the `[0, 1)`
+/// range (via its `normalizeLeadingZero` normalizer) and leaves negative
+/// decimals untouched. Class names are hashed from the normalized value, so
+/// this divergence yields mismatched class names between the two compilers.
+/// Restoring the leading zero on negative decimals keeps them aligned.
 ///
 /// Scans the string once over Unicode scalar values so multibyte characters
 /// (e.g. emoji inside `content`) are preserved. Quoted strings are skipped so
@@ -297,7 +306,7 @@ pub(crate) fn restore_negative_leading_zero(value: &str) -> String {
     // A sign-position `-` immediately followed by `.<digit>` lost its leading
     // zero to the minifier; restore it. `.` and digits are single-byte ASCII,
     // so inspecting the raw bytes after `-` is UTF-8 safe.
-    if cur == '-' && !prev.is_some_and(is_number_part) {
+    if cur == '-' && is_sign_position(prev) {
       let rest = &value.as_bytes()[idx + 1..];
       if rest.first() == Some(&b'.') && rest.get(1).is_some_and(u8::is_ascii_digit) {
         result.push('-');

--- a/crates/stylex-css/src/css/normalizers/base.rs
+++ b/crates/stylex-css/src/css/normalizers/base.rs
@@ -9,6 +9,8 @@ use swc_core::{
   },
 };
 
+use std::borrow::Cow;
+
 use stylex_constants::constants::common::ROOT_FONT_SIZE;
 use stylex_utils::string::dashify;
 
@@ -252,7 +254,7 @@ fn zero_dimension_normalizer(
 fn is_sign_position(prev: Option<char>) -> bool {
   match prev {
     None => true,
-    Some(c) => c.is_whitespace() || matches!(c, '(' | ',' | '+' | '-' | '*' | '/'),
+    Some(c) => c.is_ascii_whitespace() || matches!(c, '(' | ',' | '+' | '-' | '*' | '/'),
   }
 }
 
@@ -270,9 +272,14 @@ fn is_sign_position(prev: Option<char>) -> bool {
 /// Scans the string once over Unicode scalar values so multibyte characters
 /// (e.g. emoji inside `content`) are preserved. Quoted strings are skipped so
 /// values such as `content: "-.5"` are left untouched.
-pub(crate) fn restore_negative_leading_zero(value: &str) -> String {
+///
+/// Returns [`Cow::Borrowed`] when nothing needs changing — the overwhelmingly
+/// common case — so the hot path (every normalized CSS value) allocates only
+/// when a leading zero is actually restored.
+pub(crate) fn restore_negative_leading_zero(value: &str) -> Cow<'_, str> {
+  // Fast path: a leading zero can only be missing where a `-.` substring exists.
   if !value.contains("-.") {
-    return value.to_string();
+    return Cow::Borrowed(value);
   }
 
   let mut result = String::with_capacity(value.len() + 2);
@@ -281,6 +288,7 @@ pub(crate) fn restore_negative_leading_zero(value: &str) -> String {
   // The previous character, used to tell a sign `-` (start of a negative
   // number) from a `-` that follows a number or identifier.
   let mut prev: Option<char> = None;
+  let mut modified = false;
 
   for (idx, cur) in value.char_indices() {
     if let Some(quote) = in_quote {
@@ -311,6 +319,7 @@ pub(crate) fn restore_negative_leading_zero(value: &str) -> String {
       if rest.first() == Some(&b'.') && rest.get(1).is_some_and(u8::is_ascii_digit) {
         result.push('-');
         result.push('0');
+        modified = true;
         prev = Some('-');
         continue;
       }
@@ -320,5 +329,11 @@ pub(crate) fn restore_negative_leading_zero(value: &str) -> String {
     prev = Some(cur);
   }
 
-  result
+  // The `-.` substring may have been inside a quoted string or otherwise not a
+  // sign position, in which case the scan produced an identical copy.
+  if modified {
+    Cow::Owned(result)
+  } else {
+    Cow::Borrowed(value)
+  }
 }

--- a/crates/stylex-css/src/css/normalizers/tests/base.rs
+++ b/crates/stylex-css/src/css/normalizers/tests/base.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use swc_core::{common::DUMMY_SP, css::ast::Ident};
 
 use crate::css::normalizers::base::{restore_negative_leading_zero, zero_unit};
@@ -831,69 +833,71 @@ fn zero_unit_test() {
 
 #[test]
 fn restore_negative_leading_zero_test() {
+  // Compare the result as a plain string regardless of the `Cow` variant.
+  let restore = |value: &str| restore_negative_leading_zero(value).into_owned();
+
   // Negative decimals get their leading zero restored (the reported bug).
-  assert_eq!(restore_negative_leading_zero("-.24px"), "-0.24px");
-  assert_eq!(restore_negative_leading_zero("-.9s"), "-0.9s");
+  assert_eq!(restore("-.24px"), "-0.24px");
+  assert_eq!(restore("-.9s"), "-0.9s");
   // Leading sign at the very start of the value.
-  assert_eq!(restore_negative_leading_zero("-.5"), "-0.5");
+  assert_eq!(restore("-.5"), "-0.5");
 
   // Positive decimals keep the stripped leading zero (matches Babel).
-  assert_eq!(restore_negative_leading_zero(".5px"), ".5px");
+  assert_eq!(restore(".5px"), ".5px");
 
   // Restores negatives inside functions and lists.
+  assert_eq!(restore("calc(-.5px + 1px)"), "calc(-0.5px + 1px)");
   assert_eq!(
-    restore_negative_leading_zero("calc(-.5px + 1px)"),
-    "calc(-0.5px + 1px)"
-  );
-  assert_eq!(
-    restore_negative_leading_zero("translate(-.5px,-.25px)"),
+    restore("translate(-.5px,-.25px)"),
     "translate(-0.5px,-0.25px)"
   );
 
   // Subtraction operators are left alone, whatever token precedes them:
   // a unit/ident, a closing paren, or a percentage (common calc patterns).
-  assert_eq!(
-    restore_negative_leading_zero("calc(1px-.5px)"),
-    "calc(1px-.5px)"
-  );
-  assert_eq!(
-    restore_negative_leading_zero("calc(var(--x)-.5px)"),
-    "calc(var(--x)-.5px)"
-  );
-  assert_eq!(restore_negative_leading_zero("10%-.5px"), "10%-.5px");
+  assert_eq!(restore("calc(1px-.5px)"), "calc(1px-.5px)");
+  assert_eq!(restore("calc(var(--x)-.5px)"), "calc(var(--x)-.5px)");
+  assert_eq!(restore("10%-.5px"), "10%-.5px");
 
   // A sign-position `-` not followed by `.<digit>` (e.g. a negative integer)
   // is left untouched, while a later `-.<digit>` is still restored.
-  assert_eq!(restore_negative_leading_zero("-5px -.5px"), "-5px -0.5px");
+  assert_eq!(restore("-5px -.5px"), "-5px -0.5px");
 
   // Quoted strings are never touched, even when they contain the pattern.
-  assert_eq!(
-    restore_negative_leading_zero(r#"content:"-.5""#),
-    r#"content:"-.5""#
-  );
-  assert_eq!(
-    restore_negative_leading_zero(r#"content:'-.5'"#),
-    r#"content:'-.5'"#
-  );
+  assert_eq!(restore(r#"content:"-.5""#), r#"content:"-.5""#);
+  assert_eq!(restore(r#"content:'-.5'"#), r#"content:'-.5'"#);
 
   // Escaped quote inside a string does not prematurely end the string, so the
   // `-.5` stays protected.
-  assert_eq!(
-    restore_negative_leading_zero(r#"content:"a\"-.5""#),
-    r#"content:"a\"-.5""#
-  );
+  assert_eq!(restore(r#"content:"a\"-.5""#), r#"content:"a\"-.5""#);
 
   // Multibyte UTF-8 (emoji) is preserved verbatim, inside and outside quotes.
-  assert_eq!(
-    restore_negative_leading_zero(r#"content:"🎉 -.5""#),
-    r#"content:"🎉 -.5""#
-  );
-  assert_eq!(
-    restore_negative_leading_zero("translate(🎉,-.5px)"),
-    "translate(🎉,-0.5px)"
-  );
+  assert_eq!(restore(r#"content:"🎉 -.5""#), r#"content:"🎉 -.5""#);
+  assert_eq!(restore("translate(🎉,-.5px)"), "translate(🎉,-0.5px)");
 
   // Values without a candidate pattern are returned unchanged.
-  assert_eq!(restore_negative_leading_zero("10px"), "10px");
-  assert_eq!(restore_negative_leading_zero("🎉"), "🎉");
+  assert_eq!(restore("10px"), "10px");
+  assert_eq!(restore("🎉"), "🎉");
+
+  // Allocation contract: only borrow when nothing changes. An unchanged value
+  // (including a `-.` that turns out not to be a sign) must not allocate; a
+  // genuine restoration must return an owned string.
+  assert!(matches!(
+    restore_negative_leading_zero("10px"),
+    Cow::Borrowed(_)
+  ));
+  assert!(matches!(
+    restore_negative_leading_zero("calc(1px-.5px)"),
+    Cow::Borrowed(_)
+  ));
+  assert!(matches!(
+    restore_negative_leading_zero("-.5px"),
+    Cow::Owned(_)
+  ));
+
+  // Idempotence: restoring an already-restored value is a no-op (and borrows).
+  let once = restore("translate(-.5px,-.25px)");
+  assert!(matches!(
+    restore_negative_leading_zero(&once),
+    Cow::Borrowed(_)
+  ));
 }

--- a/crates/stylex-css/src/css/normalizers/tests/base.rs
+++ b/crates/stylex-css/src/css/normalizers/tests/base.rs
@@ -851,6 +851,10 @@ fn restore_negative_leading_zero_test() {
     restore("translate(-.5px,-.25px)"),
     "translate(-0.5px,-0.25px)"
   );
+  assert_eq!(
+    restore(r#"translate(-.5px,"-.25px")"#),
+    r#"translate(-0.5px,"-.25px")"#
+  );
 
   // Subtraction operators are left alone, whatever token precedes them:
   // a unit/ident, a closing paren, or a percentage (common calc patterns).

--- a/crates/stylex-css/src/css/normalizers/tests/base.rs
+++ b/crates/stylex-css/src/css/normalizers/tests/base.rs
@@ -850,11 +850,17 @@ fn restore_negative_leading_zero_test() {
     "translate(-0.5px,-0.25px)"
   );
 
-  // Subtraction operators (a `-` preceded by a number/ident) are left alone.
+  // Subtraction operators are left alone, whatever token precedes them:
+  // a unit/ident, a closing paren, or a percentage (common calc patterns).
   assert_eq!(
     restore_negative_leading_zero("calc(1px-.5px)"),
     "calc(1px-.5px)"
   );
+  assert_eq!(
+    restore_negative_leading_zero("calc(var(--x)-.5px)"),
+    "calc(var(--x)-.5px)"
+  );
+  assert_eq!(restore_negative_leading_zero("10%-.5px"), "10%-.5px");
 
   // A sign-position `-` not followed by `.<digit>` (e.g. a negative integer)
   // is left untouched, while a later `-.<digit>` is still restored.

--- a/crates/stylex-css/src/css/normalizers/tests/base.rs
+++ b/crates/stylex-css/src/css/normalizers/tests/base.rs
@@ -1,6 +1,6 @@
 use swc_core::{common::DUMMY_SP, css::ast::Ident};
 
-use crate::css::normalizers::base::zero_unit;
+use crate::css::normalizers::base::{restore_negative_leading_zero, zero_unit};
 
 #[cfg(test)]
 mod normalizers {
@@ -827,4 +827,67 @@ fn zero_unit_test() {
       raw: None
     }
   );
+}
+
+#[test]
+fn restore_negative_leading_zero_test() {
+  // Negative decimals get their leading zero restored (the reported bug).
+  assert_eq!(restore_negative_leading_zero("-.24px"), "-0.24px");
+  assert_eq!(restore_negative_leading_zero("-.9s"), "-0.9s");
+  // Leading sign at the very start of the value.
+  assert_eq!(restore_negative_leading_zero("-.5"), "-0.5");
+
+  // Positive decimals keep the stripped leading zero (matches Babel).
+  assert_eq!(restore_negative_leading_zero(".5px"), ".5px");
+
+  // Restores negatives inside functions and lists.
+  assert_eq!(
+    restore_negative_leading_zero("calc(-.5px + 1px)"),
+    "calc(-0.5px + 1px)"
+  );
+  assert_eq!(
+    restore_negative_leading_zero("translate(-.5px,-.25px)"),
+    "translate(-0.5px,-0.25px)"
+  );
+
+  // Subtraction operators (a `-` preceded by a number/ident) are left alone.
+  assert_eq!(
+    restore_negative_leading_zero("calc(1px-.5px)"),
+    "calc(1px-.5px)"
+  );
+
+  // A sign-position `-` not followed by `.<digit>` (e.g. a negative integer)
+  // is left untouched, while a later `-.<digit>` is still restored.
+  assert_eq!(restore_negative_leading_zero("-5px -.5px"), "-5px -0.5px");
+
+  // Quoted strings are never touched, even when they contain the pattern.
+  assert_eq!(
+    restore_negative_leading_zero(r#"content:"-.5""#),
+    r#"content:"-.5""#
+  );
+  assert_eq!(
+    restore_negative_leading_zero(r#"content:'-.5'"#),
+    r#"content:'-.5'"#
+  );
+
+  // Escaped quote inside a string does not prematurely end the string, so the
+  // `-.5` stays protected.
+  assert_eq!(
+    restore_negative_leading_zero(r#"content:"a\"-.5""#),
+    r#"content:"a\"-.5""#
+  );
+
+  // Multibyte UTF-8 (emoji) is preserved verbatim, inside and outside quotes.
+  assert_eq!(
+    restore_negative_leading_zero(r#"content:"🎉 -.5""#),
+    r#"content:"🎉 -.5""#
+  );
+  assert_eq!(
+    restore_negative_leading_zero("translate(🎉,-.5px)"),
+    "translate(🎉,-0.5px)"
+  );
+
+  // Values without a candidate pattern are returned unchanged.
+  assert_eq!(restore_negative_leading_zero("10px"), "10px");
+  assert_eq!(restore_negative_leading_zero("🎉"), "🎉");
 }

--- a/crates/stylex-css/src/css/tests/common_test.rs
+++ b/crates/stylex-css/src/css/tests/common_test.rs
@@ -414,6 +414,21 @@ mod normalize_css_property_value_tests {
     assert_eq!(result, "0");
   }
 
+  #[test]
+  fn keeps_leading_zero_on_negative_decimals() {
+    let opts = default_options();
+
+    assert_eq!(
+      normalize_css_property_value("letterSpacing", "-0.24px", &opts),
+      "-0.24px"
+    );
+
+    assert_eq!(
+      normalize_css_property_value("marginTop", "-0.5px", &opts),
+      "-0.5px"
+    );
+  }
+
   // --- Calc expressions ---
 
   #[test]

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_value_normalization_test/css_value_normalization.rs/keep_leading_zero_on_negative_decimals.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_value_normalization_test/css_value_normalization.rs/keep_leading_zero_on_negative_decimals.js
@@ -1,0 +1,11 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import stylex from 'stylex';
+_inject2({
+    ltr: ".x1gu5id8{letter-spacing:-0.24px}",
+    priority: 3000
+});
+_inject2({
+    ltr: ".x1qnv4r7{margin-top:-0.5px}",
+    priority: 4000
+});

--- a/crates/stylex-transform/tests/fixture/spot-loader/output.js
+++ b/crates/stylex-transform/tests/fixture/spot-loader/output.js
@@ -79,7 +79,7 @@ _inject2({
     priority: 4000
 });
 _inject2({
-    ltr: ".animationDelay-x1olj69{animation-delay:-.9s}",
+    ltr: ".animationDelay-x1ba7lo8{animation-delay:-0.9s}",
     priority: 3000
 });
 _inject2({
@@ -87,7 +87,7 @@ _inject2({
     priority: 3000
 });
 _inject2({
-    ltr: ".animationDelay-x1ryhrx7{animation-delay:-.8s}",
+    ltr: ".animationDelay-xdwblqi{animation-delay:-0.8s}",
     priority: 3000
 });
 _inject2({
@@ -149,13 +149,13 @@ const styles = {
         $$css: "tests/fixture/spot-loader/input.stylex.js:36"
     },
     rect4: {
-        animationDelay: "animationDelay-x1olj69",
+        animationDelay: "animationDelay-x1ba7lo8",
         backgroundColor: "backgroundColor-xb4ade6",
         height: "height-x1lnynta",
         $$css: "tests/fixture/spot-loader/input.stylex.js:40"
     },
     rect5: {
-        animationDelay: "animationDelay-x1ryhrx7",
+        animationDelay: "animationDelay-xdwblqi",
         height: "height-x10buj8t",
         $$css: "tests/fixture/spot-loader/input.stylex.js:45"
     },

--- a/crates/stylex-transform/tests/fixture/spot-loader/output_prod.js
+++ b/crates/stylex-transform/tests/fixture/spot-loader/output_prod.js
@@ -35,13 +35,13 @@ const styles = {
         $$css: true
     },
     rect4: {
-        kKxzle: "x1olj69",
+        kKxzle: "x1ba7lo8",
         kWkggS: "xb4ade6",
         kZKoxP: "x1lnynta",
         $$css: true
     },
     rect5: {
-        kKxzle: "x1ryhrx7",
+        kKxzle: "xdwblqi",
         kZKoxP: "x10buj8t",
         $$css: true
     },

--- a/crates/stylex-transform/tests/transform_value_normalization_test/css_value_normalization.rs
+++ b/crates/stylex-transform/tests/transform_value_normalization_test/css_value_normalization.rs
@@ -98,6 +98,21 @@ stylex_test!(
   "#
 );
 
+// Negative decimals between -1 and 0 must keep their leading zero.
+// The class name hash is derived from the normalized value, so a divergence here
+// produces mismatched class names across compilers (issue #1049).
+stylex_test!(
+  keep_leading_zero_on_negative_decimals,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import stylex from 'stylex';
+    const styles = stylex.create({ x: {
+        letterSpacing: '-0.24px',
+        marginTop: '-0.5px'
+      } });
+  "#
+);
+
 stylex_test!(
   use_double_quotes_in_empty_strings,
   |tr| stylex_transform(tr.comments.clone(), |b| b),

--- a/guidelines/SCRIPTS.md
+++ b/guidelines/SCRIPTS.md
@@ -68,3 +68,34 @@ pnpm run test:coverage:workspace
 # Per-crate coverage (from crate directory)
 pnpm run test:coverage
 ```
+
+### Finding uncovered lines
+
+`test:coverage:workspace` only reports pass/fail percentages. When it fails, use
+`scripts/coverage-missing.sh` to print the exact `file: line` ranges that no
+test exercises, so you know precisely what needs a test.
+
+```sh
+# Whole workspace (same crate excludes as test:coverage:workspace)
+scripts/coverage-missing.sh
+
+# Single crate — much faster while iterating on one module
+scripts/coverage-missing.sh stylex_css
+scripts/coverage-missing.sh -p stylex_css   # equivalent, explicit flag
+
+# Also emit an HTML report (and open it in a browser with --open)
+scripts/coverage-missing.sh stylex_css --html
+scripts/coverage-missing.sh stylex_css --open
+
+scripts/coverage-missing.sh --help
+```
+
+The uncovered `file: line` list is printed beneath the per-file table. The
+script exits `0` when every measured line is covered and `1` otherwise, so it
+doubles as a local gate. It requires the nightly toolchain plus `cargo-llvm-cov`
+and `cargo-nextest`:
+
+```sh
+rustup toolchain install nightly
+cargo install cargo-llvm-cov cargo-nextest --locked
+```

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -78,7 +78,8 @@
     "postbuild": "pnpm run check:artifacts",
     "prepublishOnly": "pnpm run build",
     "start": "esno src/index.ts",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
     "typecheck": "scripty --ts"
   },
   "config": {

--- a/scripts/coverage-missing.sh
+++ b/scripts/coverage-missing.sh
@@ -28,17 +28,33 @@ set -euo pipefail
 
 # Crates excluded from workspace coverage, kept in sync with the
 # `test:coverage:workspace` script in the root package.json.
-WORKSPACE_EXCLUDES="--exclude stylex_logs \
-  --exclude stylex_compiler_rs \
-  --exclude stylex_test_parser \
-  --exclude stylex_css_parser \
-  --exclude stylex_transform"
+WORKSPACE_EXCLUDES=(
+  --exclude stylex_logs
+  --exclude stylex_compiler_rs
+  --exclude stylex_test_parser
+  --exclude stylex_css_parser
+  --exclude stylex_transform
+)
 
 # Generated test/bench/example files are never counted, matching CI.
 IGNORE_REGEX='(tests?|benches?|examples)/'
 
 usage() {
-  sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+  cat <<'EOF'
+coverage-missing.sh — pinpoint uncovered lines in the Rust workspace.
+
+USAGE
+  scripts/coverage-missing.sh                 # whole workspace (matches CI excludes)
+  scripts/coverage-missing.sh stylex_css      # single crate (fast iteration)
+  scripts/coverage-missing.sh -p stylex_css   # same, explicit flag
+  scripts/coverage-missing.sh --html          # also write an HTML report, print its path
+  scripts/coverage-missing.sh --open          # write + open the HTML report in a browser
+  scripts/coverage-missing.sh -h | --help
+
+EXIT STATUS
+  0  every measured line is covered
+  1  one or more lines are uncovered (the `file: line` list is printed above)
+EOF
   exit "${1:-0}"
 }
 
@@ -72,28 +88,28 @@ while [ $# -gt 0 ]; do
 done
 
 # Select scope: a single crate (fast) or the whole workspace (CI parity).
+# Arrays keep each argument a distinct word, so no `shellcheck disable=SC2086`.
+scope=()
 if [ -n "$package" ]; then
-  scope="-p $package"
+  scope=(-p "$package")
   echo "==> Coverage for crate: $package"
 else
-  # shellcheck disable=SC2086
-  scope="--workspace $WORKSPACE_EXCLUDES"
+  scope=(--workspace "${WORKSPACE_EXCLUDES[@]}")
   echo "==> Coverage for workspace (excluding non-instrumented crates)"
 fi
 
 # `--show-missing-lines` prints the uncovered `file: line` list.
 # `--fail-uncovered-lines 0` makes the command exit non-zero if any remain,
 # so this script is CI-friendly and usable as a pre-commit gate.
-report_flags="--show-missing-lines --fail-uncovered-lines 0"
+report_flags=(--show-missing-lines --fail-uncovered-lines 0)
 
 if [ "$html" -eq 1 ]; then
-  report_flags="$report_flags --html"
-  [ "$open" -eq 1 ] && report_flags="$report_flags --open"
+  report_flags+=(--html)
+  [ "$open" -eq 1 ] && report_flags+=(--open)
 fi
 
-# shellcheck disable=SC2086
 cargo +nightly llvm-cov nextest \
-  $scope \
+  "${scope[@]}" \
   --all-features \
   --ignore-filename-regex "$IGNORE_REGEX" \
-  $report_flags
+  "${report_flags[@]}"

--- a/scripts/coverage-missing.sh
+++ b/scripts/coverage-missing.sh
@@ -101,7 +101,12 @@ fi
 # `--show-missing-lines` prints the uncovered `file: line` list.
 # `--fail-uncovered-lines 0` makes the command exit non-zero if any remain,
 # so this script is CI-friendly and usable as a pre-commit gate.
-report_flags=(--show-missing-lines --fail-uncovered-lines 0)
+report_flags=(
+  --show-missing-lines
+  --fail-uncovered-lines 0
+  --fail-uncovered-regions 0
+  --fail-under-functions 0
+)
 
 if [ "$html" -eq 1 ]; then
   report_flags+=(--html)

--- a/scripts/coverage-missing.sh
+++ b/scripts/coverage-missing.sh
@@ -24,7 +24,7 @@
 #   0  every measured line is covered
 #   1  one or more lines are uncovered (the `file: line` list is printed above)
 
-set -eu
+set -euo pipefail
 
 # Crates excluded from workspace coverage, kept in sync with the
 # `test:coverage:workspace` script in the root package.json.

--- a/scripts/coverage-missing.sh
+++ b/scripts/coverage-missing.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# scripts/coverage-missing.sh
+#
+# Pinpoint uncovered lines in the Rust workspace using cargo-llvm-cov.
+#
+# This is the diagnostic companion to `pnpm test:coverage:workspace`, which only
+# reports pass/fail percentages per file. This script additionally prints the
+# exact `file: line` list of code that no test exercises, so you know precisely
+# which branches still need a test.
+#
+# REQUIREMENTS
+#   - Rust nightly toolchain          : rustup toolchain install nightly
+#   - cargo-llvm-cov + cargo-nextest  : cargo install cargo-llvm-cov cargo-nextest --locked
+#
+# USAGE
+#   scripts/coverage-missing.sh                 # whole workspace (matches CI excludes)
+#   scripts/coverage-missing.sh stylex_css      # single crate (fast iteration)
+#   scripts/coverage-missing.sh -p stylex_css   # same, explicit flag
+#   scripts/coverage-missing.sh --html          # also write an HTML report, print its path
+#   scripts/coverage-missing.sh --open          # write + open the HTML report in a browser
+#   scripts/coverage-missing.sh -h | --help
+#
+# EXIT STATUS
+#   0  every measured line is covered
+#   1  one or more lines are uncovered (the `file: line` list is printed above)
+
+set -eu
+
+# Crates excluded from workspace coverage, kept in sync with the
+# `test:coverage:workspace` script in the root package.json.
+WORKSPACE_EXCLUDES="--exclude stylex_logs \
+  --exclude stylex_compiler_rs \
+  --exclude stylex_test_parser \
+  --exclude stylex_css_parser \
+  --exclude stylex_transform"
+
+# Generated test/bench/example files are never counted, matching CI.
+IGNORE_REGEX='(tests?|benches?|examples)/'
+
+usage() {
+  sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+package=""
+html=0
+open=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h | --help) usage 0 ;;
+    --html) html=1 ;;
+    --open)
+      html=1
+      open=1
+      ;;
+    -p | --package)
+      [ $# -ge 2 ] || { echo "error: $1 requires a crate name" >&2; exit 2; }
+      package="$2"
+      shift
+      ;;
+    -*) echo "error: unknown option '$1' (try --help)" >&2; exit 2 ;;
+    *)
+      if [ -n "$package" ]; then
+        echo "error: unexpected argument '$1'" >&2
+        exit 2
+      fi
+      package="$1"
+      ;;
+  esac
+  shift
+done
+
+# Select scope: a single crate (fast) or the whole workspace (CI parity).
+if [ -n "$package" ]; then
+  scope="-p $package"
+  echo "==> Coverage for crate: $package"
+else
+  # shellcheck disable=SC2086
+  scope="--workspace $WORKSPACE_EXCLUDES"
+  echo "==> Coverage for workspace (excluding non-instrumented crates)"
+fi
+
+# `--show-missing-lines` prints the uncovered `file: line` list.
+# `--fail-uncovered-lines 0` makes the command exit non-zero if any remain,
+# so this script is CI-friendly and usable as a pre-commit gate.
+report_flags="--show-missing-lines --fail-uncovered-lines 0"
+
+if [ "$html" -eq 1 ]; then
+  report_flags="$report_flags --html"
+  [ "$open" -eq 1 ] && report_flags="$report_flags --open"
+fi
+
+# shellcheck disable=SC2086
+cargo +nightly llvm-cov nextest \
+  $scope \
+  --all-features \
+  --ignore-filename-regex "$IGNORE_REGEX" \
+  $report_flags


### PR DESCRIPTION
- Added `restore_negative_leading_zero` function to handle cases where SWC's CSS minifier strips leading zeros from negative decimals.
- Updated `normalize_css_property_value` to utilize the new function.
- Enhanced tests to verify the correct restoration of leading zeros in various scenarios, ensuring consistency with Babel's behavior.
- Updated imports in relevant files to include the new normalizer function.

## Description

This pull request fixes a bug where negative decimal CSS values (like `-.24px`) were incorrectly normalized by stripping their leading zero, which caused mismatched class names between compilers. It introduces a new normalizer to restore the leading zero for negative decimals, updates affected code paths, adds comprehensive tests, and improves documentation for coverage tooling.

**Negative decimal normalization and bug fix:**

* Added the `restore_negative_leading_zero` function in `base.rs` to restore the leading zero for negative decimal CSS values (e.g., `-.24px` → `-0.24px`), ensuring class name hashes match those from Babel and fixing cross-compiler mismatches.
* Integrated `restore_negative_leading_zero` into the CSS property normalization pipeline in `common.rs`. [[1]](diffhunk://#diff-a5328fecac28c42cbdb7fcd4b0b78704003088a7a31e437307876f1b84011eaeL6-R9) [[2]](diffhunk://#diff-a5328fecac28c42cbdb7fcd4b0b78704003088a7a31e437307876f1b84011eaeR715)

**Testing and verification:**

* Added extensive unit tests for `restore_negative_leading_zero`, covering edge cases such as quoted strings, subtraction operators, multibyte characters, and values without negative decimals.
* Added a new test in the transform suite to verify that negative decimals keep their leading zero and produce the correct class names.
* Updated transform test snapshots and output files to reflect the new normalization behavior and resulting class names. [[1]](diffhunk://#diff-d62ddacd377e6948a5ffd6765b9071e7bd8ce1b9e7d5232fcde1a39bd1e488cfR1-R11) [[2]](diffhunk://#diff-1c5515aecd2664b0e0edbaefa6e58cd78f7e93a2ebe6f5d6702a403b8a759624L82-R90) [[3]](diffhunk://#diff-1c5515aecd2664b0e0edbaefa6e58cd78f7e93a2ebe6f5d6702a403b8a759624L152-R158) [[4]](diffhunk://#diff-9fb4cf6461bb2c7ae32d4b9ac27332fb2464d0134ad942857559deb4abaf58daL38-R44)

**Developer tooling/documentation:**

* Added documentation to `SCRIPTS.md` describing how to find uncovered lines using the new `coverage-missing.sh` script.
* Introduced the `scripts/coverage-missing.sh` utility to print exact uncovered lines in Rust code, aiding in test coverage efforts.

## Fixes

(Optional) Fixes #1049

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
