### PR TITLE
fix(stylex_position_try): improve RTL handling and add tests

### DIFF
--- a/crates/stylex-css/src/utils/pre_rule.rs
+++ b/crates/stylex-css/src/utils/pre_rule.rs
@@ -26,7 +26,7 @@ pub fn sort_pseudos(pseudos: &[String]) -> Vec<String> {
     .flat_map(|pseudo| {
       if pseudo.len() > 1 {
         let mut sorted_pseudo = pseudo;
-        sorted_pseudo.sort();
+        sorted_pseudo.sort_unstable();
         sorted_pseudo
       } else {
         pseudo
@@ -38,7 +38,7 @@ pub fn sort_pseudos(pseudos: &[String]) -> Vec<String> {
 pub fn sort_at_rules(at_rules: &[String]) -> Vec<String> {
   let mut unsorted_at_rules = at_rules.to_vec();
 
-  unsorted_at_rules.sort_by(|a, b| string_comparator(a, b));
+  unsorted_at_rules.sort_unstable_by(|a, b| string_comparator(a, b));
 
   unsorted_at_rules
 }

--- a/crates/stylex-transform/src/shared/transformers/stylex_create_theme.rs
+++ b/crates/stylex-transform/src/shared/transformers/stylex_create_theme.rs
@@ -47,7 +47,7 @@ pub(crate) fn stylex_create_theme(
   };
   let mut variables_key_values = Box::new(get_key_values_from_object(variables_obj));
 
-  variables_key_values.sort_by_key(convert_key_value_to_str);
+  variables_key_values.sort_unstable_by_key(convert_key_value_to_str);
 
   let var_group_hash: String;
   let mut theme_vars_key_values: Vec<KeyValueProp>;
@@ -128,7 +128,7 @@ pub(crate) fn stylex_create_theme(
   // But also put "default" first
   let mut sorted_at_rules = rules_by_at_rule.keys().collect::<Vec<&String>>();
 
-  sorted_at_rules.sort_by(|a, b| {
+  sorted_at_rules.sort_unstable_by(|a, b| {
     if a.as_str() == "default" {
       Ordering::Less
     } else if b.as_str() == "default" {

--- a/crates/stylex-transform/src/shared/transformers/stylex_position_try.rs
+++ b/crates/stylex-transform/src/shared/transformers/stylex_position_try.rs
@@ -115,18 +115,17 @@ pub(crate) fn stylex_position_try(
     })
     .unwrap_or_default();
 
-    let key = tuple.0.clone();
-
     let pair = Pair {
-      key: key.clone(),
+      key: tuple.0.clone(),
       value: value.clone(),
     };
 
-    let rtl_values = generate_rtl(&pair, &options);
-
-    match rtl_values {
+    // When no RTL transform applies, the fallback is the bare value (a string),
+    // which serializes to `key:value;` rather than the doubled `key:key;key:value;`
+    // form produced for the LTR `[key, value]` tuple.
+    match generate_rtl(&pair, &options) {
       Some(rtl_value) => Rc::new(FlatCompiledStylesValue::KeyValue(rtl_value.into_owned())),
-      None => Rc::new(FlatCompiledStylesValue::KeyValue(Pair { key, value })),
+      None => Rc::new(FlatCompiledStylesValue::String(value)),
     }
   });
 
@@ -192,12 +191,13 @@ fn construct_position_try_obj(styles: FlatCompiledStyles) -> String {
       FlatCompiledStylesValue::String(val) => {
         let _ = write!(output, "{}:{};", k, val);
       },
+      // A `[key, value]` tuple serializes each element as a value under the outer key
       FlatCompiledStylesValue::KeyValue(pair) => {
-        let _ = write!(output, "{}:{};{}:{};", k, k, pair.key, pair.value);
+        let _ = write!(output, "{}:{};{}:{};", k, pair.key, k, pair.value);
       },
       FlatCompiledStylesValue::KeyValues(pairs) => {
         for pair in pairs {
-          let _ = write!(output, "{}:{};{}:{};", k, k, pair.key, pair.value);
+          let _ = write!(output, "{}:{};{}:{};", k, pair.key, k, pair.value);
         }
       },
       _ => {},

--- a/crates/stylex-transform/src/shared/transformers/stylex_position_try.rs
+++ b/crates/stylex-transform/src/shared/transformers/stylex_position_try.rs
@@ -85,18 +85,7 @@ pub(crate) fn stylex_position_try(
     ObjMapType::Object(extended_object.clone()),
     state,
     |style, _| {
-      let Some(tuple) = style.as_tuple() else {
-        stylex_panic!("{}", THEME_VAR_TUPLE)
-      };
-
-      let pair = Pair {
-        key: tuple.0.clone(),
-        value: convert_lit_to_string(match tuple.1.as_lit() {
-          Some(lit) => lit,
-          None => stylex_panic!("{}", VALUE_MUST_BE_STRING),
-        })
-        .unwrap_or_default(),
-      };
+      let pair = tuple_to_pair(style.as_ref());
 
       let ltr_values = generate_ltr(&pair, &options).into_owned();
 
@@ -105,20 +94,7 @@ pub(crate) fn stylex_position_try(
   );
 
   let rtl_styles = obj_map(ObjMapType::Object(extended_object), state, |style, _| {
-    let Some(tuple) = style.as_tuple() else {
-      stylex_panic!("{}", THEME_VAR_TUPLE)
-    };
-
-    let value = convert_lit_to_string(match tuple.1.as_lit() {
-      Some(lit) => lit,
-      None => stylex_panic!("{}", VALUE_MUST_BE_STRING),
-    })
-    .unwrap_or_default();
-
-    let pair = Pair {
-      key: tuple.0.clone(),
-      value,
-    };
+    let pair = tuple_to_pair(style.as_ref());
 
     // When no RTL transform applies, the fallback is the bare value (a string),
     // which serializes to `key:value;` rather than the doubled `key:key;key:value;`
@@ -129,8 +105,8 @@ pub(crate) fn stylex_position_try(
     }
   });
 
-  let ltr_string = construct_position_try_obj(ltr_styles);
-  let rtl_string = construct_position_try_obj(rtl_styles);
+  let ltr_string = construct_position_try_obj(&ltr_styles);
+  let rtl_string = construct_position_try_obj(&rtl_styles);
 
   let position_try_name = format!("--{}{}", class_name_prefix, create_hash(&ltr_string));
 
@@ -174,15 +150,33 @@ pub(crate) fn get_position_try_fn() -> FunctionConfig {
   }
 }
 
-fn construct_position_try_obj(styles: FlatCompiledStyles) -> String {
-  // Collect and sort keys for deterministic output
-  let mut sorted_keys = styles.keys().cloned().collect::<Vec<String>>();
-  sorted_keys.sort();
+fn tuple_to_pair(style: &FlatCompiledStylesValue) -> Pair {
+  let Some(tuple) = style.as_tuple() else {
+    stylex_panic!("{}", THEME_VAR_TUPLE)
+  };
+
+  let Some(lit) = tuple.1.as_lit() else {
+    stylex_panic!("{}", VALUE_MUST_BE_STRING)
+  };
+
+  let Some(value) = convert_lit_to_string(lit) else {
+    stylex_panic!("{}", VALUE_MUST_BE_STRING)
+  };
+
+  Pair {
+    key: tuple.0.clone(),
+    value,
+  }
+}
+
+fn construct_position_try_obj(styles: &FlatCompiledStyles) -> String {
+  let mut sorted_keys = styles.keys().collect::<Vec<_>>();
+  sorted_keys.sort_unstable();
 
   let mut output = String::with_capacity(sorted_keys.len().saturating_mul(32));
 
   for k in sorted_keys {
-    let v = match styles.get(&k) {
+    let v = match styles.get(k) {
       Some(v) => v,
       None => stylex_panic!("Expected property key to exist in compiled styles."),
     };
@@ -191,7 +185,7 @@ fn construct_position_try_obj(styles: FlatCompiledStyles) -> String {
       FlatCompiledStylesValue::String(val) => {
         let _ = write!(output, "{}:{};", k, val);
       },
-      // A `[key, value]` tuple serializes each element as a value under the outer key
+      // Array values are serialized as repeated values under the outer key.
       FlatCompiledStylesValue::KeyValue(pair) => {
         let _ = write!(output, "{}:{};{}:{};", k, pair.key, k, pair.value);
       },

--- a/crates/stylex-transform/src/shared/transformers/stylex_position_try.rs
+++ b/crates/stylex-transform/src/shared/transformers/stylex_position_try.rs
@@ -91,7 +91,7 @@ pub(crate) fn stylex_position_try(
 
       let pair = Pair {
         key: tuple.0.clone(),
-        value: convert_lit_to_string(match tuple.1.clone().as_lit() {
+        value: convert_lit_to_string(match tuple.1.as_lit() {
           Some(lit) => lit,
           None => stylex_panic!("{}", VALUE_MUST_BE_STRING),
         })
@@ -109,7 +109,7 @@ pub(crate) fn stylex_position_try(
       stylex_panic!("{}", THEME_VAR_TUPLE)
     };
 
-    let value = convert_lit_to_string(match tuple.1.clone().as_lit() {
+    let value = convert_lit_to_string(match tuple.1.as_lit() {
       Some(lit) => lit,
       None => stylex_panic!("{}", VALUE_MUST_BE_STRING),
     })
@@ -117,7 +117,7 @@ pub(crate) fn stylex_position_try(
 
     let pair = Pair {
       key: tuple.0.clone(),
-      value: value.clone(),
+      value,
     };
 
     // When no RTL transform applies, the fallback is the bare value (a string),
@@ -125,7 +125,7 @@ pub(crate) fn stylex_position_try(
     // form produced for the LTR `[key, value]` tuple.
     match generate_rtl(&pair, &options) {
       Some(rtl_value) => Rc::new(FlatCompiledStylesValue::KeyValue(rtl_value.into_owned())),
-      None => Rc::new(FlatCompiledStylesValue::String(value)),
+      None => Rc::new(FlatCompiledStylesValue::String(pair.value)),
     }
   });
 

--- a/crates/stylex-transform/src/shared/utils/core/define_vars_utils.rs
+++ b/crates/stylex-transform/src/shared/utils/core/define_vars_utils.rs
@@ -111,7 +111,7 @@ pub(crate) fn collect_vars_by_at_rules(
         "default".to_string()
       } else {
         let mut keys = at_rules.to_vec();
-        keys.sort();
+        keys.sort_unstable();
         keys.join(SPLIT_TOKEN)
       };
 

--- a/crates/stylex-transform/src/shared/utils/core/tests/stylex_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/core/tests/stylex_tests.rs
@@ -411,11 +411,11 @@ fn with_complicated_set_of_arguments() {
   assert_eq!(classname_string, repeat_classname_string);
 
   let mut parts: Vec<_> = classname_string.split_whitespace().collect();
-  parts.sort();
+  parts.sort_unstable();
   let result_classname_string = parts.join(" ");
 
   let mut parts: Vec<_> = "g5ia77u1 tpe1esc0 gewhe1h2 gcovof34 bdao358l a8c37x1j s5oniofx kvgmc6g5 cxmmr5t8 oygrvhab hcukyx3x jb3vyjys rz4wbd8a qt6c0cv9 a8nywdso oajrlxb2 i1ao9s8h myohyog2 n3t5jt4f gh25dzvf g4tp4svg nhd2j8a9 f1sip0of icdlwmnq e4t7hp5w gmql0nx0 ihxqhq3m l94mrbxd aenfhxwr k4urcfbm gofk2cf1 ksdfmwjs tm8avpzi bj9fd4vl".split_whitespace().collect();
-  parts.sort();
+  parts.sort_unstable();
   let expected_classname_string = parts.join(" ");
 
   assert_eq!(result_classname_string, expected_classname_string);

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_define_vars_call/helpers.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_define_vars_call/helpers.rs
@@ -161,7 +161,7 @@ pub(super) fn assert_no_define_vars_cycles(dependency_map: &FxHashMap<Atom, FxHa
 
   // Sort keys for deterministic error messages across platforms.
   let mut keys: Vec<&Atom> = dependency_map.keys().collect();
-  keys.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
+  keys.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
 
   for key in keys {
     if !visited.contains(key) {
@@ -195,7 +195,7 @@ fn detect_cycle(
 
   if let Some(deps) = dependency_map.get(node) {
     let mut sorted_deps: Vec<&Atom> = deps.iter().collect();
-    sorted_deps.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
+    sorted_deps.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
 
     for dep in sorted_deps {
       if !visited.contains(dep) {

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/create_with_position_try_object_logical_rtl.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/create_with_position_try_object_logical_rtl.js
@@ -1,0 +1,18 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as stylex from '@stylexjs/stylex';
+_inject2({
+    ltr: "@position-try --x19wrq7r{inset-inline-start:inset-inline-start;inset-inline-start:0;top:top;top:10px;}",
+    priority: 0,
+    rtl: "@position-try --x19wrq7r{inset-inline-start:0;top:10px;}"
+});
+_inject2({
+    ltr: ".xwfam2r{position-try-fallbacks:--x19wrq7r}",
+    priority: 3000
+});
+export const styles = {
+    foo: {
+        k9M3vk: "xwfam2r",
+        $$css: true
+    }
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/create_with_position_try_object_rtl.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/create_with_position_try_object_rtl.js
@@ -1,0 +1,18 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as stylex from '@stylexjs/stylex';
+_inject2({
+    ltr: "@position-try --xcj43v6{left:left;left:10px;top:top;top:0;}",
+    priority: 0,
+    rtl: "@position-try --xcj43v6{left:10px;top:0;}"
+});
+_inject2({
+    ltr: ".x1brxqts{position-try-fallbacks:--xcj43v6}",
+    priority: 3000
+});
+export const styles = {
+    foo: {
+        k9M3vk: "x1brxqts",
+        $$css: true
+    }
+};

--- a/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
@@ -859,3 +859,14 @@ stylex_test!(
     });
   "#
 );
+
+stylex_test!(
+  create_with_position_try_object_rtl,
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    const positionTryObject = stylex.positionTry({ top: '0', left: '10px' });
+
+    export const styles = stylex.create({ foo: { positionTryFallbacks: positionTryObject } });
+  "#
+);

--- a/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
@@ -870,3 +870,14 @@ stylex_test!(
     export const styles = stylex.create({ foo: { positionTryFallbacks: positionTryObject } });
   "#
 );
+
+stylex_test!(
+  create_with_position_try_object_logical_rtl,
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    const positionTryObject = stylex.positionTry({ insetInlineStart: '0', top: '10px' });
+
+    export const styles = stylex.create({ foo: { positionTryFallbacks: positionTryObject } });
+  "#
+);

--- a/crates/stylex-utils/src/tests/collection_test.rs
+++ b/crates/stylex-utils/src/tests/collection_test.rs
@@ -180,28 +180,28 @@ mod sort_numbers_factory_tests {
   #[test]
   fn sorts_ascending() {
     let mut nums = vec![3.0, 1.0, 2.0];
-    nums.sort_by(sort_numbers_factory());
+    nums.sort_unstable_by(sort_numbers_factory());
     assert_eq!(nums, vec![1.0, 2.0, 3.0]);
   }
 
   #[test]
   fn sorts_with_negatives() {
     let mut nums = vec![0.0, -1.0, 1.0, -2.0];
-    nums.sort_by(sort_numbers_factory());
+    nums.sort_unstable_by(sort_numbers_factory());
     assert_eq!(nums, vec![-2.0, -1.0, 0.0, 1.0]);
   }
 
   #[test]
   fn sorts_already_sorted() {
     let mut nums = vec![1.0, 2.0, 3.0];
-    nums.sort_by(sort_numbers_factory());
+    nums.sort_unstable_by(sort_numbers_factory());
     assert_eq!(nums, vec![1.0, 2.0, 3.0]);
   }
 
   #[test]
   fn handles_empty() {
     let mut nums: Vec<f64> = vec![];
-    nums.sort_by(sort_numbers_factory());
+    nums.sort_unstable_by(sort_numbers_factory());
     assert!(nums.is_empty());
   }
 }


### PR DESCRIPTION
- Updated the `stylex_position_try` function to simplify RTL value generation and fallback handling.
- Changed the serialization of `KeyValue` pairs to ensure correct output format.
- Added a new test case for creating position try objects with RTL support in `static_styles.rs`.

## Description

This pull request updates the serialization logic for RTL (right-to-left) and LTR (left-to-right) style transformations in the `stylex_position_try` transformer, ensuring that fallback values are handled correctly and that the generated CSS output is accurate. It also adds new tests to verify the behavior for RTL scenarios.

**Improvements to style serialization and RTL handling:**

* Updated the fallback serialization logic in `stylex_position_try.rs` so that when no RTL transform applies, the fallback is now a simple string value (e.g., `key:value;`) instead of duplicating the key, ensuring correct CSS output for both LTR and RTL cases.
* Fixed the serialization of `[key, value]` tuples in `construct_position_try_obj` to ensure the correct order of keys and values in the generated CSS.

**Testing enhancements:**

* Added a new test case (`create_with_position_try_object_rtl`) to verify that `stylex.positionTry` with RTL input produces the expected injected CSS, improving test coverage for RTL scenarios. [[1]](diffhunk://#diff-4f871c7e50939e4a7f2ade15f531e673cd4406247a9285898923d32074053eeeR862-R872) [[2]](diffhunk://#diff-37c3feae197f5881d36fa48bb656fb911786cd3182aa850913a3809a9a4b86dcR1-R18)

## Fixes

Fixes #1046 

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
