### PR TITLE
chore: update Rust version to 1.96.0 across configuration files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
       "pnpmVersion": "10.30.3"
     },
     "ghcr.io/devcontainers/features/rust:1": {
-      "version": "1.95.0",
+      "version": "1.96.0",
       "targets": [
         "wasm32-wasip1",
         "x86_64-apple-darwin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/stylex-*"]
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/Dwlad90/stylex-swc-plugin.git"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 version = "0.16.5"
 
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -22,5 +22,5 @@ ignore-interior-mutability = [
   "swc_atoms::JsWord",
   "swc_ecma_ast::Id",
 ]
-msrv = "1.95.0"
+msrv = "1.96.0"
 type-complexity-threshold = 25000

--- a/crates/stylex-css-parser/Cargo.toml
+++ b/crates/stylex-css-parser/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 description = "CSS value parser"
-edition = "2024"
-license = "MIT"
+edition.workspace = true
+license.workspace = true
 name = "stylex_css_parser"
-repository = "https://github.com/Dwlad90/stylex-swc-plugin.git"
-rust-version = "1.95.0"
-version = "0.16.5"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]
 targets = [
   "wasm32-wasip1",


### PR DESCRIPTION
- Updated the Rust version in `Cargo.toml`, `clippy.toml`, and `rust-toolchain.toml` to 1.96.0 for consistency.
- Adjusted the version in the `.devcontainer/devcontainer.json` to align with the new Rust version.
- Modified `Cargo.toml` in `stylex-css-parser` to use workspace settings for edition, license, repository, and rust-version.

## Description

This pull request updates the project to Rust 1.96.0 and refactors configuration to use workspace inheritance for shared metadata. The main changes ensure consistency across toolchain, build, and linting configurations, and simplify crate-level configuration.

**Rust version upgrade:**

* Updated the Rust toolchain version to `1.96.0` in `rust-toolchain.toml`, `.devcontainer/devcontainer.json`, and set the minimum supported Rust version (`msrv`) to `1.96.0` in `clippy.toml`. [[1]](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL2-R2) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L10-R10) [[3]](diffhunk://#diff-f3dbfb2563c3490394f44c26b51837018e79a79e75fd31e89b19e943a38317eaL25-R25)
* Updated the `rust-version` field in the workspace root `Cargo.toml` to `1.96.0`.

**Configuration simplification:**

* Refactored `crates/stylex-css-parser/Cargo.toml` to inherit `edition`, `license`, `repository`, `rust-version`, and `version` from the workspace, reducing duplication.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
