### PR TITLE
feat(stylexswc/unplugin): Enhance StyleX plugin with CSS transformation capabilities

### DIFF
--- a/packages/unplugin/__tests__/rollup.test.ts
+++ b/packages/unplugin/__tests__/rollup.test.ts
@@ -79,4 +79,20 @@ describe('@stylexswc/unplugin/rollup', () => {
 
     expect(css?.source).toMatchSnapshot();
   });
+
+  test('transforms extracted CSS before emit', async () => {
+    const seenFilePaths: Array<string | undefined> = [];
+    const { css } = await runStylex({
+      fileName: 'stylex.css',
+      async transformCss(css, filePath) {
+        seenFilePaths.push(filePath);
+
+        return `${css}\n/* transformed:${filePath} */`;
+      },
+    });
+
+    expect(seenFilePaths).toEqual(['stylex.css']);
+    expect(css).toContain('color');
+    expect(css).toContain('/* transformed:stylex.css */');
+  });
 });

--- a/packages/unplugin/__tests__/unplugin.test.ts
+++ b/packages/unplugin/__tests__/unplugin.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import * as rollup from 'rollup';
-import type { UnpluginBuildContext, UnpluginContext } from 'unplugin';
+import type { UnpluginBuildContext, UnpluginContext, UnpluginContextMeta } from 'unplugin';
 import { vi, describe, expect, test } from 'vitest';
 
 import unplugin from '../src';
@@ -10,11 +10,7 @@ import stylexPlugin from '../src/rollup';
 
 type TestPluginInstance = {
   buildStart?: (this: UnpluginBuildContext) => void;
-  transform?: (
-    this: UnpluginBuildContext & UnpluginContext,
-    code: string,
-    id: string
-  ) => unknown;
+  transform?: (this: UnpluginBuildContext & UnpluginContext, code: string, id: string) => unknown;
   webpack?: (compiler: unknown) => void;
   rspack?: (compiler: unknown) => void;
 };
@@ -75,7 +71,7 @@ async function runWebpackLikeCssInjection(framework: 'webpack' | 'rspack') {
         dev: false,
       },
     },
-    { framework } as never
+    { framework } as UnpluginContextMeta
   );
   const pluginInstance = (Array.isArray(plugin) ? plugin[0] : plugin) as TestPluginInstance;
 
@@ -85,23 +81,17 @@ async function runWebpackLikeCssInjection(framework: 'webpack' | 'rspack') {
 
   await collectStyleXRules(pluginInstance);
 
-  let processAssetsCallback:
-    | ((assets: Record<string, ReturnType<typeof createMockCssAsset>>) => Promise<void>)
-    | undefined;
+  type MockAssets = Record<string, ReturnType<typeof createMockCssAsset>>;
+  let processAssetsCallback: ((assets: MockAssets) => Promise<void>) | undefined;
   const assets = {
     'app.css': createMockCssAsset('body{margin:0}\n@stylex;'),
   };
   const compilation = {
     hooks: {
       processAssets: {
-        tapPromise: vi.fn(
-          (
-            _options: unknown,
-            callback: (assets: Record<string, ReturnType<typeof createMockCssAsset>>) => Promise<void>
-          ) => {
-            processAssetsCallback = callback;
-          }
-        ),
+        tapPromise: vi.fn((_options: unknown, callback: (assets: MockAssets) => Promise<void>) => {
+          processAssetsCallback = callback;
+        }),
       },
     },
     updateAsset: vi.fn((fileName: string, source: ReturnType<typeof createMockCssAsset>) => {

--- a/packages/unplugin/__tests__/unplugin.test.ts
+++ b/packages/unplugin/__tests__/unplugin.test.ts
@@ -8,6 +8,149 @@ import { vi, describe, expect, test } from 'vitest';
 import unplugin from '../src';
 import stylexPlugin from '../src/rollup';
 
+type TestPluginInstance = {
+  buildStart?: (this: UnpluginBuildContext) => void;
+  transform?: (
+    this: UnpluginBuildContext & UnpluginContext,
+    code: string,
+    id: string
+  ) => unknown;
+  webpack?: (compiler: unknown) => void;
+  rspack?: (compiler: unknown) => void;
+};
+
+const stylexSource = `
+  import * as stylex from '@stylexjs/stylex';
+  const styles = stylex.create({ foo: { color: 'red' } });
+  export default styles;
+`;
+
+function createMockContext(): Partial<UnpluginBuildContext & UnpluginContext> {
+  return {
+    addWatchFile: () => {},
+    emitFile: () => '',
+    getWatchFiles: () => [],
+    parse: () => ({}) as ReturnType<UnpluginBuildContext['parse']>,
+    error: () => {},
+    warn: () => {},
+  };
+}
+
+function createMockCssAsset(source: string) {
+  return {
+    source: () => ({
+      toString: () => source,
+    }),
+  };
+}
+
+async function collectStyleXRules(pluginInstance: TestPluginInstance) {
+  const mockContext = createMockContext();
+
+  if (typeof pluginInstance.buildStart === 'function') {
+    pluginInstance.buildStart.call(mockContext as UnpluginBuildContext);
+  }
+
+  if (typeof pluginInstance.transform !== 'function') {
+    throw new Error('Transform is not a function');
+  }
+
+  await pluginInstance.transform.call(
+    mockContext as UnpluginBuildContext & UnpluginContext,
+    stylexSource,
+    '/virtual/foo.js'
+  );
+}
+
+async function runWebpackLikeCssInjection(framework: 'webpack' | 'rspack') {
+  const transformCss = vi.fn(async (css: string, filePath: string | undefined) => {
+    return `${css}\n/* transformed:${framework}:${filePath} */`;
+  });
+  const plugin = unplugin.raw(
+    {
+      useCssPlaceholder: true,
+      transformCss,
+      rsOptions: {
+        runtimeInjection: false,
+        dev: false,
+      },
+    },
+    { framework } as never
+  );
+  const pluginInstance = (Array.isArray(plugin) ? plugin[0] : plugin) as TestPluginInstance;
+
+  if (!pluginInstance) {
+    throw new Error('Plugin instance is undefined');
+  }
+
+  await collectStyleXRules(pluginInstance);
+
+  let processAssetsCallback:
+    | ((assets: Record<string, ReturnType<typeof createMockCssAsset>>) => Promise<void>)
+    | undefined;
+  const assets = {
+    'app.css': createMockCssAsset('body{margin:0}\n@stylex;'),
+  };
+  const compilation = {
+    hooks: {
+      processAssets: {
+        tapPromise: vi.fn(
+          (
+            _options: unknown,
+            callback: (assets: Record<string, ReturnType<typeof createMockCssAsset>>) => Promise<void>
+          ) => {
+            processAssetsCallback = callback;
+          }
+        ),
+      },
+    },
+    updateAsset: vi.fn((fileName: string, source: ReturnType<typeof createMockCssAsset>) => {
+      assets[fileName as keyof typeof assets] = source;
+    }),
+    emitAsset: vi.fn(),
+  };
+  const compiler = {
+    webpack: {
+      Compilation: {
+        PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE: 0,
+      },
+      sources: {
+        RawSource: class RawSource {
+          #source: string;
+
+          constructor(source: string) {
+            this.#source = source;
+          }
+
+          source() {
+            return {
+              toString: () => this.#source,
+            };
+          }
+        },
+      },
+    },
+    hooks: {
+      thisCompilation: {
+        tap: vi.fn((_name: string, callback: (compilation: unknown) => void) =>
+          callback(compilation)
+        ),
+      },
+    },
+  };
+
+  const applyBundlerHook = pluginInstance[framework];
+
+  if (typeof applyBundlerHook !== 'function') {
+    throw new Error(`${framework} hook is not a function`);
+  }
+
+  applyBundlerHook(compiler);
+  await processAssetsCallback?.(assets);
+
+  return { assets, compilation, transformCss };
+}
+
 describe('@stylexswc/unplugin', () => {
   test('ignores files without StyleX imports', async () => {
     const plugin = unplugin.raw({}, { framework: 'rollup' });
@@ -46,12 +189,7 @@ describe('@stylexswc/unplugin', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stylex-unplugin-test-'));
 
     const inputFile = path.join(tempDir, 'input.js');
-    const source = `
-      import * as stylex from '@stylexjs/stylex';
-      const styles = stylex.create({ foo: { color: 'red' } });
-      export default styles;
-    `;
-    fs.writeFileSync(inputFile, source);
+    fs.writeFileSync(inputFile, stylexSource);
 
     try {
       const bundle = await rollup.rollup({
@@ -91,6 +229,32 @@ describe('@stylexswc/unplugin', () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  test('webpack hook transforms StyleX CSS before placeholder injection', async () => {
+    const { assets, compilation, transformCss } = await runWebpackLikeCssInjection('webpack');
+    const finalCSS = assets['app.css'].source().toString();
+
+    expect(transformCss).toHaveBeenCalledTimes(1);
+    expect(transformCss.mock.calls[0]?.[1]).toBe('app.css');
+    expect(compilation.updateAsset).toHaveBeenCalledTimes(1);
+    expect(finalCSS).toContain('body{margin:0}');
+    expect(finalCSS).toContain('color:red');
+    expect(finalCSS).toContain('/* transformed:webpack:app.css */');
+    expect(finalCSS).not.toContain('@stylex;');
+  });
+
+  test('rspack hook transforms StyleX CSS before placeholder injection', async () => {
+    const { assets, compilation, transformCss } = await runWebpackLikeCssInjection('rspack');
+    const finalCSS = assets['app.css'].source().toString();
+
+    expect(transformCss).toHaveBeenCalledTimes(1);
+    expect(transformCss.mock.calls[0]?.[1]).toBe('app.css');
+    expect(compilation.updateAsset).toHaveBeenCalledTimes(1);
+    expect(finalCSS).toContain('body{margin:0}');
+    expect(finalCSS).toContain('color:red');
+    expect(finalCSS).toContain('/* transformed:rspack:app.css */');
+    expect(finalCSS).not.toContain('@stylex;');
   });
 
   test('transform error includes the file path and preserves cause', async () => {

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -131,17 +131,18 @@ async function invalidateAndCollectCssModules(
  * Injects StyleX CSS into CSS assets for webpack/rspack bundlers.
  * Shared logic to avoid code duplication between webpack and rspack hooks.
  */
-function injectStyleXCss(
+async function injectStyleXCss(
   assets: Record<string, { source(): { toString(): string } }>,
   injectMarker: string,
   collectedCSS: string,
   fallbackFileName: string,
+  normalizedOptions: NormalizedOptions,
   /* eslint-disable @typescript-eslint/no-explicit-any */
   updateAsset: (fileName: string, source: any) => void,
   emitAsset: (fileName: string, source: any) => void,
   createRawSource: (content: string) => any
   /* eslint-enable @typescript-eslint/no-explicit-any */
-): void {
+): Promise<void> {
   const cssAssets = Object.keys(assets).filter(f => f.endsWith('.css'));
 
   // Try to find asset with the marker first
@@ -151,7 +152,8 @@ function injectStyleXCss(
     if (!asset) continue;
     const source = asset.source().toString();
     if (source.includes(injectMarker)) {
-      const newSource = source.replace(injectMarker, collectedCSS);
+      const finalCSS = await transformStyleXCSS(collectedCSS, fileName, normalizedOptions);
+      const newSource = source.replace(injectMarker, finalCSS);
       updateAsset(fileName, createRawSource(newSource));
       injected = true;
       break;
@@ -165,7 +167,8 @@ function injectStyleXCss(
       const asset = assets[targetAsset];
       if (asset) {
         const existing = asset.source().toString();
-        const newSource = existing ? existing + '\n' + collectedCSS : collectedCSS;
+        const finalCSS = await transformStyleXCSS(collectedCSS, targetAsset, normalizedOptions);
+        const newSource = existing ? existing + '\n' + finalCSS : finalCSS;
         updateAsset(targetAsset, createRawSource(newSource));
         injected = true;
       }
@@ -174,7 +177,8 @@ function injectStyleXCss(
 
   // Last resort: emit standalone stylex.css
   if (!injected) {
-    emitAsset(fallbackFileName, createRawSource(collectedCSS));
+    const finalCSS = await transformStyleXCSS(collectedCSS, fallbackFileName, normalizedOptions);
+    emitAsset(fallbackFileName, createRawSource(finalCSS));
   }
 }
 
@@ -298,7 +302,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
       }
     },
 
-    buildEnd() {
+    async buildEnd() {
       const framework = this.getNativeBuildContext?.().framework;
       if (framework === 'esbuild') {
         // will handle the CSS generation in the plugin itself
@@ -311,7 +315,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         return;
       }
 
-      const { processedFileName, collectedCSS } = generateCSSAssets(
+      const { processedFileName, collectedCSS } = await generateCSSAssets(
         stylexRules,
         normalizedOptions,
         transformedOptions
@@ -373,13 +377,13 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
             ? '/* StyleX styles will load after transformation */'
             : '/* No StyleX styles */';
         } else {
-          replacementCSS = collectedCSS;
+          replacementCSS = await transformStyleXCSS(collectedCSS, id, normalizedOptions);
         }
 
         return cssContent.replace(normalizedOptions.useCssPlaceholder, replacementCSS);
       },
 
-      generateBundle(_options, bundle) {
+      async generateBundle(_options, bundle) {
         if (!normalizedOptions.useCssPlaceholder) return;
 
         const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
@@ -405,7 +409,12 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
             normalizedOptions.useCssPlaceholder &&
             source.includes(normalizedOptions.useCssPlaceholder)
           ) {
-            output.source = source.replace(normalizedOptions.useCssPlaceholder, collectedCSS);
+            const finalCSS = await transformStyleXCSS(
+              collectedCSS,
+              output.fileName,
+              normalizedOptions
+            );
+            output.source = source.replace(normalizedOptions.useCssPlaceholder, finalCSS);
             injected = true;
             break;
           }
@@ -417,22 +426,32 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           const target = cssAssets.find(a => a.fileName === targetName);
           if (target && target.output.type === 'asset') {
             const existing = target.output.source.toString();
-            target.output.source = existing ? existing + '\n' + collectedCSS : collectedCSS;
+            const finalCSS = await transformStyleXCSS(
+              collectedCSS,
+              target.fileName,
+              normalizedOptions
+            );
+            target.output.source = existing ? existing + '\n' + finalCSS : finalCSS;
             injected = true;
           }
         }
 
         // Last resort: emit standalone stylex.css if no CSS assets found
         if (!injected) {
+          const finalCSS = await transformStyleXCSS(
+            collectedCSS,
+            normalizedOptions.fileName,
+            normalizedOptions
+          );
           this.emitFile({
             type: 'asset',
             fileName: normalizedOptions.fileName,
-            source: collectedCSS,
+            source: finalCSS,
           });
         }
       },
 
-      buildEnd() {
+      async buildEnd() {
         // Skip emitting CSS file when using useCssPlaceholder
         // CSS will be injected into the specified file via generateBundle
         if (normalizedOptions.useCssPlaceholder) {
@@ -445,7 +464,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           return;
         }
 
-        const { processedFileName, collectedCSS } = generateCSSAssets(
+        const { processedFileName, collectedCSS } = await generateCSSAssets(
           stylexRules,
           normalizedOptions,
           transformedOptions,
@@ -469,10 +488,19 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         server.middlewares.use(
           (req: IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
             if (cssFileName && req.url?.includes(cssFileName)) {
-              const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
+              void (async () => {
+                const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
+                const finalCSS = collectedCSS
+                  ? await transformStyleXCSS(
+                      collectedCSS,
+                      cssFileName ?? undefined,
+                      normalizedOptions
+                    )
+                  : collectedCSS;
 
-              res.setHeader('Content-Type', 'text/css');
-              res.end(collectedCSS);
+                res.setHeader('Content-Type', 'text/css');
+                res.end(finalCSS);
+              })().catch(next);
               return;
             }
             next();
@@ -515,7 +543,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
 
         transformStyleXCode(file, inputCode, normalizedOptions, stylexRules, id);
 
-        const { processedFileName, collectedCSS } = generateCSSAssets(
+        const { processedFileName, collectedCSS } = await generateCSSAssets(
           stylexRules,
           normalizedOptions,
           transformedOptions,
@@ -555,7 +583,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           }
         }
       },
-      transformIndexHtml: (html, ctx) => {
+      transformIndexHtml: async (html, ctx) => {
         // Skip HTML injection when using useCssPlaceholder
         // CSS is injected into the specified CSS file
         if (normalizedOptions.useCssPlaceholder) {
@@ -564,7 +592,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
 
         const isDev = !!ctx.server;
 
-        const { processedFileName } = generateCSSAssets(
+        const { processedFileName } = await generateCSSAssets(
           stylexRules,
           normalizedOptions,
           transformedOptions,
@@ -641,7 +669,12 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
                 const { readFile } = await import('node:fs/promises');
                 const content = await readFile(cssFile, 'utf8');
                 if (content.includes(injectMarker)) {
-                  const newContent = content.replace(injectMarker, collectedCSS);
+                  const finalCSS = await transformStyleXCSS(
+                    collectedCSS,
+                    cssFile,
+                    normalizedOptions
+                  );
+                  const newContent = content.replace(injectMarker, finalCSS);
                   await writeFile(cssFile, newContent, 'utf8');
                   injected = true;
                   break;
@@ -660,7 +693,12 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
                   try {
                     const { readFile } = await import('node:fs/promises');
                     const existing = await readFile(fullPath, 'utf8');
-                    const newContent = existing ? existing + '\n' + collectedCSS : collectedCSS;
+                    const finalCSS = await transformStyleXCSS(
+                      collectedCSS,
+                      fullPath,
+                      normalizedOptions
+                    );
+                    const newContent = existing ? existing + '\n' + finalCSS : finalCSS;
                     await writeFile(fullPath, newContent, 'utf8');
                     injected = true;
                   } catch {
@@ -673,8 +711,13 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
             // Last resort: emit standalone stylex.css
             if (!injected) {
               const generatedCSSFileName = path.join(outDir, fileName);
+              const finalCSS = await transformStyleXCSS(
+                collectedCSS,
+                generatedCSSFileName,
+                normalizedOptions
+              );
               await mkdir(path.dirname(generatedCSSFileName), { recursive: true });
-              await writeFile(generatedCSSFileName, collectedCSS, 'utf8');
+              await writeFile(generatedCSSFileName, finalCSS, 'utf8');
             }
 
             return;
@@ -683,21 +726,27 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           // Default behavior: emit standalone CSS file
           if (shouldWriteToDisk) {
             const generatedCSSFileName = path.join(process.cwd(), fileName);
+            const finalCSS = await transformStyleXCSS(
+              collectedCSS,
+              generatedCSSFileName,
+              normalizedOptions
+            );
             await mkdir(path.dirname(generatedCSSFileName), {
               recursive: true,
             });
-            await writeFile(generatedCSSFileName, collectedCSS, 'utf8');
+            await writeFile(generatedCSSFileName, finalCSS, 'utf8');
 
             return;
           }
 
           if (outputFiles !== undefined) {
+            const finalCSS = await transformStyleXCSS(collectedCSS, fileName, normalizedOptions);
             outputFiles.push({
               path: '<stdout>',
-              contents: new TextEncoder().encode(collectedCSS),
-              hash: generateHash(collectedCSS),
+              contents: new TextEncoder().encode(finalCSS),
+              hash: generateHash(finalCSS),
               get text() {
-                return collectedCSS;
+                return finalCSS;
               },
             });
           }
@@ -706,7 +755,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
     },
     farm: {
       transformHtml: {
-        executor(resource) {
+        async executor(resource) {
           // Skip HTML injection when using useCssPlaceholder
           if (normalizedOptions.useCssPlaceholder) {
             return Promise.resolve(resource.htmlResource);
@@ -722,7 +771,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
 
           htmlResource.bytes = [...Buffer.from(htmlContent, 'utf-8')];
 
-          return Promise.resolve(resource.htmlResource);
+          return resource.htmlResource;
         },
       },
       // Farm uses Rollup-like bundle hooks, so generateBundle handles CSS injection
@@ -736,20 +785,21 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
       // Use processAssets hook to replace the CSS marker with actual StyleX content
       // This runs after all CSS is processed through loaders (PostCSS, etc.)
       compiler.hooks.thisCompilation.tap(PLUGIN_NAME, compilation => {
-        compilation.hooks.processAssets.tap(
+        compilation.hooks.processAssets.tapPromise(
           {
             name: PLUGIN_NAME,
             stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
           },
-          assets => {
+          async assets => {
             const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
             if (!collectedCSS) return;
 
-            injectStyleXCss(
+            await injectStyleXCss(
               assets,
               injectMarker,
               collectedCSS,
               normalizedOptions.fileName,
+              normalizedOptions,
               (fileName, source) => compilation.updateAsset(fileName, source),
               (fileName, source) => compilation.emitAsset(fileName, source),
               content => new compiler.webpack.sources.RawSource(content)
@@ -766,20 +816,21 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
       // Use processAssets hook to replace the CSS marker with actual StyleX content
       // This runs after all CSS is processed through loaders (PostCSS, etc.)
       compiler.hooks.thisCompilation.tap(PLUGIN_NAME, compilation => {
-        compilation.hooks.processAssets.tap(
+        compilation.hooks.processAssets.tapPromise(
           {
             name: PLUGIN_NAME,
             stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
           },
-          assets => {
+          async assets => {
             const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
             if (!collectedCSS) return;
 
-            injectStyleXCss(
+            await injectStyleXCss(
               assets,
               injectMarker,
               collectedCSS,
               normalizedOptions.fileName,
+              normalizedOptions,
               (fileName, source) => compilation.updateAsset(fileName, source),
               (fileName, source) => compilation.emitAsset(fileName, source),
               content => new compiler.webpack.sources.RawSource(content)
@@ -795,17 +846,39 @@ function ensureLeadingSlash(filePath: string) {
   return filePath.startsWith('/') ? filePath : `/${filePath}`;
 }
 
-function generateCSSAssets(
+async function generateCSSAssets(
   stylexRules: Record<string, [string, { ltr: string; rtl?: null | string }, number][]>,
   normalizedOptions: NormalizedOptions,
   transformedOptions: TransformedOptions,
   assetsDir?: string
 ) {
   const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
+  const initialProcessedFileName = getProcessedFileName(
+    normalizedOptions,
+    collectedCSS || '',
+    assetsDir
+  );
+  const finalCSS = collectedCSS
+    ? await transformStyleXCSS(
+        collectedCSS,
+        initialProcessedFileName ?? undefined,
+        normalizedOptions
+      )
+    : collectedCSS;
 
-  const processedFileName = getProcessedFileName(normalizedOptions, collectedCSS || '', assetsDir);
+  const processedFileName = getProcessedFileName(normalizedOptions, finalCSS || '', assetsDir);
 
-  return { processedFileName, collectedCSS };
+  return { processedFileName, collectedCSS: finalCSS };
+}
+
+async function transformStyleXCSS(
+  css: string,
+  filePath: string | undefined,
+  normalizedOptions: NormalizedOptions
+): Promise<string> {
+  const result = await normalizedOptions.transformCss(css, filePath);
+
+  return result.toString();
 }
 
 function hasStyleXCode(normalizedOptions: NormalizedOptions, inputCode: string) {

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -7,7 +7,7 @@ import { createUnplugin } from 'unplugin';
 import type { UnpluginFactory, UnpluginInstance } from 'unplugin';
 
 import getStyleXRules from './utils/getStyleXRules';
-import normalizeOptions from './utils/normalizeOptions';
+import normalizeOptions, { identityTransformCss } from './utils/normalizeOptions';
 import type { UnpluginStylexRSOptions } from './types';
 import { shouldTransformFile, transform as stylexTransform } from '@stylexswc/rs-compiler';
 import generateHash from './utils/generateHash';
@@ -153,7 +153,8 @@ async function injectStyleXCss(
     const source = asset.source().toString();
     if (source.includes(injectMarker)) {
       const finalCSS = await transformStyleXCSS(collectedCSS, fileName, normalizedOptions);
-      const newSource = source.replace(injectMarker, finalCSS);
+      // Replacement callback keeps `$&`/`$'`-like sequences in the CSS literal
+      const newSource = source.replace(injectMarker, () => finalCSS);
       updateAsset(fileName, createRawSource(newSource));
       injected = true;
       break;
@@ -380,7 +381,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           replacementCSS = await transformStyleXCSS(collectedCSS, id, normalizedOptions);
         }
 
-        return cssContent.replace(normalizedOptions.useCssPlaceholder, replacementCSS);
+        return cssContent.replace(normalizedOptions.useCssPlaceholder, () => replacementCSS);
       },
 
       async generateBundle(_options, bundle) {
@@ -414,12 +415,15 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
               output.fileName,
               normalizedOptions
             );
-            output.source = source.replace(normalizedOptions.useCssPlaceholder, finalCSS);
+            output.source = source.replace(normalizedOptions.useCssPlaceholder, () => finalCSS);
             injected = true;
             break;
           }
         }
 
+        // The load hook may have replaced the placeholder before all modules were
+        // transformed, so the fallback append must still run to deliver the full
+        // rule set; StyleX rules are idempotent when repeated
         // Fallback: if marker not found, append to preferred CSS asset
         if (!injected && cssAssets.length > 0) {
           const targetName = pickCssAsset(cssAssets.map(a => a.fileName));
@@ -487,23 +491,22 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
 
         server.middlewares.use(
           (req: IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
-            if (cssFileName && req.url?.includes(cssFileName)) {
-              void (async () => {
-                const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
-                const finalCSS = collectedCSS
-                  ? await transformStyleXCSS(
-                      collectedCSS,
-                      cssFileName ?? undefined,
-                      normalizedOptions
-                    )
-                  : collectedCSS;
-
-                res.setHeader('Content-Type', 'text/css');
-                res.end(finalCSS);
-              })().catch(next);
+            const requestedCssFileName = cssFileName;
+            if (!requestedCssFileName || !req.url?.includes(requestedCssFileName)) {
+              next();
               return;
             }
-            next();
+
+            // Connect does not forward async rejections, hence the explicit catch
+            void (async () => {
+              const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
+              const finalCSS = collectedCSS
+                ? await transformStyleXCSS(collectedCSS, requestedCssFileName, normalizedOptions)
+                : collectedCSS;
+
+              res.setHeader('Content-Type', 'text/css');
+              res.end(finalCSS);
+            })().catch(next);
           }
         );
       },
@@ -674,7 +677,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
                     cssFile,
                     normalizedOptions
                   );
-                  const newContent = content.replace(injectMarker, finalCSS);
+                  const newContent = content.replace(injectMarker, () => finalCSS);
                   await writeFile(cssFile, newContent, 'utf8');
                   injected = true;
                   break;
@@ -688,7 +691,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
             if (!injected && cssFiles.length > 0) {
               const targetFile = pickCssAsset(cssFiles.map(f => path.basename(f)));
               if (targetFile) {
-                const fullPath = cssFiles.find(f => f.endsWith(targetFile));
+                const fullPath = cssFiles.find(f => path.basename(f) === targetFile);
                 if (fullPath) {
                   try {
                     const { readFile } = await import('node:fs/promises');
@@ -758,10 +761,10 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         async executor(resource) {
           // Skip HTML injection when using useCssPlaceholder
           if (normalizedOptions.useCssPlaceholder) {
-            return Promise.resolve(resource.htmlResource);
+            return resource.htmlResource;
           }
 
-          if (!hasCssToExtract) return Promise.resolve(resource.htmlResource);
+          if (!hasCssToExtract) return resource.htmlResource;
 
           const htmlResource = resource.htmlResource;
 
@@ -853,15 +856,12 @@ async function generateCSSAssets(
   assetsDir?: string
 ) {
   const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
-  const initialProcessedFileName = getProcessedFileName(
-    normalizedOptions,
-    collectedCSS || '',
-    assetsDir
-  );
+  // The callback receives the un-hashed template path: the hashed name depends on
+  // the transform output, so it cannot exist before the transform runs
   const finalCSS = collectedCSS
     ? await transformStyleXCSS(
         collectedCSS,
-        initialProcessedFileName ?? undefined,
+        getCssFilePathTemplate(normalizedOptions, assetsDir) ?? undefined,
         normalizedOptions
       )
     : collectedCSS;
@@ -871,14 +871,41 @@ async function generateCSSAssets(
   return { processedFileName, collectedCSS: finalCSS };
 }
 
+// Memoized per transformCss callback and file path while the input CSS is unchanged,
+// because the same collected CSS is requested by several hooks per build and by
+// every dev-server request for the CSS file
+const transformCssCache = new WeakMap<
+  NormalizedOptions['transformCss'],
+  Map<string, { css: string; result: string }>
+>();
+
 async function transformStyleXCSS(
   css: string,
   filePath: string | undefined,
   normalizedOptions: NormalizedOptions
 ): Promise<string> {
-  const result = await normalizedOptions.transformCss(css, filePath);
+  const { transformCss } = normalizedOptions;
 
-  return result.toString();
+  if (transformCss === identityTransformCss) {
+    return css;
+  }
+
+  let cache = transformCssCache.get(transformCss);
+  if (!cache) {
+    cache = new Map();
+    transformCssCache.set(transformCss, cache);
+  }
+
+  const cacheKey = filePath ?? '';
+  const cached = cache.get(cacheKey);
+  if (cached && cached.css === css) {
+    return cached.result;
+  }
+
+  const result = (await transformCss(css, filePath)).toString();
+  cache.set(cacheKey, { css, result });
+
+  return result;
 }
 
 function hasStyleXCode(normalizedOptions: NormalizedOptions, inputCode: string) {
@@ -912,18 +939,22 @@ function transformStyleXCode(
   return result;
 }
 
+function getCssFilePathTemplate(normalizedOptions: NormalizedOptions, assetsDir?: string) {
+  if (!normalizedOptions.fileName) return null;
+
+  return assetsDir
+    ? path.posix.join(assetsDir, normalizedOptions.fileName)
+    : normalizedOptions.fileName;
+}
+
 function getProcessedFileName(
   normalizedOptions: NormalizedOptions,
   collectedCSS?: string,
   assetsDir?: string
 ) {
-  if (!normalizedOptions.fileName) return null;
+  const template = getCssFilePathTemplate(normalizedOptions, assetsDir);
 
-  const computedFileName = assetsDir
-    ? path.posix.join(assetsDir, normalizedOptions.fileName)
-    : normalizedOptions.fileName;
-
-  return replaceFileName(computedFileName, collectedCSS || '');
+  return template ? replaceFileName(template, collectedCSS || '') : null;
 }
 
 export const unplugin: UnpluginInstance<UnpluginStylexRSOptions | undefined, boolean> =

--- a/packages/unplugin/src/types.ts
+++ b/packages/unplugin/src/types.ts
@@ -1,6 +1,21 @@
 import type { StyleXOptions } from '@stylexswc/rs-compiler';
 import type { TransformedOptions } from '@stylexswc/rs-compiler';
 
+/**
+ * Transforms extracted StyleX CSS before it is emitted or injected.
+ *
+ * `filePath` identifies the CSS destination and is bundler-specific:
+ * - webpack/rspack/rollup injection: the output asset name (e.g. `app.css`)
+ * - esbuild disk writes: the absolute path of the written file
+ * - Vite placeholder replacement: the id of the CSS module being loaded
+ * - generated assets: the configured `fileName`, with `[hash]` left unresolved
+ *   (the hash is computed from the transformed CSS, so it cannot be known earlier)
+ * - `undefined` when no destination is known
+ *
+ * Buffer results are decoded as UTF-8. Results are memoized per `filePath`
+ * while the input CSS is unchanged, so the callback must be a pure function
+ * of its arguments.
+ */
 export type CSSTransformer = (
   css: string,
   filePath: string | undefined

--- a/packages/unplugin/src/types.ts
+++ b/packages/unplugin/src/types.ts
@@ -1,12 +1,24 @@
 import type { StyleXOptions } from '@stylexswc/rs-compiler';
 import type { TransformedOptions } from '@stylexswc/rs-compiler';
 
+export type CSSTransformer = (
+  css: string,
+  filePath: string | undefined
+) => string | Buffer | Promise<string | Buffer>;
+
 export interface UnpluginStylexRSOptions {
   fileName?: string;
   useCSSLayers?: TransformedOptions['useLayers'];
   pageExtensions?: string[];
   rsOptions?: StyleXOptions;
   extractCSS?: boolean;
+  /**
+   * Transform the extracted StyleX CSS before it is emitted or injected.
+   *
+   * This matches the webpack plugin API and receives the generated CSS plus the
+   * target CSS asset path when one is known.
+   */
+  transformCss?: CSSTransformer;
   /**
    * Enable CSS injection into CSS files via placeholder marker.
    *

--- a/packages/unplugin/src/utils/normalizeOptions.ts
+++ b/packages/unplugin/src/utils/normalizeOptions.ts
@@ -4,7 +4,8 @@ import type { TransformedOptions } from '@stylexswc/rs-compiler';
 import type { UnpluginStylexRSOptions } from '../types';
 
 const DEFAULT_CSS_PLACEHOLDER = '@stylex;';
-const identityTransformCss: NonNullable<UnpluginStylexRSOptions['transformCss']> = css => css;
+export const identityTransformCss: NonNullable<UnpluginStylexRSOptions['transformCss']> = css =>
+  css;
 
 export type NormalizedOptions = Omit<
   Required<UnpluginStylexRSOptions>,

--- a/packages/unplugin/src/utils/normalizeOptions.ts
+++ b/packages/unplugin/src/utils/normalizeOptions.ts
@@ -4,6 +4,7 @@ import type { TransformedOptions } from '@stylexswc/rs-compiler';
 import type { UnpluginStylexRSOptions } from '../types';
 
 const DEFAULT_CSS_PLACEHOLDER = '@stylex;';
+const identityTransformCss: NonNullable<UnpluginStylexRSOptions['transformCss']> = css => css;
 
 export type NormalizedOptions = Omit<
   Required<UnpluginStylexRSOptions>,
@@ -34,6 +35,7 @@ export default function normalizeOptions(options: UnpluginStylexRSOptions): Norm
     pageExtensions: options.pageExtensions ?? ['tsx', 'jsx', 'js', 'ts'],
     rsOptions: normalizedRsOptions,
     extractCSS: options.extractCSS ?? true,
+    transformCss: options.transformCss ?? identityTransformCss,
     useCssPlaceholder,
     enableLTRRTLComments: normalizedRsOptions.enableLTRRTLComments,
     legacyDisableLayers: normalizedRsOptions.legacyDisableLayers,

--- a/packages/webpack-plugin/__tests__/index.test.ts
+++ b/packages/webpack-plugin/__tests__/index.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test, vi } from 'vitest';
 
 import StyleXPlugin, { STYLEX_CHUNK_NAME } from '../src';
 
+import type { Rule as StyleXRule } from '@stylexjs/babel-plugin';
+
 describe('@stylexswc/webpack-plugin', () => {
   test('transforms generated StyleX CSS before appending to the CSS asset', async () => {
     const { RawSource, ConcatSource } = webpack.sources;
@@ -10,11 +12,11 @@ describe('@stylexswc/webpack-plugin', () => {
       return `${css}\n/* transformed:${filePath} */`;
     });
     const plugin = new StyleXPlugin({ transformCss });
-    plugin.stylexRules.set('/button.tsx', [['x1abcd', { ltr: 'color:red' }, 3000]] as never);
+    const stylexRules: StyleXRule[] = [['x1abcd', { ltr: 'color:red', rtl: null }, 3000]];
+    plugin.stylexRules.set('/button.tsx', stylexRules);
 
     let processAssetsCallback:
-      | ((assets: Record<string, webpack.sources.Source>) => Promise<void>)
-      | undefined;
+      ((assets: Record<string, webpack.sources.Source>) => Promise<void>) | undefined;
     const assets: Record<string, webpack.sources.Source> = {
       'stylex.css': new RawSource('/* existing */'),
     };
@@ -26,7 +28,7 @@ describe('@stylexswc/webpack-plugin', () => {
               _options: unknown,
               callback: (assets: Record<string, webpack.sources.Source>) => Promise<void>
             ) => {
-            processAssetsCallback = callback;
+              processAssetsCallback = callback;
             }
           ),
         },

--- a/packages/webpack-plugin/__tests__/index.test.ts
+++ b/packages/webpack-plugin/__tests__/index.test.ts
@@ -1,0 +1,99 @@
+import webpack from 'webpack';
+import { describe, expect, test, vi } from 'vitest';
+
+import StyleXPlugin, { STYLEX_CHUNK_NAME } from '../src';
+
+describe('@stylexswc/webpack-plugin', () => {
+  test('transforms generated StyleX CSS before appending to the CSS asset', async () => {
+    const { RawSource, ConcatSource } = webpack.sources;
+    const transformCss = vi.fn(async (css: string, filePath: string | undefined) => {
+      return `${css}\n/* transformed:${filePath} */`;
+    });
+    const plugin = new StyleXPlugin({ transformCss });
+    plugin.stylexRules.set('/button.tsx', [['x1abcd', { ltr: 'color:red' }, 3000]] as never);
+
+    let processAssetsCallback:
+      | ((assets: Record<string, webpack.sources.Source>) => Promise<void>)
+      | undefined;
+    const assets: Record<string, webpack.sources.Source> = {
+      'stylex.css': new RawSource('/* existing */'),
+    };
+    const compilation = {
+      hooks: {
+        processAssets: {
+          tapPromise: vi.fn(
+            (
+              _options: unknown,
+              callback: (assets: Record<string, webpack.sources.Source>) => Promise<void>
+            ) => {
+            processAssetsCallback = callback;
+            }
+          ),
+        },
+      },
+      namedChunks: new Map([
+        [
+          STYLEX_CHUNK_NAME,
+          {
+            files: new Set(['stylex.css']),
+          },
+        ],
+      ]),
+      updateAsset: vi.fn(
+        (assetName: string, update: (source: webpack.sources.Source) => unknown) => {
+          const source = assets[assetName];
+
+          if (!source) {
+            throw new Error(`Missing asset: ${assetName}`);
+          }
+
+          assets[assetName] = update(source) as webpack.sources.Source;
+        }
+      ),
+    };
+    const compiler = {
+      options: {
+        optimization: {
+          splitChunks: {
+            cacheGroups: {},
+          },
+        },
+      },
+      webpack: {
+        Compilation: {
+          PROCESS_ASSETS_STAGE_PRE_PROCESS: 0,
+        },
+        NormalModule: {
+          getCompilationHooks: () => ({
+            loader: {
+              tap: vi.fn(),
+            },
+          }),
+        },
+        sources: {
+          RawSource,
+          ConcatSource,
+        },
+      },
+      hooks: {
+        normalModuleFactory: {
+          tap: vi.fn(),
+        },
+        make: {
+          tap: vi.fn((_name: string, callback: (compilation: unknown) => void) =>
+            callback(compilation)
+          ),
+        },
+      },
+    };
+
+    plugin.apply(compiler as unknown as webpack.Compiler);
+    await processAssetsCallback?.(assets);
+
+    expect(transformCss).toHaveBeenCalledTimes(1);
+    expect(transformCss.mock.calls[0]?.[1]).toBe('stylex.css');
+    expect(assets['stylex.css']?.source().toString()).toContain('/* existing */');
+    expect(assets['stylex.css']?.source().toString()).toContain('color:red');
+    expect(assets['stylex.css']?.source().toString()).toContain('/* transformed:stylex.css */');
+  });
+});

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -2,29 +2,6 @@
   "name": "@stylexswc/webpack-plugin",
   "description": "StyleX webpack plugin with NAPI-RS compiler",
   "version": "0.17.0-rc.2",
-  "private": false,
-  "license": "MIT",
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "scripts": {
-    "build": "scripty --ts",
-    "check:artifacts": "scripty",
-    "clean": "del-cli dist",
-    "lint": "eslint . --color",
-    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
-    "postbuild": "pnpm run check:artifacts",
-    "precommit": "lint-staged",
-    "prepublishOnly": "pnpm run build",
-    "prepush": "lint-prepush",
-    "test": "echo \"Error: no test specified\" && exit 0",
-    "typecheck": "scripty --ts"
-  },
   "config": {
     "scripty": {
       "path": "../../scripts/packages"
@@ -41,14 +18,38 @@
     "@types/loader-utils": "^3.0.0",
     "@types/node": "^26.1.0",
     "mini-css-extract-plugin": "^2.10.2",
+    "vitest": "^4.1.9",
     "webpack": "^5.108.3"
   },
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "stylex",
     "swc",
     "webpack",
     "webpack-plugin"
   ],
+  "license": "MIT",
   "main": "dist/index.js",
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin"
+  "private": false,
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": "https://github.com/Dwlad90/stylex-swc-plugin",
+  "scripts": {
+    "build": "scripty --ts",
+    "check:artifacts": "scripty",
+    "clean": "del-cli dist",
+    "lint": "eslint . --color",
+    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
+    "postbuild": "pnpm run check:artifacts",
+    "precommit": "lint-staged",
+    "prepublishOnly": "pnpm run build",
+    "prepush": "lint-prepush",
+    "test": "vitest run",
+    "typecheck": "scripty --ts"
+  },
+  "sideEffects": false
 }

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -23,8 +23,16 @@ import type {
 } from './types';
 import type { CssModule } from 'mini-css-extract-plugin';
 
-const stylexLoaderPath = require.resolve('./stylex-loader');
-const stylexVirtualLoaderPath = require.resolve('./stylex-virtual-css-loader');
+function resolveLoaderPath(loaderName: string) {
+  try {
+    return require.resolve(`./${loaderName}`);
+  } catch {
+    return require.resolve(`./${loaderName}.ts`);
+  }
+}
+
+const stylexLoaderPath = resolveLoaderPath('stylex-loader');
+const stylexVirtualLoaderPath = resolveLoaderPath('stylex-virtual-css-loader');
 
 const getStyleXRules = (
   stylexRules: Map<string, readonly StyleXRule[]>,
@@ -258,9 +266,14 @@ export { VIRTUAL_CSS_PATTERN, STYLEX_CHUNK_NAME };
 
 export type { StyleXPluginOption, CacheGroupOptions } from './types';
 
-module.exports = StyleXPlugin;
-module.exports.default = StyleXPlugin;
-module.exports.loader = stylexLoaderPath;
-module.exports.virtualLoader = stylexVirtualLoaderPath;
-module.exports.VIRTUAL_CSS_PATTERN = VIRTUAL_CSS_PATTERN;
-module.exports.STYLEX_CHUNK_NAME = STYLEX_CHUNK_NAME;
+if (
+  typeof module !== 'undefined' &&
+  Object.prototype.toString.call(module.exports) !== '[object Module]'
+) {
+  module.exports = StyleXPlugin;
+  module.exports.default = StyleXPlugin;
+  module.exports.loader = stylexLoaderPath;
+  module.exports.virtualLoader = stylexVirtualLoaderPath;
+  module.exports.VIRTUAL_CSS_PATTERN = VIRTUAL_CSS_PATTERN;
+  module.exports.STYLEX_CHUNK_NAME = STYLEX_CHUNK_NAME;
+}

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -26,7 +26,16 @@ import type { CssModule } from 'mini-css-extract-plugin';
 function resolveLoaderPath(loaderName: string) {
   try {
     return require.resolve(`./${loaderName}`);
-  } catch {
+  } catch (error) {
+    const isModuleNotFound =
+      error instanceof Error && 'code' in error && error.code === 'MODULE_NOT_FOUND';
+
+    if (!isModuleNotFound) {
+      throw error;
+    }
+
+    // Loaders resolve as `.ts` only when the plugin runs from source (e.g. vitest);
+    // published dist builds always resolve above
     return require.resolve(`./${loaderName}.ts`);
   }
 }
@@ -263,9 +272,14 @@ export default class StyleXPlugin {
 }
 
 export { VIRTUAL_CSS_PATTERN, STYLEX_CHUNK_NAME };
+// ESM exports keep the loader paths reachable in environments where the guarded
+// CJS block below is skipped (e.g. tooling that evaluates this file as ESM)
+export { stylexLoaderPath as loader, stylexVirtualLoaderPath as virtualLoader };
 
 export type { StyleXPluginOption, CacheGroupOptions } from './types';
 
+// Skipped when `module.exports` is an ES module namespace (frozen, cannot be
+// reassigned) — the ESM exports above provide the same surface there
 if (
   typeof module !== 'undefined' &&
   Object.prototype.toString.call(module.exports) !== '[object Module]'

--- a/packages/webpack-plugin/vitest.config.ts
+++ b/packages/webpack-plugin/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,7 +402,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       eslint-config-next:
         specifier: ^16.2.9
-        version: 16.2.9(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.2.9(@typescript-eslint/parser@8.59.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@26.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))
@@ -490,7 +490,7 @@ importers:
         version: 10.5.2(postcss@8.5.16)
       eslint-config-next:
         specifier: ^16.2.9
-        version: 16.2.9(@typescript-eslint/parser@8.59.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.2.9(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@26.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,7 +356,7 @@ importers:
         version: link:../../packages/nextjs-plugin
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -441,7 +441,7 @@ importers:
         version: link:../../packages/postcss-plugin
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -526,7 +526,7 @@ importers:
         version: link:../../packages/postcss-plugin
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -1872,7 +1872,7 @@ importers:
         version: 26.1.0
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       postcss:
         specifier: ^8.5.16
         version: 8.5.16
@@ -2095,16 +2095,19 @@ importers:
         version: link:../typescript-config
       '@types/loader-utils':
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(esbuild@0.28.1)
       '@types/node':
         specifier: ^26.1.0
         version: 26.1.0
       mini-css-extract-plugin:
         specifier: ^2.10.2
-        version: 2.10.2(webpack@5.108.3)
+        version: 2.10.2(webpack@5.108.3(esbuild@0.28.1))
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.2)(yaml@2.9.0))
       webpack:
         specifier: ^5.108.3
-        version: 5.108.3
+        version: 5.108.3(esbuild@0.28.1)
 
 packages:
 
@@ -16701,6 +16704,25 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@types/loader-utils@3.0.0(esbuild@0.28.1)':
+    dependencies:
+      '@types/node': 26.1.0
+      webpack: 5.108.3(esbuild@0.28.1)
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+      - webpack-cli
+
   '@types/mdx@2.0.14': {}
 
   '@types/mime@1.3.5': {}
@@ -21716,6 +21738,12 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  mini-css-extract-plugin@2.10.2(webpack@5.108.3(esbuild@0.28.1)):
+    dependencies:
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      webpack: 5.108.3(esbuild@0.28.1)
+
   mini-css-extract-plugin@2.10.2(webpack@5.108.3):
     dependencies:
       schema-utils: 4.3.3
@@ -21770,6 +21798,16 @@ snapshots:
       esbuild: 0.28.1
       postcss: 8.5.16
     optional: true
+
+  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(webpack@5.108.3(esbuild@0.28.1)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.108.3(esbuild@0.28.1)
+    optionalDependencies:
+      esbuild: 0.28.1
 
   minimizer-webpack-plugin@5.6.1(postcss@8.5.16)(webpack@5.108.3(postcss@8.5.16)):
     dependencies:
@@ -21841,7 +21879,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -21850,7 +21888,7 @@ snapshots:
       postcss: 8.5.16
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@8.0.1)(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -23508,12 +23546,12 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
-  styled-jsx@5.1.6(@babel/core@8.0.1)(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
     optionalDependencies:
-      '@babel/core': 8.0.1
+      '@babel/core': 7.29.7
 
   stylehacks@7.0.11(postcss@8.5.16):
     dependencies:
@@ -24554,6 +24592,44 @@ snapshots:
       webpack-sources: 3.5.0
     optionalDependencies:
       webpack-cli: 7.1.0(js-yaml@4.3.0)(json5@2.2.3)(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.5)(webpack@5.108.3)
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.108.3(esbuild@0.28.1):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.4
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.1
+      es-module-lexer: 2.2.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(webpack@5.108.3(esbuild@0.28.1))
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.0
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'


### PR DESCRIPTION
- Added a `transformCss` option to the unplugin and webpack plugin for transforming extracted CSS before injection.
- Updated various functions to support asynchronous operations for CSS transformation.
- Introduced new tests to validate the CSS transformation functionality in both Rollup and Webpack environments.
- Updated the pnpm-lock file to reflect dependency changes.

## Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Fixes

(Optional) Fixes # (issue)

## Additional Info

(Optional) Add any other relevant information about the pull request here.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
