### PR TITLE
feat(log): enhance error handling with panic boundaries and add tests

### DIFF
--- a/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
+++ b/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
@@ -99,26 +99,33 @@ pub(crate) fn add_source_map_data(
                 );
               };
             } else {
-              let original_line_number = code_frame.get_span_line_number(span);
-              let filename = state.get_filename().to_string();
-              let raw_short_filename = create_short_filename(&filename, state, package_json_seen);
-              let short_filename_expr = if let Some(ref f) = state.options.debug_file_path {
-                f.call(vec![create_string_expr(&raw_short_filename)])
-              } else {
-                create_string_expr(&raw_short_filename)
-              };
-
-              let short_filename = convert_expr_to_str(&short_filename_expr, state, functions);
-
-              if original_line_number > 0
-                && let Some(short_filename) = short_filename
-                && !short_filename.is_empty()
+              if let Some(original_line_number) = code_frame.try_get_span_line_number(span)
+                && original_line_number > 0
               {
-                let source_map = format!("{}:{}", short_filename, original_line_number);
-                inner_map.insert(
-                  COMPILED_KEY.to_owned(),
-                  Rc::new(FlatCompiledStylesValue::String(source_map)),
-                );
+                let filename = state.get_filename().to_string();
+                let raw_short_filename = create_short_filename(&filename, state, package_json_seen);
+                let short_filename_expr = if let Some(ref f) = state.options.debug_file_path {
+                  f.call(vec![create_string_expr(&raw_short_filename)])
+                } else {
+                  create_string_expr(&raw_short_filename)
+                };
+
+                let short_filename = convert_expr_to_str(&short_filename_expr, state, functions);
+
+                if let Some(short_filename) = short_filename
+                  && !short_filename.is_empty()
+                {
+                  let source_map = format!("{}:{}", short_filename, original_line_number);
+                  inner_map.insert(
+                    COMPILED_KEY.to_owned(),
+                    Rc::new(FlatCompiledStylesValue::String(source_map)),
+                  );
+                } else {
+                  inner_map.insert(
+                    COMPILED_KEY.to_owned(),
+                    Rc::new(FlatCompiledStylesValue::Bool(true)),
+                  );
+                }
               } else {
                 inner_map.insert(
                   COMPILED_KEY.to_owned(),

--- a/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
+++ b/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
@@ -21,6 +21,7 @@ use swc_core::{
     codegen::Config,
     parser::{Syntax, TsSyntax},
     transforms::typescript::strip,
+    utils::DropSpan,
     visit::*,
   },
 };
@@ -74,6 +75,33 @@ impl CodeFrame {
   pub(crate) fn get_span_line_number(&self, span: Span) -> usize {
     self.source_map.lookup_char_pos(span.lo).line
   }
+
+  /// Emits the diagnostic behind a panic boundary: the code frame is a
+  /// best-effort aid, so a source-map lookup panic (e.g. a span whose byte
+  /// offsets fall inside a multi-byte character) must never replace the error
+  /// being reported.
+  pub(crate) fn emit_error(&self, span: Span, message: &str) {
+    let emitted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+      self.create_error(span, message).emit();
+    }));
+
+    if emitted.is_err() {
+      warn!("Failed to emit the code frame for error: {}", message);
+    }
+  }
+
+  /// Like `get_span_line_number`, but behind the same panic boundary as
+  /// `emit_error` and `None` for dummy spans ("location unknown").
+  pub(crate) fn try_get_span_line_number(&self, span: Span) -> Option<usize> {
+    if span.is_dummy() {
+      return None;
+    }
+
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+      self.get_span_line_number(span)
+    }))
+    .ok()
+  }
 }
 
 fn read_source_file(file_name: &FileName) -> Result<String, std::io::Error> {
@@ -93,7 +121,7 @@ pub(crate) fn build_code_frame_error<'a>(
 ) -> &'a str {
   match get_span_from_source_code(wrapped_expression, fault_expression, state) {
     Ok((code_frame, span)) => {
-      code_frame.create_error(span, error_message).emit();
+      code_frame.emit_error(span, error_message);
     },
     Err(error) => {
       if log::log_enabled!(log::Level::Debug) {
@@ -129,6 +157,24 @@ pub(crate) fn build_code_frame_error<'a>(
 /// A tuple of (CodeFrame, Span) where CodeFrame contains the source map for
 /// error display
 pub(crate) fn get_span_from_source_code(
+  wrapped_expression: &Expr,
+  target_expression: &Expr,
+  state: &mut StateManager,
+) -> Result<(CodeFrame, Span), Error> {
+  // Panic boundary: locating a span re-reads, re-prints, and re-parses the
+  // module purely to improve diagnostics; a panic anywhere in there must
+  // degrade to "no code frame", never abort the compilation.
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    get_span_from_source_code_impl(wrapped_expression, target_expression, state)
+  }))
+  .unwrap_or_else(|_| {
+    Err(anyhow::anyhow!(
+      "Panicked while locating the source span for a diagnostic"
+    ))
+  })
+}
+
+fn get_span_from_source_code_impl(
   wrapped_expression: &Expr,
   target_expression: &Expr,
   state: &mut StateManager,
@@ -194,9 +240,11 @@ fn find_expression_span(program: Program, target_expression: &Expr) -> Span {
   let mut fallback_finder = ExpressionFinder::new(&converted_target);
   program.visit_with(&mut fallback_finder);
 
-  fallback_finder
-    .get_span()
-    .unwrap_or_else(|| target_expression.span())
+  // The target expression's own span belongs to the caller's source map, not
+  // the code-frame one, so its byte offsets are meaningless here and can even
+  // land inside a multi-byte character, panicking on source-map lookups. A
+  // dummy span signals "location unknown" instead.
+  fallback_finder.get_span().unwrap_or(DUMMY_SP)
 }
 
 /// Gets or parses the source code as a Program AST, with memoization.
@@ -331,9 +379,16 @@ pub(crate) fn print_module(
 
 pub(crate) fn print_program(
   code_frame: &CodeFrame,
-  program: Program,
+  mut program: Program,
   codegen_config: Option<Config>,
 ) -> String {
+  // The printed AST carries spans from the compiler's own source map, which
+  // are meaningless in the shared code-frame map. The codegen resolves
+  // non-dummy spans against its source map (e.g. `span_to_snippet` for
+  // trailing-comma detection), so foreign offsets would read unrelated files
+  // and can panic mid-character on multi-byte sources.
+  program.visit_mut_with(&mut DropSpan {});
+
   let printed_source_code = print(
     code_frame.source_map.clone(),
     &program,
@@ -467,9 +522,9 @@ pub(crate) fn build_code_frame_error_and_panic(
   // Emit the code frame diagnostic to stderr (already [StyleX]-prefixed)
   let (file, line) = match get_span_from_source_code(wrapped_expression, fault_expression, state) {
     Ok((code_frame, span)) => {
-      code_frame.create_error(span, error_message).emit();
-      let line_num = code_frame.get_span_line_number(span);
-      (Some(state.get_filename().to_owned()), Some(line_num))
+      code_frame.emit_error(span, error_message);
+      let line_num = code_frame.try_get_span_line_number(span);
+      (Some(state.get_filename().to_owned()), line_num)
     },
     Err(error) => {
       if log::log_enabled!(log::Level::Debug) {
@@ -511,3 +566,7 @@ pub(crate) fn build_code_frame_error_and_panic_at(
 ) -> ! {
   build_code_frame_error_and_panic(expr, expr, error_message, state)
 }
+
+#[cfg(test)]
+#[path = "tests/build_code_frame_error_tests.rs"]
+mod tests;

--- a/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
+++ b/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
@@ -1,11 +1,13 @@
 use anyhow::Error;
 use log::{debug, warn};
 use std::{
+  cell::Cell,
   collections::hash_map::DefaultHasher,
   fs,
   hash::{Hash, Hasher},
+  panic::{self, AssertUnwindSafe, UnwindSafe},
   path::Path,
-  sync::{Arc, OnceLock},
+  sync::{Arc, Once, OnceLock},
 };
 use stylex_macros::{panic_macros::__stylex_panic, stylex_error::StyleXError, stylex_panic};
 use swc_compiler_base::{PrintArgs, SourceMapsConfig, TransformOutput, parse_js, print};
@@ -38,6 +40,36 @@ pub(crate) struct CodeFrame {
 }
 
 static SOURCE_MAP: OnceLock<Arc<SourceMap>> = OnceLock::new();
+static DIAGNOSTIC_PANIC_HOOK: Once = Once::new();
+
+thread_local! {
+  static SUPPRESS_DIAGNOSTIC_PANIC_HOOK: Cell<bool> = const { Cell::new(false) };
+}
+
+fn install_diagnostic_panic_hook() {
+  DIAGNOSTIC_PANIC_HOOK.call_once(|| {
+    let previous_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |panic_info| {
+      let suppress = SUPPRESS_DIAGNOSTIC_PANIC_HOOK.with(Cell::get);
+      if !suppress {
+        previous_hook(panic_info);
+      }
+    }));
+  });
+}
+
+fn catch_diagnostic_unwind<F, T>(operation: F) -> std::thread::Result<T>
+where
+  F: FnOnce() -> T + UnwindSafe,
+{
+  install_diagnostic_panic_hook();
+
+  let previous_suppression = SUPPRESS_DIAGNOSTIC_PANIC_HOOK.with(|suppress| suppress.replace(true));
+  let result = panic::catch_unwind(operation);
+  SUPPRESS_DIAGNOSTIC_PANIC_HOOK.with(|suppress| suppress.set(previous_suppression));
+
+  result
+}
 
 impl CodeFrame {
   pub(crate) fn new() -> Self {
@@ -81,7 +113,7 @@ impl CodeFrame {
   /// offsets fall inside a multi-byte character) must never replace the error
   /// being reported.
   pub(crate) fn emit_error(&self, span: Span, message: &str) {
-    let emitted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let emitted = catch_diagnostic_unwind(AssertUnwindSafe(|| {
       self.create_error(span, message).emit();
     }));
 
@@ -97,10 +129,7 @@ impl CodeFrame {
       return None;
     }
 
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-      self.get_span_line_number(span)
-    }))
-    .ok()
+    catch_diagnostic_unwind(AssertUnwindSafe(|| self.get_span_line_number(span))).ok()
   }
 }
 
@@ -164,7 +193,7 @@ pub(crate) fn get_span_from_source_code(
   // Panic boundary: locating a span re-reads, re-prints, and re-parses the
   // module purely to improve diagnostics; a panic anywhere in there must
   // degrade to "no code frame", never abort the compilation.
-  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+  catch_diagnostic_unwind(AssertUnwindSafe(|| {
     get_span_from_source_code_impl(wrapped_expression, target_expression, state)
   }))
   .unwrap_or_else(|_| {
@@ -427,7 +456,7 @@ pub(crate) fn create_module(wrapped_expression: &Expr) -> Module {
 struct ExpressionFinder {
   target: Expr,
   target_discriminant: std::mem::Discriminant<Expr>,
-  found_expr: Option<Expr>,
+  found_span: Option<Span>,
 }
 
 /// Visitor that normalizes AST by removing syntax contexts and type
@@ -459,14 +488,12 @@ impl ExpressionFinder {
     Self {
       target: cleaned_target,
       target_discriminant,
-      found_expr: None,
+      found_span: None,
     }
   }
 
   fn get_span(&self) -> Option<Span> {
-    let expr = self.found_expr.as_ref()?;
-
-    Some(Span::new(expr.span_lo(), expr.span_hi()))
+    self.found_span
   }
 }
 
@@ -489,7 +516,7 @@ impl Visit for ExpressionFinder {
   noop_visit_type!();
 
   fn visit_expr(&mut self, expr: &Expr) {
-    if self.found_expr.is_some() {
+    if self.found_span.is_some() {
       return;
     }
 
@@ -501,7 +528,7 @@ impl Visit for ExpressionFinder {
 
     // Expensive structural comparison only for matching variants
     if self.target.eq_ignore_span(expr) {
-      self.found_expr = Some(expr.clone());
+      self.found_span = Some(Span::new(expr.span_lo(), expr.span_hi()));
       return;
     }
 

--- a/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
@@ -1,0 +1,172 @@
+use std::{
+  fs,
+  panic::AssertUnwindSafe,
+  path::{Path, PathBuf},
+  sync::Arc,
+};
+
+use swc_core::common::{BytePos, DUMMY_SP, FileName, GLOBALS, Globals, Span, SyntaxContext};
+use swc_core::ecma::ast::{
+  Expr, Ident, ImportDecl, ImportNamedSpecifier, ImportSpecifier, Module, ModuleDecl, ModuleItem,
+  Str,
+};
+
+use crate::shared::{
+  structures::state_manager::StateManager,
+  utils::log::build_code_frame_error::{
+    CodeFrame, build_code_frame_error_and_panic, get_span_from_source_code, print_module,
+  },
+};
+
+/// Writes a fixture whose content contains multi-byte characters, so any byte
+/// offset taken from a foreign source map is likely to land inside a character
+/// instead of on a char boundary.
+fn write_multibyte_fixture(name: &str) -> PathBuf {
+  let dir = std::env::temp_dir().join("stylex_code_frame_error_tests");
+  fs::create_dir_all(&dir).unwrap();
+
+  // Two-byte characters ("λ" is U+03BB) after the 3-byte "// " prefix, so
+  // every even offset >= 4 falls inside a character.
+  let source = format!(
+    "// {}\nexport const styles = {{ root: {{ color: 'red' }} }};\n",
+    "λ".repeat(700)
+  );
+
+  let path = dir.join(name);
+  fs::write(&path, source).unwrap();
+
+  path
+}
+
+fn state_for_fixture(path: &Path) -> StateManager {
+  let mut state = StateManager::default();
+  state.plugin_pass.filename = FileName::Real(path.to_path_buf());
+  state
+}
+
+/// An expression that does not exist in the fixture, carrying a span from a
+/// foreign source map (e.g. the compiler's own parse) whose byte offsets are
+/// meaningless for the code-frame source map.
+fn unmatched_expression_with_foreign_span() -> Expr {
+  Expr::Ident(Ident::new(
+    "identifier_not_present_in_fixture".into(),
+    Span::new(BytePos(17), BytePos(27)),
+    SyntaxContext::empty(),
+  ))
+}
+
+#[test]
+fn unmatched_expression_yields_dummy_span() {
+  let path = write_multibyte_fixture("unmatched_expression.tsx");
+  let mut state = state_for_fixture(&path);
+  let target = unmatched_expression_with_foreign_span();
+
+  let (_code_frame, span) = GLOBALS.set(&Globals::default(), || {
+    get_span_from_source_code(&target, &target, &mut state).unwrap()
+  });
+
+  assert!(
+    span.is_dummy(),
+    "an expression that cannot be located in the source must not leak its \
+     foreign span (got {:?}); foreign byte offsets can land inside multi-byte \
+     characters and panic on source-map lookups",
+    span
+  );
+}
+
+/// Recreates the production failure: the shared code-frame source map holds a
+/// multi-byte source, and a module carrying spans from the compiler's own
+/// source map gets printed against it. The codegen samples snippets for
+/// non-dummy list spans (`span_to_snippet`), so a foreign span whose offsets
+/// land inside a multi-byte character panics unless spans are dropped first.
+#[test]
+fn print_module_ignores_foreign_spans_over_multibyte_sources() {
+  let code_frame = CodeFrame::new();
+
+  // A large single-character run so mid-character offsets are dense: after the
+  // 2-byte "//" prefix every character occupies two bytes, meaning one of any
+  // two consecutive offsets is not a char boundary wherever the file lands in
+  // the shared source map.
+  let multibyte_source = format!("//{}", "λ".repeat(300_000));
+  code_frame.source_map.new_source_file(
+    Arc::new(FileName::Custom("foreign_span_fixture.tsx".to_string())),
+    multibyte_source,
+  );
+
+  // Named import/export specifier lists are the codegen's trailing-comma
+  // snippet-sampling case (`ListFormat::NamedImportsOrExportsElements`), with
+  // the import declaration's own span as the sampled range.
+  let import_with_span = |lo: u32, hi: u32| {
+    ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+      span: Span::new(BytePos(lo), BytePos(hi)),
+      specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
+        span: DUMMY_SP,
+        local: Ident::new("exampleExport".into(), DUMMY_SP, SyntaxContext::empty()),
+        imported: None,
+        is_type_only: false,
+      })],
+      src: Box::new(Str {
+        span: DUMMY_SP,
+        value: "example-package".into(),
+        raw: None,
+      }),
+      type_only: false,
+      with: None,
+      phase: Default::default(),
+    }))
+  };
+
+  // Two consecutive parities: whichever the fixture's start position is, one
+  // of these spans starts or ends inside a character.
+  let module = Module {
+    span: DUMMY_SP,
+    body: vec![
+      import_with_span(100_000, 100_010),
+      import_with_span(100_001, 100_011),
+    ],
+    shebang: None,
+  };
+
+  let printed = print_module(&code_frame, module, None);
+
+  assert!(
+    printed.contains("exampleExport"),
+    "printing must succeed and include the module contents, got: {}",
+    printed
+  );
+}
+
+#[test]
+fn panic_reports_real_message_for_multibyte_source() {
+  let path = write_multibyte_fixture("panic_real_message.tsx");
+  let mut state = state_for_fixture(&path);
+  let target = unmatched_expression_with_foreign_span();
+
+  let error_message = "A style value must be static";
+
+  let panic_payload = std::panic::catch_unwind(AssertUnwindSafe(|| {
+    GLOBALS.set(&Globals::default(), || {
+      build_code_frame_error_and_panic(&target, &target, error_message, &mut state)
+    })
+  }))
+  .unwrap_err();
+
+  let message = match panic_payload.downcast_ref::<String>() {
+    Some(message) => message.clone(),
+    None => match panic_payload.downcast_ref::<&str>() {
+      Some(message) => (*message).to_string(),
+      None => String::from("<non-string panic payload>"),
+    },
+  };
+
+  assert!(
+    message.contains(error_message),
+    "panic must surface the original StyleX error, got: {}",
+    message
+  );
+  assert!(
+    !message.contains("char boundary"),
+    "panic must not be replaced by a char-boundary slicing panic, got: {}",
+    message
+  );
+}

--- a/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
@@ -2,7 +2,10 @@ use std::{
   fs,
   panic::AssertUnwindSafe,
   path::{Path, PathBuf},
-  sync::Arc,
+  sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+  },
 };
 
 use swc_core::common::{BytePos, DUMMY_SP, FileName, GLOBALS, Globals, Span, SyntaxContext};
@@ -18,12 +21,21 @@ use crate::shared::{
   },
 };
 
+static TEST_FILE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 /// Writes a fixture whose content contains multi-byte characters, so any byte
 /// offset taken from a foreign source map is likely to land inside a character
 /// instead of on a char boundary.
 fn write_multibyte_fixture(name: &str) -> PathBuf {
-  let dir = std::env::temp_dir().join("stylex_code_frame_error_tests");
-  fs::create_dir_all(&dir).unwrap();
+  let id = TEST_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+  let dir = std::env::temp_dir().join(format!(
+    "stylex_code_frame_error_tests_{}_{}",
+    std::process::id(),
+    id
+  ));
+  if let Err(error) = fs::create_dir_all(&dir) {
+    panic!("failed to create temp fixture directory: {error}");
+  }
 
   // Two-byte characters ("λ" is U+03BB) after the 3-byte "// " prefix, so
   // every even offset >= 4 falls inside a character.
@@ -33,7 +45,9 @@ fn write_multibyte_fixture(name: &str) -> PathBuf {
   );
 
   let path = dir.join(name);
-  fs::write(&path, source).unwrap();
+  if let Err(error) = fs::write(&path, source) {
+    panic!("failed to write temp fixture: {error}");
+  }
 
   path
 }
@@ -61,8 +75,11 @@ fn unmatched_expression_yields_dummy_span() {
   let mut state = state_for_fixture(&path);
   let target = unmatched_expression_with_foreign_span();
 
-  let (_code_frame, span) = GLOBALS.set(&Globals::default(), || {
-    get_span_from_source_code(&target, &target, &mut state).unwrap()
+  let span = GLOBALS.set(&Globals::default(), || {
+    match get_span_from_source_code(&target, &target, &mut state) {
+      Ok((_code_frame, span)) => span,
+      Err(error) => panic!("failed to get source span: {error}"),
+    }
   });
 
   assert!(
@@ -144,12 +161,14 @@ fn panic_reports_real_message_for_multibyte_source() {
 
   let error_message = "A style value must be static";
 
-  let panic_payload = std::panic::catch_unwind(AssertUnwindSafe(|| {
+  let panic_payload = match std::panic::catch_unwind(AssertUnwindSafe(|| {
     GLOBALS.set(&Globals::default(), || {
       build_code_frame_error_and_panic(&target, &target, error_message, &mut state)
     })
-  }))
-  .unwrap_err();
+  })) {
+    Ok(()) => panic!("expected build_code_frame_error_and_panic to panic"),
+    Err(panic_payload) => panic_payload,
+  };
 
   let message = match panic_payload.downcast_ref::<String>() {
     Some(message) => message.clone(),


### PR DESCRIPTION
- Introduced `emit_error` and `try_get_span_line_number` methods to handle diagnostics safely within panic boundaries.
- Updated `build_code_frame_error` to utilize the new error handling methods.
- Added comprehensive tests for multi-byte character handling and panic scenarios in `build_code_frame_error_tests.rs`.
- Ensured that foreign spans do not cause panics during source map lookups.

## Description

This pull request improves the robustness of the code frame error reporting logic in the StyleX transform, especially for scenarios involving multi-byte characters and foreign source maps. The main changes ensure that panics during code frame generation do not mask the original error, and that spans from different source maps do not cause crashes. Comprehensive tests have been added to cover these edge cases.

**Error handling and robustness:**

* Wrapped code frame emission and span lookups in panic boundaries to prevent panics (such as those caused by invalid byte offsets in multi-byte sources) from replacing the original diagnostic error. Now, if a panic occurs during code frame generation, a warning is logged and the original error is preserved. [[1]](diffhunk://#diff-a0d17cea47d3d8cf35609e6d5efd5b29e3bc623acf75b25165753df3260e3ef6R78-R104) [[2]](diffhunk://#diff-a0d17cea47d3d8cf35609e6d5efd5b29e3bc623acf75b25165753df3260e3ef6L96-R124) [[3]](diffhunk://#diff-a0d17cea47d3d8cf35609e6d5efd5b29e3bc623acf75b25165753df3260e3ef6R163-R180) [[4]](diffhunk://#diff-a0d17cea47d3d8cf35609e6d5efd5b29e3bc623acf75b25165753df3260e3ef6L470-R527)
* When a target expression's span cannot be found in the code frame's source map, a dummy span is used instead of leaking a foreign span, avoiding panics on invalid byte offsets.

**Multi-byte and foreign span handling:**

* Added logic to drop all spans from AST nodes before printing modules for code frames, ensuring that codegen does not attempt to resolve foreign spans against the code frame's source map, which could otherwise panic. [[1]](diffhunk://#diff-a0d17cea47d3d8cf35609e6d5efd5b29e3bc623acf75b25165753df3260e3ef6R24) [[2]](diffhunk://#diff-a0d17cea47d3d8cf35609e6d5efd5b29e3bc623acf75b25165753df3260e3ef6L334-R391)

**Testing:**

* Introduced a comprehensive test suite (`tests/build_code_frame_error_tests.rs`) that covers multi-byte character handling, foreign span robustness, and ensures that panics do not mask the original error message. Tests include creating fixtures with multi-byte characters, simulating unmatched expressions, and verifying correct panic behavior. [[1]](diffhunk://#diff-988e9426be447d52e1e80fbf4576828970f868735bcf8b8cbe070ee70ef732a3R1-R172) [[2]](diffhunk://#diff-a0d17cea47d3d8cf35609e6d5efd5b29e3bc623acf75b25165753df3260e3ef6R569-R572)

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
