### PR TITLE
feat(log): add key-based source span lookup for style namespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
+++ b/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
@@ -16,7 +16,7 @@ use crate::shared::{
   utils::{
     ast::convertors::{convert_expr_to_str, create_string_expr},
     js::evaluate::evaluate_obj_key,
-    log::build_code_frame_error::get_span_from_source_code,
+    log::build_code_frame_error::{get_key_span_from_source_code, get_span_from_source_code},
   },
 };
 use stylex_ast::ast::convertors::get_key_values_from_object;
@@ -75,11 +75,21 @@ pub(crate) fn add_source_map_data(
 
     match style_node_paths.remove(key) {
       Some(style_node_path) => {
-        let source_code_frame_and_span = get_span_from_source_code(
-          &Expr::Call(call_expr.clone()),
-          &style_node_path.value,
-          state,
-        );
+        // Locate the namespace by its key first: keys are static strings that
+        // survive value-level code transforms (e.g. macro expansion by an
+        // earlier loader), so this finds the original source position even
+        // when the compiled values no longer match the file content. Fall
+        // back to matching the value expression when the key cannot be
+        // located (e.g. computed keys).
+        let source_code_frame_and_span = match get_key_span_from_source_code(call_expr, key, state)
+        {
+          Ok((code_frame, span)) if !span.eq(&DUMMY_SP) => Ok((code_frame, span)),
+          _ => get_span_from_source_code(
+            &Expr::Call(call_expr.clone()),
+            &style_node_path.value,
+            state,
+          ),
+        };
 
         match source_code_frame_and_span {
           Ok((code_frame, span)) => {

--- a/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
+++ b/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
@@ -13,8 +13,9 @@ use stylex_macros::{panic_macros::__stylex_panic, stylex_error::StyleXError, sty
 use swc_compiler_base::{PrintArgs, SourceMapsConfig, TransformOutput, parse_js, print};
 use swc_config::is_module::IsModule;
 use swc_core::{
+  atoms::Atom,
   common::{
-    DUMMY_SP, EqIgnoreSpan, FileName, Mark, SourceMap, Span, Spanned, SyntaxContext,
+    BytePos, DUMMY_SP, EqIgnoreSpan, FileName, Mark, SourceMap, Span, Spanned, SyntaxContext,
     errors::{Handler, *},
     util::take::Take,
   },
@@ -217,7 +218,7 @@ fn get_span_from_source_code_impl(
 
   // Check cache first - avoid expensive AST operations if we've seen this before
   if let Some(cached_span) = state.cached_span(cache_key) {
-    let code_frame = load_code_frame_from_cache(&file_name)?;
+    let code_frame = load_code_frame_from_cache_for_state(&file_name, state)?;
     return Ok((code_frame, cached_span));
   }
 
@@ -268,7 +269,7 @@ pub(crate) fn get_key_span_from_source_code(
 ) -> Result<(CodeFrame, Span), Error> {
   // Same panic boundary as `get_span_from_source_code`: locating a span is
   // best-effort and must never abort the compilation.
-  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+  catch_diagnostic_unwind(AssertUnwindSafe(|| {
     get_key_span_from_source_code_impl(call_expr, namespace_key, state)
   }))
   .unwrap_or_else(|_| {
@@ -284,11 +285,17 @@ fn get_key_span_from_source_code_impl(
   state: &mut StateManager,
 ) -> Result<(CodeFrame, Span), Error> {
   let sibling_keys = collect_object_arg_keys(call_expr);
-  let cache_key = compute_key_span_cache_key(namespace_key, &sibling_keys);
+  let namespace_value_keys = collect_namespace_value_keys(call_expr, namespace_key);
+  let cache_key = compute_key_span_cache_key(
+    call_expr,
+    namespace_key,
+    &sibling_keys,
+    &namespace_value_keys,
+  );
   let file_name = FileName::Custom(state.get_filename().to_owned());
 
   if let Some(cached_span) = state.cached_span(cache_key) {
-    let code_frame = load_code_frame_from_cache(&file_name)?;
+    let code_frame = load_code_frame_from_cache_for_state(&file_name, state)?;
     return Ok((code_frame, cached_span));
   }
 
@@ -306,11 +313,15 @@ fn get_key_span_from_source_code_impl(
   let mut finder = KeySpanFinder {
     namespace_key,
     sibling_keys: &sibling_keys,
+    namespace_value_keys: &namespace_value_keys,
+    target_lo: first_object_arg_span(call_expr)
+      .or_else(|| (!call_expr.span.is_dummy()).then_some(call_expr.span.lo)),
     best: None,
+    ambiguous_best: false,
   };
   program.visit_with(&mut finder);
 
-  let span = finder.best.map_or(DUMMY_SP, |(_, span)| span);
+  let span = finder.resolved_span();
 
   state.insert_cached_span(cache_key, span);
 
@@ -318,7 +329,7 @@ fn get_key_span_from_source_code_impl(
 }
 
 /// Collects the literal property keys of a call's first object argument.
-fn collect_object_arg_keys(call_expr: &CallExpr) -> FxHashSet<String> {
+fn collect_object_arg_keys(call_expr: &CallExpr) -> FxHashSet<Atom> {
   let mut keys = FxHashSet::default();
 
   if let Some(arg) = call_expr.args.first()
@@ -329,7 +340,7 @@ fn collect_object_arg_keys(call_expr: &CallExpr) -> FxHashSet<String> {
         && let Prop::KeyValue(key_value) = prop.as_ref()
         && let Some(name) = namespace_name_from_prop_key(&key_value.key)
       {
-        keys.insert(name.to_string());
+        keys.insert(name);
       }
     }
   }
@@ -337,31 +348,118 @@ fn collect_object_arg_keys(call_expr: &CallExpr) -> FxHashSet<String> {
   keys
 }
 
-fn compute_key_span_cache_key(namespace_key: &str, sibling_keys: &FxHashSet<String>) -> u64 {
+fn first_object_arg_span(call_expr: &CallExpr) -> Option<BytePos> {
+  call_expr
+    .args
+    .first()
+    .and_then(|arg| match arg.expr.as_ref() {
+      Expr::Object(object) if !object.span.is_dummy() => Some(object.span.lo),
+      _ => None,
+    })
+}
+
+fn collect_namespace_value_keys(call_expr: &CallExpr, namespace_key: &str) -> FxHashSet<Atom> {
+  let mut keys = FxHashSet::default();
+
+  if let Some(arg) = call_expr.args.first()
+    && let Expr::Object(object) = arg.expr.as_ref()
+  {
+    for prop in &object.props {
+      if let PropOrSpread::Prop(prop) = prop
+        && let Prop::KeyValue(key_value) = prop.as_ref()
+        && namespace_name_from_prop_key(&key_value.key)
+          .is_some_and(|name| name.as_ref() == namespace_key)
+        && let Expr::Object(namespace_value) = key_value.value.as_ref()
+      {
+        keys.extend(collect_object_lit_keys(namespace_value));
+        break;
+      }
+    }
+  }
+
+  keys
+}
+
+fn collect_object_lit_keys(object: &ObjectLit) -> impl Iterator<Item = Atom> + '_ {
+  object.props.iter().filter_map(|prop| {
+    if let PropOrSpread::Prop(prop) = prop
+      && let Prop::KeyValue(key_value) = prop.as_ref()
+    {
+      namespace_name_from_prop_key(&key_value.key)
+    } else {
+      None
+    }
+  })
+}
+
+fn compute_key_span_cache_key(
+  call_expr: &CallExpr,
+  namespace_key: &str,
+  sibling_keys: &FxHashSet<Atom>,
+  namespace_value_keys: &FxHashSet<Atom>,
+) -> u64 {
   let mut hasher = DefaultHasher::new();
-  "stylex-key-span".hash(&mut hasher);
+  "stylex-key-span:v2".hash(&mut hasher);
+  call_expr.callee.hash(&mut hasher);
+  call_expr.span.lo.0.hash(&mut hasher);
+  call_expr.span.hi.0.hash(&mut hasher);
+  if let Some(arg) = call_expr.args.first()
+    && let Expr::Object(object) = arg.expr.as_ref()
+  {
+    object.span.lo.0.hash(&mut hasher);
+    object.span.hi.0.hash(&mut hasher);
+  }
   namespace_key.hash(&mut hasher);
 
-  let mut sorted_keys: Vec<&String> = sibling_keys.iter().collect();
+  let mut sorted_keys: Vec<&Atom> = sibling_keys.iter().collect();
   sorted_keys.sort();
   sorted_keys.hash(&mut hasher);
+
+  let mut sorted_value_keys: Vec<&Atom> = namespace_value_keys.iter().collect();
+  sorted_value_keys.sort();
+  sorted_value_keys.hash(&mut hasher);
 
   hasher.finish()
 }
 
-/// Visitor that finds the object property named `namespace_key`, preferring
-/// the object whose keys overlap the compiled call's argument keys the most.
+struct KeySpanCandidate {
+  namespace_value_overlap: usize,
+  overlap: usize,
+  distance_from_target: Option<u32>,
+  span: Span,
+}
+
+/// Visitor that finds call-expression object arguments and returns the property
+/// span for `namespace_key`. The sibling-key overlap is a tie-breaker for
+/// compiled calls with dummy spans.
 struct KeySpanFinder<'a> {
   namespace_key: &'a str,
-  sibling_keys: &'a FxHashSet<String>,
-  best: Option<(usize, Span)>,
+  sibling_keys: &'a FxHashSet<Atom>,
+  namespace_value_keys: &'a FxHashSet<Atom>,
+  target_lo: Option<BytePos>,
+  best: Option<KeySpanCandidate>,
+  ambiguous_best: bool,
 }
 
 impl Visit for KeySpanFinder<'_> {
   noop_visit_type!();
 
-  fn visit_object_lit(&mut self, object: &ObjectLit) {
+  fn visit_call_expr(&mut self, call: &CallExpr) {
+    if let Some(arg) = call.args.first()
+      && let Expr::Object(object) = arg.expr.as_ref()
+      && let Some(candidate) = self.candidate_from_object(call, object)
+    {
+      self.record_candidate(candidate);
+    }
+
+    call.visit_children_with(self);
+  }
+}
+
+impl KeySpanFinder<'_> {
+  fn candidate_from_object(&self, call: &CallExpr, object: &ObjectLit) -> Option<KeySpanCandidate> {
     let mut key_span = None;
+    let mut namespace_value_overlap = 0;
     let mut overlap = 0;
 
     for prop in &object.props {
@@ -369,38 +467,97 @@ impl Visit for KeySpanFinder<'_> {
         && let Prop::KeyValue(key_value) = prop.as_ref()
         && let Some(name) = namespace_name_from_prop_key(&key_value.key)
       {
-        let name = name.to_string();
-
         if self.sibling_keys.contains(&name) {
           overlap += 1;
         }
 
-        if name == self.namespace_key {
+        if name.as_ref() == self.namespace_key {
           key_span = Some(key_value.key.span());
+
+          if let Expr::Object(namespace_value) = key_value.value.as_ref() {
+            namespace_value_overlap = collect_object_lit_keys(namespace_value)
+              .filter(|name| self.namespace_value_keys.contains(name))
+              .count();
+          }
         }
       }
     }
 
-    if let Some(span) = key_span
-      && self
-        .best
-        .is_none_or(|(best_overlap, _)| overlap > best_overlap)
-    {
-      self.best = Some((overlap, span));
-    }
+    key_span.map(|span| KeySpanCandidate {
+      namespace_value_overlap,
+      overlap,
+      distance_from_target: self.target_lo.map(|target_lo| {
+        let candidate_lo = if !object.span.is_dummy() {
+          object.span.lo
+        } else {
+          call.span.lo
+        };
 
-    object.visit_children_with(self);
+        candidate_lo.0.abs_diff(target_lo.0)
+      }),
+      span,
+    })
+  }
+
+  fn record_candidate(&mut self, candidate: KeySpanCandidate) {
+    match self.best.as_ref() {
+      None => {
+        self.best = Some(candidate);
+        self.ambiguous_best = false;
+      },
+      Some(best) if is_better_key_span_candidate(&candidate, best) => {
+        self.best = Some(candidate);
+        self.ambiguous_best = false;
+      },
+      Some(best) if is_equal_key_span_candidate_rank(&candidate, best) => {
+        self.ambiguous_best = true;
+      },
+      Some(_) => {},
+    }
+  }
+
+  fn resolved_span(self) -> Span {
+    if self.ambiguous_best {
+      DUMMY_SP
+    } else {
+      self.best.map_or(DUMMY_SP, |candidate| candidate.span)
+    }
   }
 }
 
-/// Loads a CodeFrame with the source file for error display
-fn load_code_frame_from_cache(file_name: &FileName) -> Result<CodeFrame, Error> {
+fn is_better_key_span_candidate(candidate: &KeySpanCandidate, best: &KeySpanCandidate) -> bool {
+  candidate.namespace_value_overlap > best.namespace_value_overlap
+    || candidate.namespace_value_overlap == best.namespace_value_overlap
+      && (candidate.overlap > best.overlap
+        || candidate.overlap == best.overlap
+          && candidate.distance_from_target < best.distance_from_target)
+}
+
+fn is_equal_key_span_candidate_rank(candidate: &KeySpanCandidate, best: &KeySpanCandidate) -> bool {
+  candidate.namespace_value_overlap == best.namespace_value_overlap
+    && candidate.overlap == best.overlap
+    && candidate.distance_from_target == best.distance_from_target
+}
+
+/// Loads a CodeFrame with the source file for error display.
+fn load_code_frame_from_cache_for_state(
+  file_name: &FileName,
+  state: &StateManager,
+) -> Result<CodeFrame, Error> {
   let code_frame = CodeFrame::new();
-  let source = read_source_file(file_name)
-    .map_err(|e| anyhow::anyhow!("Failed to read source file: {}", e))?;
+  let source = state
+    .get_seen_module_source_code()
+    .and_then(|(_, source_code)| source_code.as_ref().cloned())
+    .map(Ok)
+    .unwrap_or_else(|| {
+      read_source_file(file_name)
+        .map_err(|error| anyhow::anyhow!("Failed to read source file: {}", error))
+    })?;
+
   code_frame
     .source_map
     .new_source_file(file_name.clone().into(), source);
+
   Ok(code_frame)
 }
 

--- a/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
+++ b/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
@@ -30,8 +30,12 @@ use swc_core::{
 
 use crate::shared::{
   structures::state_manager::StateManager,
-  utils::ast::convertors::{convert_concat_to_tpl_expr, convert_simple_tpl_to_str_expr},
+  utils::ast::{
+    convertors::{convert_concat_to_tpl_expr, convert_simple_tpl_to_str_expr},
+    helpers::namespace_name_from_prop_key,
+  },
 };
+use rustc_hash::FxHashSet;
 use stylex_regex::regex::URL_REGEX;
 
 pub(crate) struct CodeFrame {
@@ -241,6 +245,152 @@ fn compute_cache_key(expr: &Expr) -> u64 {
   std::mem::discriminant(expr).hash(&mut hasher);
   expr.hash(&mut hasher);
   hasher.finish()
+}
+
+/// Finds the span of a style namespace by its **key** inside the parsed
+/// source, instead of matching the namespace's value expression.
+///
+/// Object keys are static strings that survive value-level code transforms
+/// (e.g. compile-time macro expansion done by an earlier loader), so this
+/// locates the original source position even when the compiled AST's values
+/// no longer textually match the file on disk — the case where
+/// `find_expression_span` has nothing to match against.
+///
+/// The `call_expr`'s own argument keys are used to disambiguate between
+/// multiple objects containing an identically named property: the candidate
+/// object sharing the most sibling keys with the compiled call wins.
+///
+/// Returns a dummy span when the key cannot be located.
+pub(crate) fn get_key_span_from_source_code(
+  call_expr: &CallExpr,
+  namespace_key: &str,
+  state: &mut StateManager,
+) -> Result<(CodeFrame, Span), Error> {
+  // Same panic boundary as `get_span_from_source_code`: locating a span is
+  // best-effort and must never abort the compilation.
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    get_key_span_from_source_code_impl(call_expr, namespace_key, state)
+  }))
+  .unwrap_or_else(|_| {
+    Err(anyhow::anyhow!(
+      "Panicked while locating the source span for a diagnostic"
+    ))
+  })
+}
+
+fn get_key_span_from_source_code_impl(
+  call_expr: &CallExpr,
+  namespace_key: &str,
+  state: &mut StateManager,
+) -> Result<(CodeFrame, Span), Error> {
+  let sibling_keys = collect_object_arg_keys(call_expr);
+  let cache_key = compute_key_span_cache_key(namespace_key, &sibling_keys);
+  let file_name = FileName::Custom(state.get_filename().to_owned());
+
+  if let Some(cached_span) = state.cached_span(cache_key) {
+    let code_frame = load_code_frame_from_cache(&file_name)?;
+    return Ok((code_frame, cached_span));
+  }
+
+  let code_frame = CodeFrame::new();
+  let wrapped_expression = Expr::Call(call_expr.clone());
+  let program = get_memoized_frame_source_code(
+    &wrapped_expression,
+    &wrapped_expression,
+    state,
+    &file_name,
+    &code_frame,
+  )
+  .ok_or_else(|| anyhow::anyhow!("Failed to parse source file: {}", state.get_filename()))?;
+
+  let mut finder = KeySpanFinder {
+    namespace_key,
+    sibling_keys: &sibling_keys,
+    best: None,
+  };
+  program.visit_with(&mut finder);
+
+  let span = finder.best.map_or(DUMMY_SP, |(_, span)| span);
+
+  state.insert_cached_span(cache_key, span);
+
+  Ok((code_frame, span))
+}
+
+/// Collects the literal property keys of a call's first object argument.
+fn collect_object_arg_keys(call_expr: &CallExpr) -> FxHashSet<String> {
+  let mut keys = FxHashSet::default();
+
+  if let Some(arg) = call_expr.args.first()
+    && let Expr::Object(object) = arg.expr.as_ref()
+  {
+    for prop in &object.props {
+      if let PropOrSpread::Prop(prop) = prop
+        && let Prop::KeyValue(key_value) = prop.as_ref()
+        && let Some(name) = namespace_name_from_prop_key(&key_value.key)
+      {
+        keys.insert(name.to_string());
+      }
+    }
+  }
+
+  keys
+}
+
+fn compute_key_span_cache_key(namespace_key: &str, sibling_keys: &FxHashSet<String>) -> u64 {
+  let mut hasher = DefaultHasher::new();
+  "stylex-key-span".hash(&mut hasher);
+  namespace_key.hash(&mut hasher);
+
+  let mut sorted_keys: Vec<&String> = sibling_keys.iter().collect();
+  sorted_keys.sort();
+  sorted_keys.hash(&mut hasher);
+
+  hasher.finish()
+}
+
+/// Visitor that finds the object property named `namespace_key`, preferring
+/// the object whose keys overlap the compiled call's argument keys the most.
+struct KeySpanFinder<'a> {
+  namespace_key: &'a str,
+  sibling_keys: &'a FxHashSet<String>,
+  best: Option<(usize, Span)>,
+}
+
+impl Visit for KeySpanFinder<'_> {
+  noop_visit_type!();
+
+  fn visit_object_lit(&mut self, object: &ObjectLit) {
+    let mut key_span = None;
+    let mut overlap = 0;
+
+    for prop in &object.props {
+      if let PropOrSpread::Prop(prop) = prop
+        && let Prop::KeyValue(key_value) = prop.as_ref()
+        && let Some(name) = namespace_name_from_prop_key(&key_value.key)
+      {
+        let name = name.to_string();
+
+        if self.sibling_keys.contains(&name) {
+          overlap += 1;
+        }
+
+        if name == self.namespace_key {
+          key_span = Some(key_value.key.span());
+        }
+      }
+    }
+
+    if let Some(span) = key_span
+      && self
+        .best
+        .is_none_or(|(best_overlap, _)| overlap > best_overlap)
+    {
+      self.best = Some((overlap, span));
+    }
+
+    object.visit_children_with(self);
+  }
 }
 
 /// Loads a CodeFrame with the source file for error display

--- a/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
@@ -57,6 +57,55 @@ fn write_multibyte_fixture(name: &str) -> PathBuf {
   path
 }
 
+fn write_fixture(name: &str, source: &str) -> PathBuf {
+  let id = TEST_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+  let dir = std::env::temp_dir().join(format!(
+    "stylex_code_frame_error_tests_{}_{}",
+    std::process::id(),
+    id
+  ));
+
+  if let Err(error) = fs::create_dir_all(&dir) {
+    panic!("failed to create temp fixture directory: {error}");
+  }
+
+  let path = dir.join(name);
+
+  if let Err(error) = fs::write(&path, source) {
+    panic!("failed to write temp fixture: {error}");
+  }
+
+  path
+}
+
+fn compiled_create_call() -> CallExpr {
+  let compiled_arg = create_object_expression(vec![
+    create_nested_object_prop(
+      "root",
+      vec![create_key_value_prop("color", create_string_expr("red"))],
+    ),
+    create_nested_object_prop(
+      "other",
+      vec![create_key_value_prop("display", create_string_expr("flex"))],
+    ),
+  ]);
+
+  CallExpr {
+    span: DUMMY_SP,
+    ctxt: SyntaxContext::empty(),
+    callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(
+      "create".into(),
+      DUMMY_SP,
+      SyntaxContext::empty(),
+    )))),
+    args: vec![ExprOrSpread {
+      spread: None,
+      expr: Box::new(compiled_arg),
+    }],
+    type_args: None,
+  }
+}
+
 fn state_for_fixture(path: &Path) -> StateManager {
   let mut state = StateManager::default();
   state.plugin_pass.filename = FileName::Real(path.to_path_buf());
@@ -165,9 +214,6 @@ fn print_module_ignores_foreign_spans_over_multibyte_sources() {
 /// resolve the real line number.
 #[test]
 fn key_lookup_finds_line_when_values_differ_from_source() {
-  let dir = std::env::temp_dir().join("stylex_code_frame_error_tests");
-  fs::create_dir_all(&dir).unwrap();
-
   let source = "\
 import fancyMacro from 'example-macro';
 
@@ -180,42 +226,17 @@ export const styles = create({
   },
 });
 ";
-  let path = dir.join("key_lookup.tsx");
-  fs::write(&path, source).unwrap();
-
+  let path = write_fixture("key_lookup.tsx", source);
   let mut state = state_for_fixture(&path);
+  let call_expr = compiled_create_call();
 
-  // The compiled call as this plugin sees it: macro calls already replaced
-  // with their literal results.
-  let compiled_arg = create_object_expression(vec![
-    create_nested_object_prop(
-      "root",
-      vec![create_key_value_prop("color", create_string_expr("red"))],
-    ),
-    create_nested_object_prop(
-      "other",
-      vec![create_key_value_prop("display", create_string_expr("flex"))],
-    ),
-  ]);
-
-  let call_expr = CallExpr {
-    span: DUMMY_SP,
-    ctxt: SyntaxContext::empty(),
-    callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(
-      "create".into(),
-      DUMMY_SP,
-      SyntaxContext::empty(),
-    )))),
-    args: vec![ExprOrSpread {
-      spread: None,
-      expr: Box::new(compiled_arg),
-    }],
-    type_args: None,
-  };
-
-  let (code_frame, span) = GLOBALS.set(&Globals::default(), || {
-    get_key_span_from_source_code(&call_expr, "other", &mut state).unwrap()
+  let result = GLOBALS.set(&Globals::default(), || {
+    get_key_span_from_source_code(&call_expr, "other", &mut state)
   });
+  let (code_frame, span) = match result {
+    Ok(result) => result,
+    Err(error) => panic!("failed to get source span: {error}"),
+  };
 
   assert!(
     !span.is_dummy(),
@@ -225,6 +246,81 @@ export const styles = create({
     code_frame.get_span_line_number(span),
     7,
     "the span must point at the `other` key in the on-disk source"
+  );
+}
+
+#[test]
+fn key_lookup_ignores_unrelated_objects_with_matching_keys() {
+  let source = "\
+const unrelated = {
+  root: {},
+  other: {},
+};
+
+export const styles = create({
+  root: {
+    color: fancyMacro(2),
+  },
+  other: {
+    display: fancyMacro('flex'),
+  },
+});
+";
+  let path = write_fixture("key_lookup_ignores_unrelated.tsx", source);
+  let mut state = state_for_fixture(&path);
+  let call_expr = compiled_create_call();
+
+  let result = GLOBALS.set(&Globals::default(), || {
+    get_key_span_from_source_code(&call_expr, "other", &mut state)
+  });
+  let (code_frame, span) = match result {
+    Ok(result) => result,
+    Err(error) => panic!("failed to get source span: {error}"),
+  };
+
+  assert_eq!(
+    code_frame.get_span_line_number(span),
+    10,
+    "the span must point at the `other` key in the stylex create call"
+  );
+}
+
+#[test]
+fn key_lookup_returns_dummy_for_ambiguous_dummy_span_calls() {
+  let source = "\
+export const first = create({
+  root: {
+    color: fancyMacro(1),
+  },
+  other: {
+    display: fancyMacro('flex'),
+  },
+});
+
+export const second = create({
+  root: {
+    color: fancyMacro(2),
+  },
+  other: {
+    display: fancyMacro('block'),
+  },
+});
+";
+  let path = write_fixture("key_lookup_ambiguous_dummy_span.tsx", source);
+  let mut state = state_for_fixture(&path);
+  let call_expr = compiled_create_call();
+
+  let result = GLOBALS.set(&Globals::default(), || {
+    get_key_span_from_source_code(&call_expr, "other", &mut state)
+  });
+  let (_code_frame, span) = match result {
+    Ok(result) => result,
+    Err(error) => panic!("failed to get source span: {error}"),
+  };
+
+  assert!(
+    span.is_dummy(),
+    "ambiguous dummy-span calls must fall back to value-expression matching"
   );
 }
 

--- a/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
@@ -10,15 +10,20 @@ use std::{
 
 use swc_core::common::{BytePos, DUMMY_SP, FileName, GLOBALS, Globals, Span, SyntaxContext};
 use swc_core::ecma::ast::{
-  Expr, Ident, ImportDecl, ImportNamedSpecifier, ImportSpecifier, Module, ModuleDecl, ModuleItem,
-  Str,
+  CallExpr, Callee, Expr, ExprOrSpread, Ident, ImportDecl, ImportNamedSpecifier, ImportSpecifier,
+  Module, ModuleDecl, ModuleItem, Str,
 };
 
 use crate::shared::{
   structures::state_manager::StateManager,
   utils::log::build_code_frame_error::{
-    CodeFrame, build_code_frame_error_and_panic, get_span_from_source_code, print_module,
+    CodeFrame, build_code_frame_error_and_panic, get_key_span_from_source_code,
+    get_span_from_source_code, print_module,
   },
+};
+use stylex_ast::ast::{
+  convertors::create_string_expr,
+  factories::{create_key_value_prop, create_nested_object_prop, create_object_expression},
 };
 
 static TEST_FILE_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -150,6 +155,76 @@ fn print_module_ignores_foreign_spans_over_multibyte_sources() {
     printed.contains("exampleExport"),
     "printing must succeed and include the module contents, got: {}",
     printed
+  );
+}
+
+/// When an earlier loader rewrites style values (e.g. compile-time macros),
+/// the compiled AST no longer textually matches the file on disk, so
+/// value-expression matching cannot locate a source position. Namespace keys
+/// are untouched by such transforms, so the key-based lookup must still
+/// resolve the real line number.
+#[test]
+fn key_lookup_finds_line_when_values_differ_from_source() {
+  let dir = std::env::temp_dir().join("stylex_code_frame_error_tests");
+  fs::create_dir_all(&dir).unwrap();
+
+  let source = "\
+import fancyMacro from 'example-macro';
+
+export const styles = create({
+  root: {
+    color: fancyMacro(2),
+  },
+  other: {
+    display: fancyMacro('flex'),
+  },
+});
+";
+  let path = dir.join("key_lookup.tsx");
+  fs::write(&path, source).unwrap();
+
+  let mut state = state_for_fixture(&path);
+
+  // The compiled call as this plugin sees it: macro calls already replaced
+  // with their literal results.
+  let compiled_arg = create_object_expression(vec![
+    create_nested_object_prop(
+      "root",
+      vec![create_key_value_prop("color", create_string_expr("red"))],
+    ),
+    create_nested_object_prop(
+      "other",
+      vec![create_key_value_prop("display", create_string_expr("flex"))],
+    ),
+  ]);
+
+  let call_expr = CallExpr {
+    span: DUMMY_SP,
+    ctxt: SyntaxContext::empty(),
+    callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(
+      "create".into(),
+      DUMMY_SP,
+      SyntaxContext::empty(),
+    )))),
+    args: vec![ExprOrSpread {
+      spread: None,
+      expr: Box::new(compiled_arg),
+    }],
+    type_args: None,
+  };
+
+  let (code_frame, span) = GLOBALS.set(&Globals::default(), || {
+    get_key_span_from_source_code(&call_expr, "other", &mut state).unwrap()
+  });
+
+  assert!(
+    !span.is_dummy(),
+    "the namespace key must be locatable even though the values differ"
+  );
+  assert_eq!(
+    code_frame.get_span_line_number(span),
+    7,
+    "the span must point at the `other` key in the on-disk source"
   );
 }
 

--- a/crates/stylex-transform/tests/fixture/spot-loader/output.js
+++ b/crates/stylex-transform/tests/fixture/spot-loader/output.js
@@ -167,7 +167,7 @@ const styles = {
     size_small: {
         height: "height-xettwda",
         width: "width-xs5h3dt",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:49"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:53"
     },
     size_normal: {
         height: "height-x1sh0tsm",

--- a/crates/stylex-transform/tests/fixture/typography/output.js
+++ b/crates/stylex-transform/tests/fixture/typography/output.js
@@ -226,7 +226,7 @@ const styles = {
     },
     color_primary: {
         color: "color-xw3ogp8",
-        $$css: "tests/fixture/typography/input.stylex.js:85"
+        $$css: "tests/fixture/typography/input.stylex.js:88"
     },
     colorSecondary: {
         color: "color-x10gd8tk",


### PR DESCRIPTION
- Introduced `get_key_span_from_source_code` function to locate the span of a style namespace by its key, enhancing error diagnostics when values differ from source.
- Updated `add_source_map_data` to utilize the new key-based lookup method.
- Added tests to verify the functionality of key-based span resolution in various scenarios, ensuring accurate line number retrieval even after transformations.
- Adjusted related utility functions and improved error handling in the logging module.

## Description

This pull request introduces a more robust method for locating the source code span of style namespace keys, improving the accuracy of source maps and diagnostics even when code transforms (such as macro expansions) alter value expressions. The core change is the addition of a key-based lookup that finds the original source position by matching static object keys, with a fallback to the previous value-based approach. The update includes new logic, helper functions, and a comprehensive test to validate the new behavior.

**Key improvements to source map accuracy and diagnostics:**

* Added `get_key_span_from_source_code` to locate the span of a style namespace by its object key, ensuring accurate source mapping even when value expressions are transformed by earlier loaders.
* Updated `add_source_map_data` to use the new key-based span lookup, falling back to the value-based method only if the key cannot be found.

**Enhancements to test coverage:**

* Added a test (`key_lookup_finds_line_when_values_differ_from_source`) that verifies the key-based lookup correctly finds the source line when values differ between the source and the compiled AST.
* Updated imports and helpers in test files to support the new test and utilities.

**Internal code organization:**

* Refactored imports and grouped related utilities for clarity and maintainability in `build_code_frame_error.rs`.

**Fixture updates:**

* Updated output line numbers in test fixtures to reflect the improved source mapping logic [[1]](diffhunk://#diff-1c5515aecd2664b0e0edbaefa6e58cd78f7e93a2ebe6f5d6702a403b8a759624L170-R170) [[2]](diffhunk://#diff-3eefcfa4d72140eaeea36f7bab264496eec487051c5646739e22b74bc01d1804L229-R229).

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
