### PR TITLE
Fix unicode source map building for non ascii files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2843,6 +2843,7 @@ dependencies = [
  "swc_compiler_base",
  "swc_core",
  "swc_ecma_parser",
+ "swc_sourcemap",
 ]
 
 [[package]]
@@ -3055,6 +3056,7 @@ dependencies = [
  "swc_config",
  "swc_core",
  "swc_ecma_parser",
+ "swc_sourcemap",
  "testing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ swc_compiler_base = { version = "59.0.0" }
 swc_config = { version = "5.0.0" }
 swc_core = { version = "71.0.6" }
 swc_ecma_parser = { version = "41.0.0" }
+swc_sourcemap = { version = "10.0.2" }
 testing = "24.0.0"
 thiserror = "2.0.18"
 # convert_case = { version = "0.11.0" }

--- a/crates/stylex-rs-compiler/Cargo.toml
+++ b/crates/stylex-rs-compiler/Cargo.toml
@@ -31,6 +31,7 @@ swc_core = { workspace = true, features = [
   "ecma_utils",
 ] }
 swc_ecma_parser = { workspace = true, features = ["verify"] }
+swc_sourcemap.workspace = true
 
 indexmap.workspace = true
 napi = { version = "3.9.0", features = ["compat-mode"] }

--- a/crates/stylex-rs-compiler/README.md
+++ b/crates/stylex-rs-compiler/README.md
@@ -251,10 +251,10 @@ const { code, metadata, sourcemap } = transform(
 ### Path Filtering
 
 > [!NOTE]
-> The `include` and `exclude` options are exclusive to
-> this NAPI-RS compiler implementation and are not available in the official
-> StyleX Babel plugin. They provide powerful file filtering capabilities to
-> control which files are transformed.
+> The `include` and `exclude` options are exclusive to this NAPI-RS
+> compiler implementation and are not available in the official StyleX Babel
+> plugin. They provide powerful file filtering capabilities to control which
+> files are transformed.
 
 The compiler exports a `shouldTransformFile` function to determine whether a
 file should be transformed based on include/exclude patterns:
@@ -345,7 +345,7 @@ shouldTransformFile(filePath, undefined, [/node_modules(?!\/@stylexjs)/]);
 ### SWC Plugin Support
 
 > [!NOTE]
->**New Feature:** The compiler now supports running SWC WASM plugins
+> **New Feature:** The compiler now supports running SWC WASM plugins
 > before StyleX transformation. This allows you to chain transformations and
 > integrate custom SWC plugins seamlessly.
 
@@ -572,18 +572,76 @@ const styles = {
 > This option is automatically enabled when using
 > `@stylexswc/webpack-plugin` with `loaderOrder: 'first'` (the default).
 
+### `inputSourceMap`
+
+**Type:** `string` (JSON source map) **Default:** `undefined`
+
+Source map for the incoming `code`, produced by earlier tooling — for example a
+loader chain that expands compile-time macros before the StyleX transformation
+runs.
+
+#### Source Map Problem
+
+When the compiler receives code that was already rewritten by previous tools,
+positions in that code no longer match the original authored file. Two things
+degrade as a result:
+
+- Debug source-map annotations (`$$css: "file.tsx:LINE"`, emitted with
+  `debug: true`) point at lines of the intermediate code
+- The emitted source map resolves to the intermediate code instead of the
+  original file
+
+#### Source Map Solution
+
+When `inputSourceMap` is provided, the compiler:
+
+1. Resolves each style namespace to its position using the namespace key's own
+   span — exact, with no re-parsing — and maps it through the input map back to
+   the original authored file
+2. Chains the emitted source map onto the input map, so downstream tooling (e.g.
+   devtools) resolves positions all the way back to the original file
+
+```ts
+const { code, metadata, map } = transform(filename, inputCode, {
+  dev: true,
+  debug: true,
+  // Source map produced by the previous transformation step
+  inputSourceMap: JSON.stringify(previousStepSourceMap),
+});
+```
+
+This is also the fastest position-resolution path: two binary searches per
+namespace instead of re-reading and re-parsing the source.
+
+> [!TIP]
+> The bundler plugins (`@stylexswc/rspack-plugin`,
+> `@stylexswc/webpack-plugin`, `@stylexswc/turbopack-plugin`,
+> `@stylexswc/rollup-plugin`, and `@stylexswc/unplugin` on Rollup-compatible
+> hosts) forward the previous loader's / plugin's source map automatically — no
+> configuration needed as long as source maps are enabled in the bundler.
+
+An invalid map is ignored with a warning, and the compiler falls back to
+locating positions in the source text as described under
+[`useRealFileForSource`](#userealfileforsource).
+
 ### `useRealFileForSource`
 
 **Type:** `boolean` **Default:** `true`
 
 Controls whether the compiler should read source files from disk for error
-reporting and source map generation.
+reporting and source map generation. Only relevant when no
+[`inputSourceMap`](#inputsourcemap) is available — with an input map, debug
+source-map annotations are resolved from the compiler's own parse and do not
+depend on this option.
 
 #### Behavior
 
 - **`true` (default)**: The compiler reads the actual source file from disk when
   generating error messages and source maps. This provides accurate line numbers
-  and source context that match what you see in your editor.
+  and source context that match what you see in your editor. Style namespaces
+  are located **by their key**, so positions resolve correctly even when the
+  incoming code was already rewritten by earlier tooling (keys survive
+  value-level transforms such as macro expansion).
 
 - **`false`**: The compiler uses the transformed AST representation for error
   reporting. This is useful when:
@@ -591,7 +649,7 @@ reporting and source map generation.
   - Source files are not available on disk
   - You want faster compilation (skips file I/O)
 
-#### Example
+#### Source Map Example
 
 ```ts
 transform(filename, code, {
@@ -621,7 +679,7 @@ transform(filename, code, {
 > Keep the default `true` value for most use cases. Only set it to
 > `false` if you have specific requirements for in-memory transformations or
 > performance-critical scenarios where file I/O is a bottleneck.
-
+>
 > [!WARNING]
 > When `useRealFileForSource` is set to `false`, error messages may
 > report **incorrect line numbers**. The compiler will use the transformed AST
@@ -633,7 +691,9 @@ transform(filename, code, {
 > - The structure may differ from what's in your actual source file
 >
 > For accurate error reporting and debugging, always use
-> `useRealFileForSource: true` (the default) during development.
+> `useRealFileForSource: true` (the default) during development, and provide an
+> [`inputSourceMap`](#inputsourcemap) when the incoming code was already
+> transformed by earlier tooling.
 
 ## Debug
 

--- a/crates/stylex-rs-compiler/src/index.ts
+++ b/crates/stylex-rs-compiler/src/index.ts
@@ -179,19 +179,20 @@ export function transform(
   }
 
   let transformedCode = code;
+  let inputSourceMap = options.inputSourceMap;
 
   if (options.swcPlugins?.length) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const swc = require('@swc/core');
 
+    // Always request an external map: it chains `inputSourceMap` and the
+    // plugins' own edits, so the positions handed to the native transform
+    // keep describing the code it actually receives. The native transform
+    // owns emission of the final map per `options.sourceMap` (incl. inline).
     const result = swc.transformSync(transformedCode, {
       filename,
-      sourceMaps:
-        options.sourceMap === 'Inline'
-          ? 'inline'
-          : options.sourceMap === 'False'
-            ? false
-            : options.sourceMap !== undefined,
+      sourceMaps: true,
+      inputSourceMap,
       jsc: {
         parser: { syntax: 'typescript', tsx: true },
         target: 'es2022',
@@ -199,6 +200,9 @@ export function transform(
       },
     });
     transformedCode = result.code;
+    if (result.map) {
+      inputSourceMap = result.map;
+    }
   }
 
   // Strip TS-only fields before passing to native transform
@@ -209,5 +213,8 @@ export function transform(
     ...nativeOptions
   } = options;
 
-  return nativeBinding.transform(filename, transformedCode, nativeOptions);
+  return nativeBinding.transform(filename, transformedCode, {
+    ...nativeOptions,
+    inputSourceMap,
+  });
 }

--- a/crates/stylex-rs-compiler/src/index.ts
+++ b/crates/stylex-rs-compiler/src/index.ts
@@ -37,6 +37,7 @@ export const PropertyValidationMode = Object.freeze({
 export interface StyleXOptions extends NativeStyleXOptions {
   include?: Array<string | RegExp>;
   exclude?: Array<string | RegExp>;
+  inputSourceMap?: string;
   swcPlugins?: Array<[string, Record<string, unknown>]>;
 }
 

--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -3,7 +3,7 @@
 mod enums;
 mod structs;
 mod utils;
-use log::info;
+use log::{info, warn};
 use napi::{Env, Result};
 use std::{env, panic, sync::Arc};
 use structs::{StyleXMetadata, StyleXOptions, StyleXTransformResult};
@@ -92,6 +92,23 @@ pub fn transform(
     };
 
     let source_map = source_maps_config(options.source_map.as_ref());
+    let should_chain_input_source_map =
+      !matches!(options.source_map.as_ref(), Some(SourceMaps::False));
+
+    // Parse the incoming source map (if any) once: it feeds both the debug
+    // source-map annotations and the chaining of the emitted map.
+    let input_source_map = options.input_source_map.take().and_then(|json| {
+      match swc_sourcemap::SourceMap::from_slice(json.as_bytes()) {
+        Ok(map) => Some(Arc::new(map)),
+        Err(err) => {
+          warn!(
+            "[StyleX] Failed to parse inputSourceMap, ignoring it: {}",
+            err
+          );
+          None
+        },
+      }
+    });
 
     let mut config: StyleXOptionsParams = options.try_into()?;
 
@@ -127,6 +144,14 @@ pub fn transform(
         let mut stylex: StyleXTransform<PluginCommentsProxy> =
           StyleXTransform::new(PluginCommentsProxy, plugin_pass, &mut config);
 
+        // Give the transform exact access to the parsed input so span-based
+        // position lookups need no re-parsing, and to the input source map so
+        // debug annotations point at the original authored file.
+        stylex.state.set_input_source_file(fm.clone());
+        if let Some(ref input_source_map) = input_source_map {
+          stylex.state.set_input_source_map(input_source_map.clone());
+        }
+
         let program = program
           .apply(resolver(unresolved_mark, top_level_mark, true))
           .apply(typescript_strip(unresolved_mark, top_level_mark))
@@ -141,6 +166,15 @@ pub fn transform(
           &program,
           PrintArgs {
             source_map,
+            // Chain the emitted map onto the input map so it resolves all the
+            // way back to the original authored file. Skip the clone when
+            // source maps are disabled; debug annotations already use the
+            // shared Arc stored in StateManager.
+            orig: if should_chain_input_source_map {
+              input_source_map.as_ref().map(|map| (**map).clone())
+            } else {
+              None
+            },
             ..Default::default()
           },
         );

--- a/crates/stylex-rs-compiler/src/structs/mod.rs
+++ b/crates/stylex-rs-compiler/src/structs/mod.rs
@@ -49,6 +49,11 @@ pub struct StyleXOptions {
   #[napi(js_name = "unstable_moduleResolution")]
   pub unstable_module_resolution: Option<StyleXModuleResolution>,
   pub source_map: Option<SourceMaps>,
+  /// JSON source map for the incoming `code`, produced by earlier tooling
+  /// (e.g. a macro loader). When provided, debug source-map annotations are
+  /// mapped back to the original authored file and the emitted source map is
+  /// chained onto it.
+  pub input_source_map: Option<String>,
   #[napi(ts_type = "'throw' | 'warn' | 'silent'")]
   pub property_validation_mode: Option<PropertyValidationMode>,
   /// Compile-time constants and functions accessible via `stylex.env`.

--- a/crates/stylex-rs-compiler/src/tests/structs_tests.rs
+++ b/crates/stylex-rs-compiler/src/tests/structs_tests.rs
@@ -27,6 +27,7 @@ fn empty_options() -> StyleXOptions {
     aliases: None,
     unstable_module_resolution: None,
     source_map: None,
+    input_source_map: None,
     property_validation_mode: None,
     env: None,
     debug_file_path: None,

--- a/crates/stylex-transform/Cargo.toml
+++ b/crates/stylex-transform/Cargo.toml
@@ -54,6 +54,7 @@ swc_core = { workspace = true, features = [
   "ecma_utils",
 ] }
 swc_ecma_parser = { workspace = true, features = ["verify"] }
+swc_sourcemap.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1,5 +1,5 @@
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::{option::Option, path::Path, rc::Rc};
+use std::{option::Option, path::Path, rc::Rc, sync::Arc};
 use stylex_macros::{stylex_panic, stylex_unimplemented};
 
 use indexmap::{IndexMap, IndexSet};
@@ -11,7 +11,7 @@ use stylex_path_resolver::{
 };
 use swc_core::{
   atoms::Atom,
-  common::{DUMMY_SP, EqIgnoreSpan, FileName, Span, SyntaxContext},
+  common::{DUMMY_SP, EqIgnoreSpan, FileName, SourceFile, Span, SyntaxContext},
   ecma::{
     ast::{
       CallExpr, Callee, Decl, Expr, ExprStmt, Id, Ident, ImportDecl, ImportDefaultSpecifier,
@@ -369,6 +369,14 @@ impl StyleInjectionState {
 pub struct StateManager {
   pub(crate) plugin_pass: PluginPass,
 
+  /// The source file the compiler parsed, when the host makes it available.
+  /// Expression spans in the transformed AST resolve exactly against it.
+  pub(crate) input_source_file: Option<Arc<SourceFile>>,
+  /// Source map for the compiler's input code, mapping positions back to the
+  /// original authored file when earlier tooling (e.g. macro loaders) already
+  /// transformed the code.
+  pub(crate) input_source_map: Option<Arc<swc_sourcemap::SourceMap>>,
+
   // Imports
   pub(crate) imports: ImportState,
   pub(crate) export_id: Option<String>,
@@ -490,6 +498,8 @@ impl StateManager {
 
     Self {
       plugin_pass: PluginPass::default(),
+      input_source_file: None,
+      input_source_map: None,
       imports: ImportState::default(),
       existing_import_sources: vec![],
       bound_names: FxHashSet::default(),
@@ -874,6 +884,19 @@ impl StateManager {
 
   pub(crate) fn enable_inlined_conditional_merge(&self) -> bool {
     self.options.enable_inlined_conditional_merge
+  }
+
+  /// Provides the parsed input source file so span positions can be resolved
+  /// without re-parsing. Set by hosts that own the parse (e.g. the NAPI
+  /// compiler).
+  pub fn set_input_source_file(&mut self, source_file: Arc<SourceFile>) {
+    self.input_source_file = Some(source_file);
+  }
+
+  /// Provides the source map of the compiler's input code, enabling positions
+  /// to be mapped back to the original authored file.
+  pub fn set_input_source_map(&mut self, source_map: Arc<swc_sourcemap::SourceMap>) {
+    self.input_source_map = Some(source_map);
   }
 
   pub(crate) fn get_short_filename(&self) -> String {

--- a/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
+++ b/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
@@ -68,6 +68,10 @@ pub(crate) fn add_source_map_data(
     },
   };
 
+  // The value-matching fallback wraps the same call for every namespace key,
+  // so build it once instead of deep-cloning the call per key.
+  let wrapped_call_expr = Expr::Call(call_expr.clone());
+
   for (key, value) in obj {
     let mut inner_map = IndexMap::new();
 
@@ -103,11 +107,7 @@ pub(crate) fn add_source_map_data(
         let source_code_frame_and_span = match get_key_span_from_source_code(call_expr, key, state)
         {
           Ok((code_frame, span)) if !span.eq(&DUMMY_SP) => Ok((code_frame, span)),
-          _ => get_span_from_source_code(
-            &Expr::Call(call_expr.clone()),
-            &style_node_path.value,
-            state,
-          ),
+          _ => get_span_from_source_code(&wrapped_call_expr, &style_node_path.value, state),
         };
 
         match source_code_frame_and_span {
@@ -259,10 +259,25 @@ fn original_position_from_input_source_map(
 
   let token = input_map.lookup_token(line as u32, col as u32)?;
 
+  // `lookup_token` returns the nearest preceding token, which a sparse map
+  // (e.g. statement-level mappings only) can place on an earlier line. Only a
+  // same-line token is trustworthy for a `file:line` annotation; otherwise
+  // fall back to locating the key in the source text.
+  if token.get_dst_line() != line as u32 {
+    return None;
+  }
+
+  let filename = match token.get_source() {
+    // Scheme-qualified sources (e.g. `webpack://app/src/x.ts`) are not
+    // filesystem paths; `create_short_filename` would garble them — fall
+    // back to locating the key in the source text instead.
+    Some(source) if source.contains("://") => return None,
+    Some(source) => source.to_string(),
+    None => state.get_filename().to_string(),
+  };
+
   Some(OriginalSourcePosition {
-    filename: token
-      .get_source()
-      .map_or_else(|| state.get_filename().to_string(), ToString::to_string),
+    filename,
     line_number: token.get_src_line() as usize + 1,
   })
 }

--- a/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
+++ b/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
@@ -6,7 +6,7 @@ use stylex_macros::stylex_panic;
 use stylex_path_resolver::package_json::PackageJsonExtended;
 
 use swc_core::{
-  common::DUMMY_SP,
+  common::{DUMMY_SP, Spanned},
   ecma::ast::{CallExpr, Expr, KeyValueProp},
 };
 
@@ -75,7 +75,25 @@ pub(crate) fn add_source_map_data(
 
     match style_node_paths.remove(key) {
       Some(style_node_path) => {
-        // Locate the namespace by its key first: keys are static strings that
+        // Highest fidelity: resolve the key's own span against the compiler's
+        // input and map it through the host-provided input source map back to
+        // the original authored file. Exact even when earlier tooling (e.g.
+        // macro loaders) already rewrote the code.
+        if let Some(original_line_number) =
+          original_line_from_input_source_map(&style_node_path, state)
+        {
+          insert_compiled_entry(
+            &mut inner_map,
+            original_line_number,
+            state,
+            package_json_seen,
+            functions,
+          );
+          result.insert(key.clone(), Rc::new(inner_map));
+          continue;
+        }
+
+        // Locate the namespace by its key next: keys are static strings that
         // survive value-level code transforms (e.g. macro expansion by an
         // earlier loader), so this finds the original source position even
         // when the compiled values no longer match the file content. Fall
@@ -109,37 +127,15 @@ pub(crate) fn add_source_map_data(
                 );
               };
             } else {
-              if let Some(original_line_number) = code_frame.try_get_span_line_number(span)
-                && original_line_number > 0
-              {
-                let filename = state.get_filename().to_string();
-                let raw_short_filename = create_short_filename(&filename, state, package_json_seen);
-                let short_filename_expr = if let Some(ref f) = state.options.debug_file_path {
-                  f.call(vec![create_string_expr(&raw_short_filename)])
-                } else {
-                  create_string_expr(&raw_short_filename)
-                };
-
-                let short_filename = convert_expr_to_str(&short_filename_expr, state, functions);
-
-                if let Some(short_filename) = short_filename
-                  && !short_filename.is_empty()
-                {
-                  let source_map = format!("{}:{}", short_filename, original_line_number);
-                  inner_map.insert(
-                    COMPILED_KEY.to_owned(),
-                    Rc::new(FlatCompiledStylesValue::String(source_map)),
-                  );
-                } else {
-                  inner_map.insert(
-                    COMPILED_KEY.to_owned(),
-                    Rc::new(FlatCompiledStylesValue::Bool(true)),
-                  );
-                }
-              } else {
-                inner_map.insert(
-                  COMPILED_KEY.to_owned(),
-                  Rc::new(FlatCompiledStylesValue::Bool(true)),
+              // Panic-safe lookup: `None` leaves the map untouched and the
+              // `contains_key` fallback below inserts the plain `true` marker.
+              if let Some(original_line_number) = code_frame.try_get_span_line_number(span) {
+                insert_compiled_entry(
+                  &mut inner_map,
+                  original_line_number,
+                  state,
+                  package_json_seen,
+                  functions,
                 );
               }
             }
@@ -180,6 +176,87 @@ pub(crate) fn add_source_map_data(
 
   result
 }
+
+/// Inserts the `$$css` entry with a `file:line` annotation, or `true` when a
+/// usable short filename cannot be produced.
+fn insert_compiled_entry(
+  inner_map: &mut IndexMap<String, Rc<FlatCompiledStylesValue>>,
+  original_line_number: usize,
+  state: &mut StateManager,
+  package_json_seen: &mut FxHashMap<String, PackageJsonExtended>,
+  functions: &FunctionMap,
+) {
+  let filename = state.get_filename().to_string();
+  let raw_short_filename = create_short_filename(&filename, state, package_json_seen);
+  let short_filename_expr = if let Some(ref f) = state.options.debug_file_path {
+    f.call(vec![create_string_expr(&raw_short_filename)])
+  } else {
+    create_string_expr(&raw_short_filename)
+  };
+
+  let short_filename = convert_expr_to_str(&short_filename_expr, state, functions);
+
+  if original_line_number > 0
+    && let Some(short_filename) = short_filename
+    && !short_filename.is_empty()
+  {
+    let source_map = format!("{}:{}", short_filename, original_line_number);
+    inner_map.insert(
+      COMPILED_KEY.to_owned(),
+      Rc::new(FlatCompiledStylesValue::String(source_map)),
+    );
+  } else {
+    inner_map.insert(
+      COMPILED_KEY.to_owned(),
+      Rc::new(FlatCompiledStylesValue::Bool(true)),
+    );
+  }
+}
+
+/// Resolves a style namespace to its 1-based line in the original authored
+/// file by combining the namespace key's own span — exact in the compiler's
+/// input — with the host-provided input source map, which maps the input back
+/// to the original file when earlier tooling already transformed it.
+///
+/// Returns `None` when either piece is unavailable so callers can fall back
+/// to locating the namespace in the source text.
+fn original_line_from_input_source_map(
+  style_node_path: &KeyValueProp,
+  state: &StateManager,
+) -> Option<usize> {
+  let source_file = state.input_source_file.as_ref()?;
+  let input_map = state.input_source_map.as_ref()?;
+
+  let span = style_node_path.key.span();
+  if span.is_dummy() {
+    return None;
+  }
+
+  let pos = span.lo();
+  if pos < source_file.start_pos || pos >= source_file.end_pos {
+    return None;
+  }
+
+  let line = source_file.lookup_line(pos)?;
+  let line_begin = source_file.line_begin_pos(pos);
+
+  // Source map columns are counted in UTF-16 code units.
+  let line_start_offset = (line_begin - source_file.start_pos).0 as usize;
+  let pos_offset = (pos - source_file.start_pos).0 as usize;
+  let col = source_file
+    .src
+    .get(line_start_offset..pos_offset)?
+    .encode_utf16()
+    .count();
+
+  let token = input_map.lookup_token(line as u32, col as u32)?;
+
+  Some(token.get_src_line() as usize + 1)
+}
+
+#[cfg(test)]
+#[path = "tests/add_source_map_data_tests.rs"]
+mod tests;
 
 fn get_package_prefix(absolute_path: &str) -> Option<String> {
   const NODE_MODULES: &str = "node_modules";

--- a/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
+++ b/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
@@ -79,12 +79,13 @@ pub(crate) fn add_source_map_data(
         // input and map it through the host-provided input source map back to
         // the original authored file. Exact even when earlier tooling (e.g.
         // macro loaders) already rewrote the code.
-        if let Some(original_line_number) =
-          original_line_from_input_source_map(&style_node_path, state)
+        if let Some(original_position) =
+          original_position_from_input_source_map(&style_node_path, state)
         {
           insert_compiled_entry(
             &mut inner_map,
-            original_line_number,
+            &original_position.filename,
+            original_position.line_number,
             state,
             package_json_seen,
             functions,
@@ -130,8 +131,10 @@ pub(crate) fn add_source_map_data(
               // Panic-safe lookup: `None` leaves the map untouched and the
               // `contains_key` fallback below inserts the plain `true` marker.
               if let Some(original_line_number) = code_frame.try_get_span_line_number(span) {
+                let filename = state.get_filename().to_string();
                 insert_compiled_entry(
                   &mut inner_map,
+                  &filename,
                   original_line_number,
                   state,
                   package_json_seen,
@@ -181,13 +184,13 @@ pub(crate) fn add_source_map_data(
 /// usable short filename cannot be produced.
 fn insert_compiled_entry(
   inner_map: &mut IndexMap<String, Rc<FlatCompiledStylesValue>>,
+  filename: &str,
   original_line_number: usize,
   state: &mut StateManager,
   package_json_seen: &mut FxHashMap<String, PackageJsonExtended>,
   functions: &FunctionMap,
 ) {
-  let filename = state.get_filename().to_string();
-  let raw_short_filename = create_short_filename(&filename, state, package_json_seen);
+  let raw_short_filename = create_short_filename(filename, state, package_json_seen);
   let short_filename_expr = if let Some(ref f) = state.options.debug_file_path {
     f.call(vec![create_string_expr(&raw_short_filename)])
   } else {
@@ -213,17 +216,22 @@ fn insert_compiled_entry(
   }
 }
 
-/// Resolves a style namespace to its 1-based line in the original authored
+struct OriginalSourcePosition {
+  filename: String,
+  line_number: usize,
+}
+
+/// Resolves a style namespace to its source position in the original authored
 /// file by combining the namespace key's own span — exact in the compiler's
 /// input — with the host-provided input source map, which maps the input back
 /// to the original file when earlier tooling already transformed it.
 ///
 /// Returns `None` when either piece is unavailable so callers can fall back
 /// to locating the namespace in the source text.
-fn original_line_from_input_source_map(
+fn original_position_from_input_source_map(
   style_node_path: &KeyValueProp,
   state: &StateManager,
-) -> Option<usize> {
+) -> Option<OriginalSourcePosition> {
   let source_file = state.input_source_file.as_ref()?;
   let input_map = state.input_source_map.as_ref()?;
 
@@ -251,7 +259,12 @@ fn original_line_from_input_source_map(
 
   let token = input_map.lookup_token(line as u32, col as u32)?;
 
-  Some(token.get_src_line() as usize + 1)
+  Some(OriginalSourcePosition {
+    filename: token
+      .get_source()
+      .map_or_else(|| state.get_filename().to_string(), ToString::to_string),
+    line_number: token.get_src_line() as usize + 1,
+  })
 }
 
 #[cfg(test)]

--- a/crates/stylex-transform/src/shared/utils/core/tests/add_source_map_data_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/core/tests/add_source_map_data_tests.rs
@@ -4,7 +4,7 @@ use swc_core::common::{BytePos, FileName, SourceMap as SwcSourceMap, Span};
 use swc_core::ecma::ast::{Expr, IdentName, KeyValueProp, Lit, PropName, Str};
 use swc_sourcemap::SourceMapBuilder;
 
-use super::original_line_from_input_source_map;
+use super::original_position_from_input_source_map;
 use crate::shared::structures::state_manager::StateManager;
 
 const INPUT_CODE: &str = "\
@@ -68,13 +68,15 @@ fn maps_key_position_through_input_source_map() {
   builder.add(2, 0, 41, 0, Some("Original.tsx".into()), None, false);
   state.set_input_source_map(Arc::new(builder.into_sourcemap()));
 
-  let line = original_line_from_input_source_map(&style_node_path, &state);
+  let position = original_position_from_input_source_map(&style_node_path, &state);
 
-  assert_eq!(
-    line,
-    Some(42),
-    "the key position must map back to the original file's 1-based line"
-  );
+  let position = match position {
+    Some(position) => position,
+    None => panic!("the key position must map back to the original source"),
+  };
+
+  assert_eq!(position.filename, "Original.tsx");
+  assert_eq!(position.line_number, 42);
 }
 
 #[test]
@@ -133,7 +135,8 @@ fn returns_none_without_input_source_map() {
   let state = state_with_input(INPUT_CODE);
 
   assert_eq!(
-    original_line_from_input_source_map(&style_node_path, &state),
+    original_position_from_input_source_map(&style_node_path, &state)
+      .map(|position| (position.filename, position.line_number)),
     None,
     "without an input map the caller must fall back to source-text lookups"
   );
@@ -150,7 +153,8 @@ fn returns_none_for_spans_outside_the_input_file() {
   state.set_input_source_map(Arc::new(builder.into_sourcemap()));
 
   assert_eq!(
-    original_line_from_input_source_map(&style_node_path, &state),
+    original_position_from_input_source_map(&style_node_path, &state)
+      .map(|position| (position.filename, position.line_number)),
     None,
     "foreign spans must not resolve through the input file"
   );

--- a/crates/stylex-transform/src/shared/utils/core/tests/add_source_map_data_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/core/tests/add_source_map_data_tests.rs
@@ -1,0 +1,157 @@
+use std::sync::Arc;
+
+use swc_core::common::{BytePos, FileName, SourceMap as SwcSourceMap, Span};
+use swc_core::ecma::ast::{Expr, IdentName, KeyValueProp, Lit, PropName, Str};
+use swc_sourcemap::SourceMapBuilder;
+
+use super::original_line_from_input_source_map;
+use crate::shared::structures::state_manager::StateManager;
+
+const INPUT_CODE: &str = "\
+const styles = create({
+  root: { color: 'red' },
+  other: { display: 'flex' },
+});
+";
+
+const UNICODE_INPUT_CODE: &str = "\
+const styles = create({
+  emoji: '🚀', root: { color: 'red' },
+});
+";
+
+fn key_value_prop_at(code_offset: usize, key: &str) -> (KeyValueProp, u32) {
+  let lo = code_offset as u32;
+
+  (
+    KeyValueProp {
+      key: PropName::Ident(IdentName::new(
+        key.into(),
+        Span::new(BytePos(lo + 1), BytePos(lo + 1 + key.len() as u32)),
+      )),
+      value: Box::new(Expr::Lit(Lit::Str(Str {
+        span: swc_core::common::DUMMY_SP,
+        value: "unused".into(),
+        raw: None,
+      }))),
+    },
+    lo,
+  )
+}
+
+fn state_with_input(code: &str) -> StateManager {
+  let cm = SwcSourceMap::default();
+  let source_file = cm.new_source_file(
+    Arc::new(FileName::Custom("input_source_map_fixture.tsx".to_string())),
+    code.to_string(),
+  );
+
+  let mut state = StateManager::default();
+  state.set_input_source_file(source_file);
+  state
+}
+
+#[test]
+fn maps_key_position_through_input_source_map() {
+  // `other` sits on line index 2 (0-based), column 2 of the compiler input.
+  let key_offset = match INPUT_CODE.find("other") {
+    Some(offset) => offset,
+    None => panic!("fixture must contain the key"),
+  };
+  let (style_node_path, _) = key_value_prop_at(key_offset, "other");
+
+  let mut state = state_with_input(INPUT_CODE);
+
+  // The input map records that input line 2 originates from line index 41 of
+  // the original authored file (as if a macro loader shifted the code).
+  let mut builder = SourceMapBuilder::new(None);
+  builder.add(2, 0, 41, 0, Some("Original.tsx".into()), None, false);
+  state.set_input_source_map(Arc::new(builder.into_sourcemap()));
+
+  let line = original_line_from_input_source_map(&style_node_path, &state);
+
+  assert_eq!(
+    line,
+    Some(42),
+    "the key position must map back to the original file's 1-based line"
+  );
+}
+
+#[test]
+fn maps_key_position_after_non_ascii_text_using_utf16_columns() {
+  let key_offset = match UNICODE_INPUT_CODE.find("root") {
+    Some(offset) => offset,
+    None => panic!("fixture must contain the key"),
+  };
+  let (style_node_path, _) = key_value_prop_at(key_offset, "root");
+
+  let mut state = state_with_input(UNICODE_INPUT_CODE);
+
+  let line_start = match UNICODE_INPUT_CODE.rfind("  emoji") {
+    Some(offset) => offset,
+    None => panic!("fixture must contain the line start"),
+  };
+  let prefix = &UNICODE_INPUT_CODE[line_start..key_offset];
+  let utf16_col = prefix.encode_utf16().count() as u32;
+  let byte_col = prefix.len() as u32;
+
+  assert_ne!(
+    utf16_col, byte_col,
+    "fixture must distinguish UTF-16 columns from byte offsets"
+  );
+
+  let mut builder = SourceMapBuilder::new(None);
+  builder.add(
+    1,
+    utf16_col,
+    10,
+    0,
+    Some("Original.tsx".into()),
+    None,
+    false,
+  );
+  builder.add(1, byte_col, 99, 0, Some("Wrong.tsx".into()), None, false);
+  state.set_input_source_map(Arc::new(builder.into_sourcemap()));
+
+  let position = match original_position_from_input_source_map(&style_node_path, &state) {
+    Some(position) => position,
+    None => panic!("the key position must map using UTF-16 source-map columns"),
+  };
+
+  assert_eq!(position.filename, "Original.tsx");
+  assert_eq!(position.line_number, 11);
+}
+
+#[test]
+fn returns_none_without_input_source_map() {
+  let key_offset = match INPUT_CODE.find("other") {
+    Some(offset) => offset,
+    None => panic!("fixture must contain the key"),
+  };
+  let (style_node_path, _) = key_value_prop_at(key_offset, "other");
+
+  let state = state_with_input(INPUT_CODE);
+
+  assert_eq!(
+    original_line_from_input_source_map(&style_node_path, &state),
+    None,
+    "without an input map the caller must fall back to source-text lookups"
+  );
+}
+
+#[test]
+fn returns_none_for_spans_outside_the_input_file() {
+  let (style_node_path, _) = key_value_prop_at(1_000_000, "other");
+
+  let mut state = state_with_input(INPUT_CODE);
+
+  let mut builder = SourceMapBuilder::new(None);
+  builder.add(2, 0, 41, 0, Some("Original.tsx".into()), None, false);
+  state.set_input_source_map(Arc::new(builder.into_sourcemap()));
+
+  assert_eq!(
+    original_line_from_input_source_map(&style_node_path, &state),
+    None,
+    "foreign spans must not resolve through the input file"
+  );
+}

--- a/crates/stylex-transform/src/shared/utils/core/tests/add_source_map_data_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/core/tests/add_source_map_data_tests.rs
@@ -159,3 +159,107 @@ fn returns_none_for_spans_outside_the_input_file() {
     "foreign spans must not resolve through the input file"
   );
 }
+
+#[test]
+fn returns_none_for_dummy_key_spans() {
+  let key = "other";
+  let style_node_path = KeyValueProp {
+    key: PropName::Ident(IdentName::new(key.into(), swc_core::common::DUMMY_SP)),
+    value: Box::new(Expr::Lit(Lit::Str(Str {
+      span: swc_core::common::DUMMY_SP,
+      value: "unused".into(),
+      raw: None,
+    }))),
+  };
+
+  let mut state = state_with_input(INPUT_CODE);
+
+  let mut builder = SourceMapBuilder::new(None);
+  builder.add(2, 0, 41, 0, Some("Original.tsx".into()), None, false);
+  state.set_input_source_map(Arc::new(builder.into_sourcemap()));
+
+  assert_eq!(
+    original_position_from_input_source_map(&style_node_path, &state)
+      .map(|position| (position.filename, position.line_number)),
+    None,
+    "dummy spans carry no position and must not resolve"
+  );
+}
+
+#[test]
+fn returns_none_for_sparse_maps_whose_nearest_token_is_on_an_earlier_line() {
+  // `other` sits on line index 2, but the map only knows about line 0:
+  // `lookup_token`'s greatest-lower-bound search would hand that earlier
+  // token back, which must not be committed as this key's position.
+  let key_offset = match INPUT_CODE.find("other") {
+    Some(offset) => offset,
+    None => panic!("fixture must contain the key"),
+  };
+  let (style_node_path, _) = key_value_prop_at(key_offset, "other");
+
+  let mut state = state_with_input(INPUT_CODE);
+
+  let mut builder = SourceMapBuilder::new(None);
+  builder.add(0, 0, 7, 0, Some("Original.tsx".into()), None, false);
+  state.set_input_source_map(Arc::new(builder.into_sourcemap()));
+
+  assert_eq!(
+    original_position_from_input_source_map(&style_node_path, &state)
+      .map(|position| (position.filename, position.line_number)),
+    None,
+    "a token from an earlier line must fall back to source-text lookups"
+  );
+}
+
+#[test]
+fn returns_none_for_scheme_qualified_source_names() {
+  let key_offset = match INPUT_CODE.find("other") {
+    Some(offset) => offset,
+    None => panic!("fixture must contain the key"),
+  };
+  let (style_node_path, _) = key_value_prop_at(key_offset, "other");
+
+  let mut state = state_with_input(INPUT_CODE);
+
+  let mut builder = SourceMapBuilder::new(None);
+  builder.add(
+    2,
+    0,
+    41,
+    0,
+    Some("webpack://app/src/Original.tsx".into()),
+    None,
+    false,
+  );
+  state.set_input_source_map(Arc::new(builder.into_sourcemap()));
+
+  assert_eq!(
+    original_position_from_input_source_map(&style_node_path, &state)
+      .map(|position| (position.filename, position.line_number)),
+    None,
+    "scheme-qualified sources are not filesystem paths and must fall back"
+  );
+}
+
+#[test]
+fn falls_back_to_the_state_filename_when_the_token_has_no_source() {
+  let key_offset = match INPUT_CODE.find("other") {
+    Some(offset) => offset,
+    None => panic!("fixture must contain the key"),
+  };
+  let (style_node_path, _) = key_value_prop_at(key_offset, "other");
+
+  let mut state = state_with_input(INPUT_CODE);
+
+  let mut builder = SourceMapBuilder::new(None);
+  builder.add(2, 0, 41, 0, None, None, false);
+  state.set_input_source_map(Arc::new(builder.into_sourcemap()));
+
+  let position = match original_position_from_input_source_map(&style_node_path, &state) {
+    Some(position) => position,
+    None => panic!("a same-line token without a source must still resolve"),
+  };
+
+  assert_eq!(position.filename, state.get_filename().to_string());
+  assert_eq!(position.line_number, 42);
+}

--- a/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
+++ b/crates/stylex-transform/src/shared/utils/log/build_code_frame_error.rs
@@ -2,6 +2,7 @@ use anyhow::Error;
 use log::{debug, warn};
 use std::{
   cell::Cell,
+  cmp::Reverse,
   collections::hash_map::DefaultHasher,
   fs,
   hash::{Hash, Hasher},
@@ -198,10 +199,17 @@ pub(crate) fn get_span_from_source_code(
   // Panic boundary: locating a span re-reads, re-prints, and re-parses the
   // module purely to improve diagnostics; a panic anywhere in there must
   // degrade to "no code frame", never abort the compilation.
-  catch_diagnostic_unwind(AssertUnwindSafe(|| {
+  locate_span_with_panic_boundary(|| {
     get_span_from_source_code_impl(wrapped_expression, target_expression, state)
-  }))
-  .unwrap_or_else(|_| {
+  })
+}
+
+/// Runs a span-locating closure behind the diagnostic panic boundary,
+/// degrading a panic to a regular "no code frame" error.
+fn locate_span_with_panic_boundary(
+  locate: impl FnOnce() -> Result<(CodeFrame, Span), Error>,
+) -> Result<(CodeFrame, Span), Error> {
+  catch_diagnostic_unwind(AssertUnwindSafe(locate)).unwrap_or_else(|_| {
     Err(anyhow::anyhow!(
       "Panicked while locating the source span for a diagnostic"
     ))
@@ -269,13 +277,8 @@ pub(crate) fn get_key_span_from_source_code(
 ) -> Result<(CodeFrame, Span), Error> {
   // Same panic boundary as `get_span_from_source_code`: locating a span is
   // best-effort and must never abort the compilation.
-  catch_diagnostic_unwind(AssertUnwindSafe(|| {
+  locate_span_with_panic_boundary(|| {
     get_key_span_from_source_code_impl(call_expr, namespace_key, state)
-  }))
-  .unwrap_or_else(|_| {
-    Err(anyhow::anyhow!(
-      "Panicked while locating the source span for a diagnostic"
-    ))
   })
 }
 
@@ -330,22 +333,10 @@ fn get_key_span_from_source_code_impl(
 
 /// Collects the literal property keys of a call's first object argument.
 fn collect_object_arg_keys(call_expr: &CallExpr) -> FxHashSet<Atom> {
-  let mut keys = FxHashSet::default();
-
-  if let Some(arg) = call_expr.args.first()
-    && let Expr::Object(object) = arg.expr.as_ref()
-  {
-    for prop in &object.props {
-      if let PropOrSpread::Prop(prop) = prop
-        && let Prop::KeyValue(key_value) = prop.as_ref()
-        && let Some(name) = namespace_name_from_prop_key(&key_value.key)
-      {
-        keys.insert(name);
-      }
-    }
+  match call_expr.args.first().map(|arg| arg.expr.as_ref()) {
+    Some(Expr::Object(object)) => collect_object_lit_keys(object).collect(),
+    _ => FxHashSet::default(),
   }
-
-  keys
 }
 
 fn first_object_arg_span(call_expr: &CallExpr) -> Option<BytePos> {
@@ -429,6 +420,18 @@ struct KeySpanCandidate {
   span: Span,
 }
 
+impl KeySpanCandidate {
+  /// Ranking key: higher is better. A smaller distance to the target wins,
+  /// hence the `Reverse`.
+  fn rank(&self) -> (usize, usize, Reverse<Option<u32>>) {
+    (
+      self.namespace_value_overlap,
+      self.overlap,
+      Reverse(self.distance_from_target),
+    )
+  }
+}
+
 /// Visitor that finds call-expression object arguments and returns the property
 /// span for `namespace_key`. The sibling-key overlap is a tie-breaker for
 /// compiled calls with dummy spans.
@@ -505,11 +508,11 @@ impl KeySpanFinder<'_> {
         self.best = Some(candidate);
         self.ambiguous_best = false;
       },
-      Some(best) if is_better_key_span_candidate(&candidate, best) => {
+      Some(best) if candidate.rank() > best.rank() => {
         self.best = Some(candidate);
         self.ambiguous_best = false;
       },
-      Some(best) if is_equal_key_span_candidate_rank(&candidate, best) => {
+      Some(best) if candidate.rank() == best.rank() => {
         self.ambiguous_best = true;
       },
       Some(_) => {},
@@ -523,20 +526,6 @@ impl KeySpanFinder<'_> {
       self.best.map_or(DUMMY_SP, |candidate| candidate.span)
     }
   }
-}
-
-fn is_better_key_span_candidate(candidate: &KeySpanCandidate, best: &KeySpanCandidate) -> bool {
-  candidate.namespace_value_overlap > best.namespace_value_overlap
-    || candidate.namespace_value_overlap == best.namespace_value_overlap
-      && (candidate.overlap > best.overlap
-        || candidate.overlap == best.overlap
-          && candidate.distance_from_target < best.distance_from_target)
-}
-
-fn is_equal_key_span_candidate_rank(candidate: &KeySpanCandidate, best: &KeySpanCandidate) -> bool {
-  candidate.namespace_value_overlap == best.namespace_value_overlap
-    && candidate.overlap == best.overlap
-    && candidate.distance_from_target == best.distance_from_target
 }
 
 /// Loads a CodeFrame with the source file for error display.

--- a/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/log/tests/build_code_frame_error_tests.rs
@@ -360,3 +360,37 @@ fn panic_reports_real_message_for_multibyte_source() {
     message
   );
 }
+
+fn key_span_candidate(
+  namespace_value_overlap: usize,
+  overlap: usize,
+  distance_from_target: Option<u32>,
+) -> super::KeySpanCandidate {
+  super::KeySpanCandidate {
+    namespace_value_overlap,
+    overlap,
+    distance_from_target,
+    span: DUMMY_SP,
+  }
+}
+
+#[test]
+fn candidate_rank_prefers_value_overlap_then_sibling_overlap_then_proximity() {
+  // Namespace-value overlap dominates every other signal.
+  assert!(key_span_candidate(2, 0, Some(100)).rank() > key_span_candidate(1, 9, Some(0)).rank());
+
+  // Sibling-key overlap breaks value-overlap ties.
+  assert!(key_span_candidate(1, 3, Some(100)).rank() > key_span_candidate(1, 2, Some(0)).rank());
+
+  // Smaller distance to the target wins a full overlap tie.
+  assert!(key_span_candidate(1, 3, Some(5)).rank() > key_span_candidate(1, 3, Some(6)).rank());
+
+  // No target position outranks any measured distance (Option: None < Some).
+  assert!(key_span_candidate(1, 3, None).rank() > key_span_candidate(1, 3, Some(0)).rank());
+
+  // Identical signals rank equal, which the finder reports as ambiguous.
+  assert_eq!(
+    key_span_candidate(1, 3, Some(5)).rank(),
+    key_span_candidate(1, 3, Some(5)).rank()
+  );
+}

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -1,4 +1,8 @@
-import { normalizeRsOptions, shouldTransformFile, transform as stylexTransform } from '@stylexswc/rs-compiler';
+import {
+  normalizeRsOptions,
+  shouldTransformFile,
+  transform as stylexTransform,
+} from '@stylexswc/rs-compiler';
 import type { Rule } from '@stylexjs/babel-plugin';
 import { transform } from 'lightningcss';
 import type { CustomAtRules, TransformOptions } from 'lightningcss';
@@ -99,6 +103,24 @@ export default function stylexPlugin({
         // In rollup, returning null from any plugin phase means
         // "no changes made".
         return null;
+      }
+
+      // The combined map of all previous plugins lets the compiler resolve
+      // debug source-map annotations to the original authored file, and lets
+      // it chain its emitted map onto it. Rollup resets the sourcemap chain
+      // when `getCombinedSourcemap` is used, so returning the chained map is
+      // the expected contract.
+      if (normalizedRsOptions.inputSourceMap === undefined) {
+        try {
+          const combinedMap = this.getCombinedSourcemap();
+
+          if (combinedMap?.mappings) {
+            normalizedRsOptions.inputSourceMap = JSON.stringify(combinedMap);
+          }
+        } catch {
+          // No usable source map for this module - annotations fall back to
+          // locating positions in the source text.
+        }
       }
 
       const result = stylexTransform(id, inputCode, normalizedRsOptions);

--- a/packages/rspack-plugin/README.md
+++ b/packages/rspack-plugin/README.md
@@ -6,8 +6,6 @@
 [`napi-rs`](https://github.com/dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
 compiler that includes the StyleX SWC code transformation under the hood.
 
-A faithful port of
-[`@stylexswc/webpack-plugin`](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/webpack-plugin):
 StyleX rules are extracted through virtual CSS imports and appended to a
 dedicated CSS chunk. For Next.js projects use
 [`@stylexswc/nextjs-plugin/rspack`](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/nextjs-plugin),
@@ -64,19 +62,18 @@ const config = (env, argv) => ({
 module.exports = config;
 ```
 
-## Differences from `@stylexswc/webpack-plugin`
+## Loader behavior
 
 Rspack computes loader lists natively, so the plugin registers a static module
-rule instead of injecting its loader per module. Two user-visible consequences:
+rule with its StyleX loader. Two user-visible consequences:
 
 - `loaderOrder` maps to `Rule.enforce`: `'first'` (default) runs the StyleX
   transform before normal loaders (`enforce: 'pre'`), `'last'` runs it after
   (`enforce: 'post'`).
 - `node_modules` is **excluded by default**. Rspack invokes JS loaders across a
-  native boundary, so touching every module just to bail out is not free like
-  it is in webpack. Packages that ship untransformed StyleX source must be
-  allowlisted via the `stylexPackages` option (path fragments, default
-  `['@stylexjs/']`):
+  native boundary, so touching every module just to bail out is not free.
+  Packages that ship untransformed StyleX source must be allowlisted via the
+  `stylexPackages` option (path fragments, default `['@stylexjs/']`):
 
 ```js
 new StylexPlugin({
@@ -84,11 +81,80 @@ new StylexPlugin({
 });
 ```
 
+### Source maps
+
+The StyleX loader automatically forwards the previous loader's source map to
+the compiler as `inputSourceMap`. With `loaderOrder: 'last'` — where the
+loader receives code already rewritten by earlier loaders — this keeps debug
+source-map annotations (`debug: true`) and the emitted source map pointing at
+the original authored file. See the
+[`inputSourceMap` compiler option](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler#inputsourcemap)
+for details.
+
 ## Plugin Options
 
-The plugin accepts the same options as
-[`@stylexswc/webpack-plugin`](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/webpack-plugin#plugin-options),
-plus:
+### `rsOptions`
+
+- Type: `Partial<StyleXOptions>`
+
+StyleX compiler options passed to
+[`@stylexswc/rs-compiler`](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler).
+See the
+[StyleX configuration docs](https://stylexjs.com/docs/api/configuration/babel-plugin/)
+for the shared option semantics.
+
+### `stylexImports`
+
+- Type: `StyleXOptions['importSources']`
+- Default: `['stylex', '@stylexjs/stylex']`
+
+Specify where StyleX will be imported from.
+
+### `useCSSLayers`
+
+- Type: `UseLayersType`
+- Default: `false`
+
+Whether to use CSS layers.
+
+### `nextjsMode`
+
+- Type: `boolean`
+- Default: `false`
+
+Enable when the plugin is driven by the Next.js integration.
+
+### `transformCss`
+
+- Type:
+  `(css: string, filePath: string | undefined) => string | Buffer | Promise<string | Buffer>`
+
+Post-process the extracted CSS. Since the plugin only injects CSS after all
+loaders, `postcss-loader` cannot be used on it — invoke `postcss()` here
+instead.
+
+### `extractCSS`
+
+- Type: `boolean`
+- Default: `true`
+
+Whether to extract CSS into the dedicated StyleX chunk.
+
+### `loaderOrder`
+
+- Type: `'first' | 'last'`
+- Default: `'first'`
+
+When the StyleX transformation is applied relative to other rspack loaders —
+see [Loader behavior](#loader-behavior).
+
+### `cacheGroup`
+
+- Type:
+  [`splitChunks.cacheGroups` entry](https://rspack.rs/plugins/webpack/split-chunks-plugin#splitchunkscachegroups)
+
+Customizes the cache group configuration for extracted CSS chunks — how CSS is
+split into files, cached, or grouped.
 
 ### `stylexPackages`
 

--- a/packages/rspack-plugin/src/stylex-loader.ts
+++ b/packages/rspack-plugin/src/stylex-loader.ts
@@ -50,7 +50,8 @@ export default function stylexLoader(
     const { code, map, metadata } = generateStyleXOutput(
       this.resourcePath,
       stringifiedInputCode,
-      rsOptions
+      rsOptions,
+      inputSourceMap
     );
 
     let parsedMap: SourceMap = undefined;

--- a/packages/rspack-plugin/src/utils.ts
+++ b/packages/rspack-plugin/src/utils.ts
@@ -3,7 +3,7 @@ import { normalizeRsOptions, transform } from '@stylexswc/rs-compiler';
 import { VIRTUAL_CSS_PATTERN } from './constants';
 
 import type { LoaderContext } from '@rspack/core';
-import type { SupplementedLoaderContext } from './types';
+import type { SourceMap, SupplementedLoaderContext } from './types';
 import type { StyleXOptions, StyleXTransformResult } from '@stylexswc/rs-compiler';
 import type { Rule as StyleXRule } from '@stylexjs/babel-plugin';
 
@@ -22,9 +22,20 @@ export const isSupplementedLoaderContext = <T>(
 export function generateStyleXOutput(
   resourcePath: string,
   inputSource: string,
-  rsOptions: Partial<StyleXOptions>
+  rsOptions: Partial<StyleXOptions>,
+  inputSourceMap?: SourceMap
 ): StyleXTransformResult {
-  return transform(resourcePath, inputSource, normalizeRsOptions(rsOptions ?? {}));
+  const options = normalizeRsOptions(rsOptions ?? {});
+
+  // Forward the previous loader's source map so debug source-map annotations
+  // and the emitted map resolve to the original authored file instead of the
+  // (possibly already transformed) loader input.
+  if (inputSourceMap != null && options.inputSourceMap === undefined) {
+    options.inputSourceMap =
+      typeof inputSourceMap === 'string' ? inputSourceMap : JSON.stringify(inputSourceMap);
+  }
+
+  return transform(resourcePath, inputSource, options);
 }
 
 /**

--- a/packages/turbopack-plugin/src/turbopack-loader.ts
+++ b/packages/turbopack-plugin/src/turbopack-loader.ts
@@ -46,7 +46,8 @@ export default async function stylexTurbopackLoader(
     const { code, map, metadata } = generateStyleXOutput(
       this.resourcePath,
       stringifiedInputCode,
-      rsOptions
+      rsOptions,
+      inputSourceMap
     );
 
     // If metadata.stylex doesn't exist at all, we only need to return the transformed code

--- a/packages/turbopack-plugin/src/utils.ts
+++ b/packages/turbopack-plugin/src/utils.ts
@@ -1,11 +1,23 @@
 import { normalizeRsOptions, transform } from '@stylexswc/rs-compiler';
 
 import type { StyleXOptions, StyleXTransformResult } from '@stylexswc/rs-compiler';
+import type { SourceMap } from './types';
 
 export function generateStyleXOutput(
   resourcePath: string,
   inputSource: string,
-  rsOptions: Partial<StyleXOptions>
+  rsOptions: Partial<StyleXOptions>,
+  inputSourceMap?: SourceMap
 ): StyleXTransformResult {
-  return transform(resourcePath, inputSource, normalizeRsOptions(rsOptions ?? {}));
+  const options = normalizeRsOptions(rsOptions ?? {});
+
+  // Forward the previous loader's source map so debug source-map annotations
+  // and the emitted map resolve to the original authored file instead of the
+  // (possibly already transformed) loader input.
+  if (inputSourceMap != null && options.inputSourceMap === undefined) {
+    options.inputSourceMap =
+      typeof inputSourceMap === 'string' ? inputSourceMap : JSON.stringify(inputSourceMap);
+  }
+
+  return transform(resourcePath, inputSource, options);
 }

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -239,12 +239,33 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
       const file = path.join(dir, basename.split('?')[0] || basename);
 
       try {
+        // Only Rollup-compatible hosts (Rollup, Vite) expose the combined
+        // source map of previous plugins; other bundlers fall back to
+        // locating positions in the source text.
+        let inputSourceMap: string | undefined;
+        const { getCombinedSourcemap } = this as {
+          getCombinedSourcemap?: () => { mappings?: string };
+        };
+
+        if (typeof getCombinedSourcemap === 'function') {
+          try {
+            const combinedMap = getCombinedSourcemap.call(this);
+
+            if (combinedMap?.mappings) {
+              inputSourceMap = JSON.stringify(combinedMap);
+            }
+          } catch {
+            // No usable source map for this module.
+          }
+        }
+
         const { code, map } = transformStyleXCode(
           file,
           inputCode,
           normalizedOptions,
           stylexRules,
-          id
+          id,
+          inputSourceMap
         );
 
         // Invalidate CSS modules in dev mode (initial load only)
@@ -923,12 +944,19 @@ function transformStyleXCode(
   inputCode: string,
   normalizedOptions: NormalizedOptions,
   stylexRules: StyleXRules,
-  id: string
+  id: string,
+  inputSourceMap?: string
 ) {
   const rsOptions = { ...normalizedOptions.rsOptions };
 
   rsOptions.include = undefined;
   rsOptions.exclude = undefined;
+
+  // Forward the combined map of previous plugins so debug source-map
+  // annotations and the emitted map resolve to the original authored file.
+  if (inputSourceMap !== undefined && rsOptions.inputSourceMap === undefined) {
+    rsOptions.inputSourceMap = inputSourceMap;
+  }
 
   const result = stylexTransform(file, inputCode, rsOptions);
 

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -243,13 +243,10 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         // source map of previous plugins; other bundlers fall back to
         // locating positions in the source text.
         let inputSourceMap: string | undefined;
-        const { getCombinedSourcemap } = this as {
-          getCombinedSourcemap?: () => { mappings?: string };
-        };
 
-        if (typeof getCombinedSourcemap === 'function') {
+        if (hasCombinedSourcemap(this)) {
           try {
-            const combinedMap = getCombinedSourcemap.call(this);
+            const combinedMap = this.getCombinedSourcemap();
 
             if (combinedMap?.mappings) {
               inputSourceMap = JSON.stringify(combinedMap);
@@ -936,6 +933,19 @@ function hasStyleXCode(normalizedOptions: NormalizedOptions, inputCode: string) 
     typeof importName === 'string'
       ? inputCode.includes(importName)
       : inputCode.includes(importName.from)
+  );
+}
+
+/**
+ * Narrows a transform-hook context to Rollup-compatible hosts that expose
+ * the combined source map of previous plugins.
+ */
+function hasCombinedSourcemap(
+  context: object
+): context is { getCombinedSourcemap: () => { mappings?: string } } {
+  return (
+    'getCombinedSourcemap' in context &&
+    typeof (context as { getCombinedSourcemap?: unknown }).getCombinedSourcemap === 'function'
   );
 }
 

--- a/packages/webpack-plugin/src/stylex-loader.ts
+++ b/packages/webpack-plugin/src/stylex-loader.ts
@@ -50,7 +50,8 @@ export default async function stylexLoader(
     const { code, map, metadata } = generateStyleXOutput(
       this.resourcePath,
       stringifiedInputCode,
-      rsOptions
+      rsOptions,
+      inputSourceMap
     );
 
     let parsedMap: SourceMap = undefined;

--- a/packages/webpack-plugin/src/utils.ts
+++ b/packages/webpack-plugin/src/utils.ts
@@ -1,7 +1,7 @@
 import { normalizeRsOptions, transform } from '@stylexswc/rs-compiler';
 
 import type webpack from 'webpack';
-import type { SupplementedLoaderContext } from './types';
+import type { SourceMap, SupplementedLoaderContext } from './types';
 import type { StyleXOptions, StyleXTransformResult } from '@stylexswc/rs-compiler';
 
 export function stringifyRequest(loaderContext: webpack.LoaderContext<unknown>, request: string) {
@@ -19,7 +19,18 @@ export const isSupplementedLoaderContext = <T>(
 export function generateStyleXOutput(
   resourcePath: string,
   inputSource: string,
-  rsOptions: Partial<StyleXOptions>
+  rsOptions: Partial<StyleXOptions>,
+  inputSourceMap?: SourceMap
 ): StyleXTransformResult {
-  return transform(resourcePath, inputSource, normalizeRsOptions(rsOptions ?? {}));
+  const options = normalizeRsOptions(rsOptions ?? {});
+
+  // Forward the previous loader's source map so debug source-map annotations
+  // and the emitted map resolve to the original authored file instead of the
+  // (possibly already transformed) loader input.
+  if (inputSourceMap != null && options.inputSourceMap === undefined) {
+    options.inputSourceMap =
+      typeof inputSourceMap === 'string' ? inputSourceMap : JSON.stringify(inputSourceMap);
+  }
+
+  return transform(resourcePath, inputSource, options);
 }


### PR DESCRIPTION
## Description

This pull request adds support for passing an `inputSourceMap` option to the StyleX compiler, allowing source maps from previous transformation steps (such as macro expansion or other loaders) to be chained and used for more accurate debug annotations and source map generation. This ensures that positions in the output map and debug metadata resolve all the way back to the original authored file, even when the incoming code has already been transformed. The implementation includes updates across the TypeScript and Rust codebases, as well as documentation.

**New `inputSourceMap` support:**

* Added an `inputSourceMap` option to the TypeScript interface (`StyleXOptions`) and Rust struct (`StyleXOptions`), passing it through the JS and native layers to the transform function. [[1]](diffhunk://#diff-f8bd27565762d42ad91d7d85bacade13b49c2f8fe122045bfff233b1f2ca8f1aR40) [[2]](diffhunk://#diff-bad1020fe866aeea92a50072cc9292dbd48d2a509404c16cf9834f8b61b4020dR52-R56) [[3]](diffhunk://#diff-399ad4ae57eb6bc1bcdbb1b0826b4bd642b0210327d263c5c7b321f114ba8e1eR30)
* The Rust transform function parses the incoming source map, logs a warning and ignores it if invalid, and provides it to the transformation state for use in debug annotation and source map chaining. [[1]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R95-R111) [[2]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R147-R154) [[3]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R169-R177)
* The transform state (`StateManager`) now stores the input source file and input source map, with methods to set them from the host. [[1]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805R372-R379) [[2]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805R501-R502) [[3]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805R889-R901)

**Source map chaining and debug annotation improvements:**

* The transform logic uses the input source map to resolve debug annotations and chains the output source map onto it, so downstream tooling can map positions back to the original source. [[1]](diffhunk://#diff-cc29c2f0a620f756d054a8c933b8052ed67e24fde6559339c481bdd04c7f4b08R71-R101) [[2]](diffhunk://#diff-cc29c2f0a620f756d054a8c933b8052ed67e24fde6559339c481bdd04c7f4b08L87-R110)
* The code now prefers resolving positions using the input source map for highest fidelity, falling back to previous methods if unavailable. [[1]](diffhunk://#diff-cc29c2f0a620f756d054a8c933b8052ed67e24fde6559339c481bdd04c7f4b08R71-R101) [[2]](diffhunk://#diff-cc29c2f0a620f756d054a8c933b8052ed67e24fde6559339c481bdd04c7f4b08L87-R110)

**TypeScript/JS integration:**

* The JS `transform` function now always requests an external source map from SWC plugins to maintain correct chaining, and passes the updated `inputSourceMap` through to the native layer. [[1]](diffhunk://#diff-f8bd27565762d42ad91d7d85bacade13b49c2f8fe122045bfff233b1f2ca8f1aR182-R205) [[2]](diffhunk://#diff-f8bd27565762d42ad91d7d85bacade13b49c2f8fe122045bfff233b1f2ca8f1aL211-R219)

**Documentation updates:**

* The README has been updated with a new section describing `inputSourceMap`, its purpose, usage, and behavior, including a code example and integration notes for bundler plugins. [[1]](diffhunk://#diff-dc7c30b4f9a4c9c61e67ff2a569bf1eccf0a6621727a9d4e25ca62c0133f88d8R575-R652) [[2]](diffhunk://#diff-dc7c30b4f9a4c9c61e67ff2a569bf1eccf0a6621727a9d4e25ca62c0133f88d8L624-R682) [[3]](diffhunk://#diff-dc7c30b4f9a4c9c61e67ff2a569bf1eccf0a6621727a9d4e25ca62c0133f88d8L636-R696)
* Clarified the interaction between `inputSourceMap` and `useRealFileForSource` in the docs. [[1]](diffhunk://#diff-dc7c30b4f9a4c9c61e67ff2a569bf1eccf0a6621727a9d4e25ca62c0133f88d8R575-R652) [[2]](diffhunk://#diff-dc7c30b4f9a4c9c61e67ff2a569bf1eccf0a6621727a9d4e25ca62c0133f88d8L636-R696)

**Dependency updates:**

* Added `swc_sourcemap` as a dependency in relevant `Cargo.toml` files to support source map parsing and chaining. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R72) [[2]](diffhunk://#diff-60b48722d886b4f63978a64c2bdfc40e302facc62c816aa69c7233fa5f0b13e0R34) [[3]](diffhunk://#diff-bc568107cce36a60bcba6caf9d2e06431e0c016b8af8457fb4beb0274acfd44aR57)

These changes collectively improve the accuracy of source maps and debug information when the StyleX compiler is used in a toolchain with multiple transformation steps.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
