### PR TITLE
docs: update README and package descriptions for StyleX compiler and plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,82 @@
-# StyleX in Rust &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE) [![npm version](https://img.shields.io/npm/v/@stylexswc/rs-compiler.svg?style=flat)](https://www.npmjs.com/package/@stylexswc/rs-compiler) ![GitHub tag check runs](https://img.shields.io/github/check-runs/Dwlad90/stylex-swc-plugin/0.17.0?label=Release%20status) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Dwlad90/stylex-swc-plugin/pr-validation.yml?branch=develop&label=Project%20Health) <!-- stylex-compatibility:start -->[![StyleX compatibility](https://img.shields.io/badge/StyleX%20compatibility-v0.19.0-blue)](https://stylexjs.com/blog)<!-- stylex-compatibility:end -->
+# StyleX SWC Compiler — StyleX in Rust
 
-> **Community-driven, high-performance StyleX compiler and tooling ecosystem
-> built with Rust**
+[![GitHub license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE) [![npm version](https://img.shields.io/npm/v/@stylexswc/rs-compiler.svg?style=flat)](https://www.npmjs.com/package/@stylexswc/rs-compiler) ![GitHub tag check runs](https://img.shields.io/github/check-runs/Dwlad90/stylex-swc-plugin/0.17.0?label=Release%20status) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Dwlad90/stylex-swc-plugin/pr-validation.yml?branch=develop&label=Project%20Health) <!-- stylex-compatibility:start -->[![StyleX compatibility](https://img.shields.io/badge/StyleX%20compatibility-v0.19.0-blue)](https://stylexjs.com/blog)<!-- stylex-compatibility:end -->
+
+> **Rust/NAPI-RS/SWC compiler for [StyleX](https://stylexjs.com) that replaces
+> the official Babel transform and adds fast integrations for Next.js, Vite,
+> webpack, Rspack, Rollup, Turbopack, PostCSS, Jest, and custom Node.js
+> tooling.**
 
 > [!IMPORTANT]
-> This is a **community-written** implementation of StyleX tooling.
-> Built with love by the open source community, it aims to provide a
-> high-performance alternative to the official StyleX tooling while not being
-> affiliated with or officially supported by Meta/Facebook.
+>
+> This is a **community-written** implementation of StyleX tooling. It aims to
+> provide a high-performance alternative to the official StyleX tooling and is
+> not affiliated with or officially supported by Meta.
 
-A comprehensive monorepo providing a community-built
-[`napi-rs`](https://napi.rs/) compiler, [SWC](https://swc.rs/) plugin, and
-complete CSS parser for [StyleX](https://github.com/facebook/stylex). Built from
-the ground up in Rust for maximum performance and developer experience.
+StyleX is Meta's CSS-in-JS library for compile-time atomic CSS extraction. This
+project is a community implementation of the StyleX compiler written in Rust and
+exposed to Node.js through [NAPI-RS](https://napi.rs). It keeps the StyleX
+authoring API unchanged while moving compilation from Babel to
+[SWC](https://swc.rs)-native tooling.
 
-## 🚀 Why StyleX + Rust?
+Nothing changes in how you write StyleX: `stylex.create` and `stylex.props` work
+exactly as documented. Only your build gets faster, and on Next.js you drop the
+Babel fallback entirely and keep the fast SWC toolchain.
 
-- **⚡ Blazing Fast**: Significantly faster build times by leveraging
-  NAPI-RS/SWC instead of Babel
-- **🔧 Performance-First Alternative**: Built from the ground up in Rust for
-  maximum speed and efficiency
-- **🧩 Modular Architecture**: 17 atomic Rust crates with strict dependency
-  layering for maximum parallel compilation and surgical rebuilds
-- **📦 Complete Ecosystem**: Community-built toolkit covering compilation to CSS
-  parsing
-- **🌐 Universal Integration**: Works seamlessly with Next.js, Webpack, Vite,
-  Rollup, and more
-- **🛡️ Type Safe**: Full Rust implementation with comprehensive error handling
-- **🤝 Community Driven**: Open source with active community contributions and
-  support
+## What problems does this solve?
 
-Perfect for developers who want blazing-fast StyleX compilation and are excited
-about Rust-powered tooling!
+| Developer need                   | How this project helps                                                                                   |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Compile StyleX without Babel     | Replaces the official StyleX Babel plugin with a Rust compiler running on SWC                            |
+| Keep Next.js on the SWC pipeline | Avoids adding `.babelrc`, which would force Next.js files through Babel                                  |
+| Use StyleX with modern bundlers  | Provides plugins for Next.js, Vite, webpack, Rspack, Rollup, Turbopack, esbuild, Farm, Rsbuild, and more |
+| Test StyleX components in Jest   | Provides `@stylexswc/jest`, a Jest transformer backed by the same Rust compiler                          |
+| Build custom StyleX tooling      | Exposes `@stylexswc/rs-compiler` with `transform()`, metadata, CSS extraction, source maps, and filters  |
 
-## 📦 Quick Start
+## Performance
+
+This compiler transforms StyleX **2x to 5x faster per file** than the official
+`@stylexjs/babel-plugin`, measured with the benchmark suite in
+[`crates/stylex-rs-compiler/benchmark`](./crates/stylex-rs-compiler/benchmark).
+The entire transform — parsing, evaluation, and code generation — is
+implemented in Rust and runs as a native Node.js addon on SWC, with none of the
+JavaScript-side AST overhead that Babel carries. The advantage grows with the
+workload: complex `stylex.create` calls, theme creation, and large design-token
+sheets see the biggest wins.
+
+Per-file speed is only half of the story. On SWC-based frameworks like Next.js,
+using this compiler keeps Babel out of the pipeline entirely. Adding the
+official plugin drags every file through Babel as soon as a `.babelrc` appears,
+while this toolchain stays on the fast SWC path.
+
+## Which package do I need?
+
+| Your setup                                | Install                                                      | Notes                                                     |
+| ----------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------- |
+| Next.js (Webpack, Rspack, Turbopack)      | [`@stylexswc/nextjs-plugin`](./packages/nextjs-plugin)       | One config surface for all three bundlers                 |
+| Vite, esbuild, Farm, Rsbuild, Nuxt, Astro | [`@stylexswc/unplugin`](./packages/unplugin)                 | Universal plugin with per-bundler entry points            |
+| webpack (standalone)                      | [`@stylexswc/webpack-plugin`](./packages/webpack-plugin)     | Loader ordering and cache-group control                   |
+| Rspack (standalone)                       | [`@stylexswc/rspack-plugin`](./packages/rspack-plugin)       | Native Rspack rule registration                           |
+| Rollup                                    | [`@stylexswc/rollup-plugin`](./packages/rollup-plugin)       | Lightning CSS post-processing built in                    |
+| Turbopack (raw loader)                    | [`@stylexswc/turbopack-plugin`](./packages/turbopack-plugin) | Usually driven via `nextjs-plugin`                        |
+| PostCSS pipeline / Turbopack CSS          | [`@stylexswc/postcss-plugin`](./packages/postcss-plugin)     | Replaces an `@stylex;` directive with generated CSS       |
+| Jest                                      | [`@stylexswc/jest`](./packages/jest)                         | Transformer so StyleX components run in tests             |
+| Custom tooling                            | [`@stylexswc/rs-compiler`](./crates/stylex-rs-compiler)      | The compiler itself: `transform()`, metadata, source maps |
+
+Every plugin drives the same Rust compiler under the hood, so options like
+`rsOptions`, `include`/`exclude` filtering, and CSS extraction behave
+consistently across build tools.
+
+## Quick Start
+
+### Next.js
 
 ```bash
-# For Next.js projects
 npm install --save-dev @stylexswc/nextjs-plugin
-
-# For other build tools
-npm install --save-dev @stylexswc/unplugin
+npm install @stylexjs/stylex
 ```
 
-### Next.js Setup
-
-#### Using with Webpack (Default)
-
-```javascript
+```js
 // next.config.js
 const stylexPlugin = require('@stylexswc/nextjs-plugin');
 
@@ -55,469 +84,130 @@ module.exports = stylexPlugin({
   rsOptions: {
     dev: process.env.NODE_ENV !== 'production',
   },
-})();
+})({
+  // Next.js config
+});
 ```
 
-#### Using with Turbopack
+Using Turbopack? Import from `@stylexswc/nextjs-plugin/turbopack` instead and
+add `@stylexswc/postcss-plugin` for CSS extraction — see the
+[plugin README](./packages/nextjs-plugin/README.md#using-with-turbopack).
 
-```typescript
-// next.config.ts
-import stylexPlugin from '@stylexswc/nextjs-plugin/turbopack';
+### Vite (and other bundlers via unplugin)
 
-export default stylexPlugin({
-  rsOptions: {
-    dev: process.env.NODE_ENV !== 'production',
-  },
-})();
+```bash
+npm install --save-dev @stylexswc/unplugin
+npm install @stylexjs/stylex
 ```
 
-## 📁 Project Architecture
+```ts
+// vite.config.ts
+import StylexRsPlugin from '@stylexswc/unplugin/vite';
+import { defineConfig } from 'vite';
 
-This monorepo is organized into a layered, strictly-scoped crate graph designed
-for maximum parallel compilation and clear domain boundaries. Each Rust crate
-owns exactly one concern — no re-export facades, no mixed-domain files.
-
-### 🔥 Core Engines
-
-The compiler pipeline is built from 18 atomic Rust crates arranged in a strict
-dependency DAG. Higher layers depend only on lower layers — never the reverse.
-
-#### Layer 0 — Primitives (no internal dependencies)
-
-- **[`stylex-constants`](./crates/stylex-constants)** — Static lookup tables,
-  keyword sets, and compile-time constants
-- **[`stylex-regex`](./crates/stylex-regex)** — Pre-compiled `lazy_static!`
-  regex patterns for CSS value matching
-- **[`stylex-styleq`](./crates/stylex-styleq)** — Rust port of the runtime
-  [`styleq`](https://github.com/necolas/styleq) class-name merger
-- **[`stylex-utils`](./crates/stylex-utils)** — Lightweight SWC AST helpers
-
-#### Layer 1 — Macros
-
-- **[`stylex-macros`](./crates/stylex-macros)** — Error-handling and diagnostic
-  macros (`stylex_panic!`, `stylex_bail!`, `stylex_unwrap!`, etc.)
-
-#### Layer 2 — Domain Leaves
-
-- **[`stylex-enums`](./crates/stylex-enums)** — 14 enum modules: `CSSSyntax`,
-  `ValueWithDefault`, `ImportPathResolution`, `StyleVarsToKeep`, and more
-- **[`stylex-js`](./crates/stylex-js)** — JS runtime guard helpers
-  (`is_valid_callee`, `is_mutation_expr`, `is_invalid_method`)
-- **[`stylex-logs`](./crates/stylex-logs)** — Structured logging with
-  ANSI-colored `[StyleX]`-branded output for the NAPI-RS pipeline
-- **[`stylex-css-parser`](./crates/stylex-css-parser)** — High-performance CSS
-  value parser with comprehensive type, property, and at-rule coverage
-- **[`stylex-path-resolver`](./crates/stylex-path-resolver)** — Import path
-  resolution with partial `package.json` exports support
-
-#### Layer 3 — Core Data Structures
-
-- **[`stylex-structures`](./crates/stylex-structures)** — 15 foundational struct
-  modules: `StylexOptions`, `UidGenerator`, `PluginPass`, `NamedImportSource`,
-  `Order`, and more
-
-#### Layer 4 — Type System
-
-- **[`stylex-types`](./crates/stylex-types)** — Cross-coupled core types
-  (`InjectableStyle*`, `MetaData`) and the `StyleOptions` trait
-
-#### Layer 5 — AST Foundations
-
-- **[`stylex-ast`](./crates/stylex-ast)** — SWC AST factory and convertor
-  functions (semantically named `create_*`, `convert_*`)
-
-#### Layer 6 — Evaluation
-
-- **[`stylex-evaluator`](./crates/stylex-evaluator)** — Pure JS expression
-  evaluator; no transform side effects
-
-#### Layer 7 — CSS Processing
-
-- **[`stylex-css`](./crates/stylex-css)** — Unified CSS processing: generation
-  (LTR/RTL), whitespace normalization, value parsing, property ordering
-  strategies, and pseudo-class selector utilities
-
-#### Layer 8 — StyleX Transform
-
-- **[`stylex-transform`](./crates/stylex-transform)** — Main SWC transform:
-  `StyleXTransform`, `StateManager`, SWC `Fold` visitor, and all injection logic
-
-#### Layer 9 — Compilers (top-level consumers)
-
-- **[`stylex-rs-compiler`](./crates/stylex-rs-compiler)** — NAPI-RS compiler
-  exposing the full pipeline to Node.js
-
-<details>
-<summary><h2>Dependency Graph</h2></summary>
-
-```mermaid
-graph TD
-  subgraph L0["Primitives"]
-    stylex_constants["constants"]
-    stylex_regex["regex"]
-    stylex_styleq["styleq"]
-    stylex_utils["utils"]
-  end
-
-  subgraph L1["Proc Macros"]
-    stylex_macros["macros"]
-  end
-
-  subgraph L2["Domain Leaves"]
-    stylex_enums["enums"]
-    stylex_js["js"]
-    stylex_logs["logs"]
-    stylex_css_parser["css-parser"]
-    stylex_path_resolver["path-resolver"]
-  end
-
-  subgraph L3["Core Data Structures"]
-    stylex_structures["structures"]
-  end
-
-  subgraph L4["Type System"]
-    stylex_types["types"]
-  end
-
-  subgraph L5["AST Foundations"]
-    stylex_ast["ast"]
-  end
-
-  subgraph L6["Evaluation"]
-    stylex_evaluator["evaluator"]
-  end
-
-  subgraph L7["CSS Processing"]
-    stylex_css["css"]
-  end
-
-  subgraph L8["StyleX Transform"]
-    stylex_transform["transform"]
-  end
-
-  subgraph L9["Compilers"]
-    stylex_compiler_rs["rs-compiler"]
-  end
-
-  stylex_utils         --> stylex_regex
-
-  stylex_macros        --> stylex_constants
-
-  stylex_enums         --> stylex_macros
-  stylex_js            --> stylex_constants
-  stylex_js            --> stylex_macros
-  stylex_logs          --> stylex_macros
-  stylex_css_parser    --> stylex_macros
-  stylex_path_resolver --> stylex_macros
-
-  stylex_structures    --> stylex_constants
-  stylex_structures    --> stylex_enums
-  stylex_structures    --> stylex_macros
-
-  stylex_types         --> stylex_constants
-  stylex_types         --> stylex_enums
-  stylex_types         --> stylex_macros
-  stylex_types         --> stylex_structures
-  stylex_types         --> stylex_utils
-
-  stylex_ast           --> stylex_constants
-  stylex_ast           --> stylex_macros
-  stylex_ast           --> stylex_types
-  stylex_ast           --> stylex_utils
-
-  stylex_evaluator     --> stylex_ast
-  stylex_evaluator     --> stylex_constants
-  stylex_evaluator     --> stylex_js
-  stylex_evaluator     --> stylex_macros
-  stylex_evaluator     --> stylex_path_resolver
-  stylex_evaluator     --> stylex_types
-
-  stylex_css           --> stylex_ast
-  stylex_css           --> stylex_constants
-  stylex_css           --> stylex_css_parser
-  stylex_css           --> stylex_enums
-  stylex_css           --> stylex_evaluator
-  stylex_css           --> stylex_macros
-  stylex_css           --> stylex_regex
-  stylex_css           --> stylex_structures
-  stylex_css           --> stylex_types
-  stylex_css           --> stylex_utils
-
-  stylex_transform     --> stylex_ast
-  stylex_transform     --> stylex_constants
-  stylex_transform     --> stylex_css
-  stylex_transform     --> stylex_css_parser
-  stylex_transform     --> stylex_enums
-  stylex_transform     --> stylex_evaluator
-  stylex_transform     --> stylex_logs
-  stylex_transform     --> stylex_macros
-  stylex_transform     --> stylex_path_resolver
-  stylex_transform     --> stylex_regex
-  stylex_transform     --> stylex_structures
-  stylex_transform     --> stylex_styleq
-  stylex_transform     --> stylex_types
-  stylex_transform     --> stylex_utils
-
-  stylex_compiler_rs   --> stylex_ast
-  stylex_compiler_rs   --> stylex_enums
-  stylex_compiler_rs   --> stylex_logs
-  stylex_compiler_rs   --> stylex_macros
-  stylex_compiler_rs   --> stylex_regex
-  stylex_compiler_rs   --> stylex_structures
-  stylex_compiler_rs   --> stylex_transform
-  stylex_compiler_rs   --> stylex_types
-  stylex_compiler_rs   --> stylex_utils
-
-  classDef l0 fill:#e8e8e8,stroke:#999,color:#333
-  classDef l1 fill:#dce8ff,stroke:#6699cc,color:#333
-  classDef l2 fill:#dcf5dc,stroke:#66aa66,color:#333
-  classDef l3 fill:#fff3dc,stroke:#cc9933,color:#333
-  classDef l4 fill:#ffe8dc,stroke:#cc6633,color:#333
-  classDef l5 fill:#f5dcff,stroke:#9933cc,color:#333
-  classDef l6 fill:#dcfff5,stroke:#33aaaa,color:#333
-  classDef l7 fill:#ffdcdc,stroke:#cc3333,color:#333
-  classDef l8 fill:#fffdc0,stroke:#aaaa33,color:#333
-  classDef l9 fill:#ffc0c0,stroke:#cc0000,color:#333
-
-  class stylex_constants,stylex_regex,stylex_styleq,stylex_utils l0
-  class stylex_macros l1
-  class stylex_enums,stylex_js,stylex_logs,stylex_css_parser,stylex_path_resolver l2
-  class stylex_structures l3
-  class stylex_types l4
-  class stylex_ast l5
-  class stylex_evaluator l6
-  class stylex_css l7
-  class stylex_transform l8
-  class stylex_compiler_rs l9
+export default defineConfig({
+  plugins: [
+    StylexRsPlugin({
+      rsOptions: {
+        dev: process.env.NODE_ENV !== 'production',
+      },
+    }),
+  ],
+});
 ```
 
-</details>
+Working example apps for every integration — Next.js (Webpack, Rspack,
+Turbopack), Vite, webpack, Rollup, Rspack, Rsbuild, Farm, esbuild, Vue, and
+Solid — live in the [`apps/`](./apps) directory.
 
-### 🔌 Framework Integrations
+## Compatibility
 
-- **[`nextjs-plugin`](./packages/nextjs-plugin)** — Next.js configuration
-  wrapper with seamless SWC integration
-- **[`turbopack-plugin`](./packages/turbopack-plugin)** — Turbopack loader for
-  Next.js with high-performance StyleX compilation
-- **[`unplugin`](./packages/unplugin)** — Universal plugin supporting Vite,
-  Webpack, Rollup, Rspack, and 8+ build tools
-- **[`jest`](./packages/jest)** — Jest transformer for StyleX testing workflows
-- **[`postcss-plugin`](./packages/postcss-plugin)** — PostCSS integration for
-  existing CSS pipelines
+- Tracks official StyleX releases; currently compatible with **StyleX v0.19.0**
+  (see the badge above, updated automatically)
+- Validated against the official StyleX test suite
+- Node.js **20 or newer**
+- Prebuilt binaries for macOS (x64, arm64), Linux (glibc and musl, x64, arm64),
+  and Windows (x64, arm64) — no Rust toolchain needed to install
 
-### ⚙️ Developer Tools
+## FAQ
 
-- **[`test-parser`](./crates/stylex-test-parser)** — Jest test parser for
-  maintaining compatibility with official StyleX
-- **[`design-system`](./packages/design-system)** — Internal design system for
-  consistent workspace examples
+### Do I have to know Rust to use this?
 
-### 🏗️ Development Infrastructure
+No. Everything installs from npm with prebuilt native binaries, and all
+configuration happens in plain JavaScript or TypeScript config files. Rust is
+only needed to contribute to the compiler itself.
 
-- **[`eslint-config`](./packages/eslint-config)** — Shared ESLint configuration
-- **[`typescript-config`](./packages/typescript-config)** — TypeScript
-  configuration presets
-- **[`playwright`](./packages/playwright)** — Visual regression testing setup
+### Does my StyleX code change?
 
-## 🎯 Build Tool Ecosystem
+No. This project swaps the build-time compiler, not the API. Your
+`stylex.create`, `stylex.props`, themes, and tokens keep working unchanged, and
+the generated atomic CSS is compatible with the official output.
 
-| Tool                 | Package                              | Experience                 |
-| -------------------- | ------------------------------------ | -------------------------- |
-| Next.js (Webpack)    | `@stylexswc/nextjs-plugin`           | 🚀 Native SWC Integration  |
-| Next.js (Turbopack)  | `@stylexswc/nextjs-plugin/turbopack` | ⚡ Ultra-Fast Builds       |
-| Vite                 | `@stylexswc/unplugin`                | ⚡ Lightning Fast HMR      |
-| Webpack              | `@stylexswc/unplugin`                | 🔧 Seamless Integration    |
-| Rollup               | `@stylexswc/unplugin`                | 📦 Optimized Bundling      |
-| Jest                 | `@stylexswc/jest`                    | 🧪 Reliable Testing        |
-| PostCSS              | `@stylexswc/postcss-plugin`          | 🎨 CSS Pipeline Ready      |
-| Rspack               | `@stylexswc/unplugin`                | 🚀 Rust-Powered Speed      |
-| Farm, Rsbuild, Solid | `@stylexswc/unplugin`                | 🌟 Modern Build Experience |
+### How is this different from the official StyleX toolchain?
 
-## 🔧 Development
+The official transform runs as a Babel plugin. This one is a Rust
+reimplementation running on SWC, which makes per-file transforms 2x to 5x
+faster and — on SWC-based frameworks like Next.js — avoids adding Babel to the
+pipeline at all.
+It also adds compiler-only features such as `include`/`exclude` file filtering,
+SWC WASM plugin chaining, and `inputSourceMap` chaining.
+
+### How do I use StyleX with Next.js without Babel?
+
+Install [`@stylexswc/nextjs-plugin`](./packages/nextjs-plugin) and wrap your
+Next.js config with it — see the [Quick Start](#quick-start). StyleX is then
+compiled by the Rust compiler inside the SWC pipeline, so no `.babelrc` is
+needed and Next.js never falls back to Babel. This works with Webpack, Rspack,
+and Turbopack, with the App Router and the Pages Router, and with React Server
+Components.
+
+### Is it production-ready?
+
+The compiler is validated against the official StyleX test suite, ships prebuilt
+binaries for all major platforms, and powers the example apps in this repository
+across ten build tools. As with any community project, pin your versions and
+report regressions in the
+[issue tracker](https://github.com/Dwlad90/stylex-swc-plugin/issues).
+
+## Development
 
 ```bash
 # Clone the repository
 git clone https://github.com/Dwlad90/stylex-swc-plugin.git
 
-# Install dependencies
-pnpm install
-
-# Build all packages
-pnpm build
-
-# Run tests
-pnpm test
-```
-
-## 📖 Documentation
-
-- [StyleX Documentation](https://stylexjs.com)
-- [SWC Documentation](https://swc.rs)
-- [NAPI-RS Documentation](https://napi.rs)
-
-## Development
-
-This project includes a comprehensive Makefile that provides convenient
-shortcuts for common development tasks. The Makefile integrates with both the
-Node.js ecosystem (using pnpm and Turborepo) and Rust toolchain.
-
-### Quick Start
-
-```bash
-# Setup development environment
+# Setup development environment (Node.js and Rust)
 make setup
-
-# Show all available commands
-make help
 
 # Build all packages
 make build
 
-# Start development servers
-make dev
-
 # Run tests
 make test
 
-# Run quality checks
+# Run quality checks (format, lint, typecheck)
 make quick-check
 ```
 
-### Available Commands
+Run `make help` for the full command list, or use `pnpm` directly
+(`pnpm install`, `pnpm build`, `pnpm test`, `pnpm lint:check`,
+`pnpm format:check`, `pnpm typecheck`).
 
-The Makefile organizes commands into several categories:
+Curious how the compiler is organized internally? The Rust workspace is a
+layered graph of single-concern crates — see
+[Project Structure](./guidelines/STRUCTURE.md) for the crate map and dependency
+graph.
 
-**Setup Commands:**
+## Documentation
 
-- `make install` — Install all dependencies (Node.js and Rust)
-- `make setup` — Full development environment setup
-- `make prepare` — Prepare hooks and development tools
+- [StyleX documentation](https://stylexjs.com)
+- [SWC documentation](https://swc.rs)
+- [NAPI-RS documentation](https://napi.rs)
 
-**Build Commands:**
+## Contributing
 
-- `make build` — Build all packages (Node.js and Rust)
-- `make build-rust` — Build only Rust packages
-- `make build-node` — Build only Node.js packages
-- `make clean` — Clean all build artifacts
+Contributions are welcome! Please read the guidelines in
+[`guidelines/`](./guidelines) and submit pull requests to the `develop` branch.
 
-**Development Commands:**
-
-- `make dev` — Start development servers
-- `make watch` — Watch for changes and rebuild
-
-**Quality Commands:**
-
-- `make lint` — Run linting on all packages
-- `make format` — Format all code
-- `make typecheck` — Run TypeScript type checking
-- `make quick-check` — Quick development check (format, lint, typecheck)
-- `make full-check` — Full development check including tests
-
-**Test Commands:**
-
-- `make test` — Run all tests
-- `make test-visual` — Run visual regression tests
-- `make bench` — Run benchmarks
-
-**App Commands:**
-
-- `make apps-build` — Build all example apps
-- `make apps-dev` — Start development servers for all apps
-- `make apps-clean` — Clean all app build artifacts
-- `make app-nextjs-dev` — Start Next.js example app in development mode
-- `make app-nextjs-build` — Build Next.js example app
-- `make app-nextjs-serve` — Serve Next.js example app (requires build first)
-- `make app-vite-dev` — Start Vite example app in development mode
-- `make app-vite-build` — Build Vite example app
-- `make app-vite-serve` — Serve Vite example app (requires build first)
-- `make app-webpack-dev` — Start Webpack example app in development mode
-- `make app-webpack-build` — Build Webpack example app
-- `make app-rollup-dev` — Start Rollup example app in development mode
-- `make app-rollup-build` — Build Rollup example app
-- `make apps-serve-common` — Serve commonly used example apps simultaneously
-
-**Documentation & Release:**
-
-- `make docs` — Generate documentation
-- `make info` — Show project information
-
-**Package Commands:**
-
-_Bulk Package Operations:_
-
-- `make packages-build` — Build all Node.js packages
-- `make packages-lint` — Lint all Node.js packages
-- `make packages-test` — Test all Node.js packages
-- `make packages-typecheck` — Typecheck all Node.js packages
-- `make packages-clean` — Clean all Node.js packages
-
-_Bulk Rust Crate Operations:_
-
-- `make crates-build` — Build all Rust crates
-- `make crates-format` — Format all Rust crates
-- `make crates-lint` — Lint all Rust crates
-- `make crates-clean` — Clean all Rust crates
-- `make crates-docs` — Generate docs for all Rust crates
-
-_Individual Package Commands:_
-
-Each package has individual commands available in the format
-`pkg-{name}-{action}` and `crate-{name}-{action}`:
-
-- **Node.js packages**: unplugin, nextjs, webpack, rollup, postcss, jest,
-  design, playwright, eslint, typescript
-- **Rust crates**: compiler, transform, resolver, parser, and all atomic crates
-  (constants, regex, utils, macros, enums, js, logs, css-parser, structures,
-  types, ast, evaluator, css, etc.)
-- **Available actions**: build, lint, test, typecheck, clean (for Node.js) /
-  build, format, lint, clean, docs (for Rust)
-
-Examples:
-
-- `make pkg-unplugin-build` — Build unplugin package
-- `make pkg-webpack-lint` — Lint webpack plugin package
-- `make crate-compiler-format` — Format Rust compiler crate
-- `make crate-transform-docs` — Generate docs for transform crate
-- `make crate-ast-lint` — Lint the AST utilities crate
-
-### Manual Commands (Alternative to Makefile)
-
-If you prefer to use the tools directly:
-
-```bash
-# Install dependencies
-pnpm install
-
-# Build all packages
-pnpm build
-
-# Run tests
-pnpm test
-
-# Run visual regression tests
-pnpm test:visual
-
-# Lint code
-pnpm lint
-
-# Check lint
-pnpm lint:check
-
-# Format code
-pnpm format
-
-# Check format
-pnpm format:check
-
-# Typecheck code
-pnpm typecheck
-```
-
-## 🤝 Contributing
-
-Contributions are welcome! Please read our contributing guidelines and submit
-pull requests to the `develop` branch.
-
-## 📄 License
+## License
 
 MIT Licensed. See [LICENSE](./LICENSE) for details.

--- a/crates/stylex-rs-compiler/README.md
+++ b/crates/stylex-rs-compiler/README.md
@@ -1,260 +1,138 @@
-# NAPI-RS compiler for StyleX (\*\*unofficial)
+# @stylexswc/rs-compiler
 
-> Part of the
+> High-performance StyleX compiler for Node.js, written in Rust on NAPI-RS and
+> SWC. Part of the
 > [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme)
-> workspace
+> workspace.
 
 <!-- stylex-compatibility:start -->
+
 > [!NOTE]
 > Compatibility target: this package has been updated through official
 > StyleX v0.19.0. This is not an official Meta support guarantee.
+
 <!-- stylex-compatibility:end -->
 
-StyleX is a JavaScript library developed by Meta for defining styles optimized
-for user interfaces. You can find the
-[official StyleX repository](https://www.github.com/facebook/stylex) here.
+[StyleX](https://stylexjs.com) is Meta's CSS-in-JS library with compile-time
+style extraction. The official toolchain compiles it with a Babel plugin; this
+package is a from-scratch Rust implementation of that same transform, exposed to
+Node.js as a native addon through [NAPI-RS](https://napi.rs) and parsed with
+[SWC](https://swc.rs). It is designed as a drop-in replacement: your StyleX code
+and its output do not change, but transforms run 2x to 5x faster than
+Babel — see
+[performance](https://github.com/Dwlad90/stylex-swc-plugin#performance).
 
-> [!WARNING]
-> This is an unofficial style compiler for StyleX.
+This is a community project and is not affiliated with or supported by Meta. It
+requires Node.js 20 or newer; prebuilt binaries ship for macOS, Linux (glibc and
+musl), and Windows on x64 and arm64.
 
-## Overview
+Most projects should not call this package directly — use the integration for
+your build tool, all of which drive this compiler under the hood:
 
-This package provides an unofficial, high-performance NAPI-RS compiler for
-StyleX, a popular library from Meta for building optimized user interfaces. It
-is the top-level consumer crate that exposes the full StyleX pipeline to
-Node.js, leveraging SWC for parsing and transformation.
+| Build tool                              | Package                                                                                |
+| --------------------------------------- | -------------------------------------------------------------------------------------- |
+| Next.js (Webpack, Rspack, Turbopack)    | [`@stylexswc/nextjs-plugin`](https://www.npmjs.com/package/@stylexswc/nextjs-plugin)   |
+| Vite, esbuild, Farm, Rsbuild, Nuxt, ... | [`@stylexswc/unplugin`](https://www.npmjs.com/package/@stylexswc/unplugin)             |
+| webpack                                 | [`@stylexswc/webpack-plugin`](https://www.npmjs.com/package/@stylexswc/webpack-plugin) |
+| Rspack                                  | [`@stylexswc/rspack-plugin`](https://www.npmjs.com/package/@stylexswc/rspack-plugin)   |
+| Rollup                                  | [`@stylexswc/rollup-plugin`](https://www.npmjs.com/package/@stylexswc/rollup-plugin)   |
+| PostCSS pipelines                       | [`@stylexswc/postcss-plugin`](https://www.npmjs.com/package/@stylexswc/postcss-plugin) |
+| Jest                                    | [`@stylexswc/jest`](https://www.npmjs.com/package/@stylexswc/jest)                     |
 
-> [!IMPORTANT]
-> The usage of StyleX does not change. All changes are internal.
-
-- Faster Build Times: By utilizing SWC instead of Babel, you can potentially
-  experience significant speed improvements during StyleX processing.
-- Seamless Integration: This compiler seamlessly integrates with Next.js's
-  default SWC Compiler, ensuring a smooth workflow.
-- Drop-in Replacement: Designed to be a drop-in replacement for the official
-  StyleX Babel plugin, minimizing disruption to existing codebases.
-- Advanced Tooling Capabilities: NAPI-RS compiler unlocks access to StyleX
-  metadata and source maps, enabling the creation of advanced plugins and tools
-  for StyleX, ex. for creating a plugin for Webpack, Rollup, or other tools.
-
-## Advantages of a `NAPI-RS` compiler versus a `SWC plugin`
-
-- Compability with SWC: under the hood, the NAPI-RS compiler uses SWC for
-  parsing and transforming JavaScript code, ensuring compatibility with the
-  latest ECMAScript features.
-- Direct Access to Node.js APIs: NAPI-RS allows you to directly access Node.js
-  APIs from your Rust code, providing greater flexibility and control.
-- Improved Performance: NAPI-RS can often offer better performance than
-  traditional Node.js addons, especially for computationally intensive tasks.
-- Simplified Development: NAPI-RS simplifies the process of developing Node.js
-  addons in Rust, making it easier to create high-performance and efficient
-  tools.
-
-## Architecture
-
-- **Layer**: 9 — Compilers (top-level consumer)
-- **Depends on**: `stylex-ast`, `stylex-enums`, `stylex-logs`, `stylex-macros`,
-  `stylex-regex`, `stylex-structures`, `stylex-transform`, `stylex-types`,
-  `stylex-utils`
-- **Depended on by**: None (top-level entry point)
-
-### Public API
-
-- `transform()` — Main entry point: takes source code + options, returns
-  transformed output
-- `should_transform_file()` — File filtering based on path patterns
-- `normalize_rs_options()` — Options normalization and validation
-
-### Modules
-
-- `enums` — Compiler-specific enum types
-- `structs` — Compiler-specific struct types
-- `utils::fn_parser` — Function argument parsing
-- `utils::metadata` — Build metadata handling
-- `utils::path_filter` — File path filtering logic
-
-## Dependency Graph
-
-<details>
-<summary><h3>Dependency Graph</h3></summary>
-
-```mermaid
-graph TD
-  subgraph L0["Primitives"]
-    stylex_constants["constants"]
-    stylex_regex["regex"]
-    stylex_styleq["styleq"]
-    stylex_utils["utils"]
-  end
-
-  subgraph L1["Proc Macros"]
-    stylex_macros["macros"]
-  end
-
-  subgraph L2["Domain Leaves"]
-    stylex_enums["enums"]
-    stylex_js["js"]
-    stylex_logs["logs"]
-    stylex_css_parser["css-parser"]
-    stylex_path_resolver["path-resolver"]
-  end
-
-  subgraph L3["Core Data Structures"]
-    stylex_structures["structures"]
-  end
-
-  subgraph L4["Type System"]
-    stylex_types["types"]
-  end
-
-  subgraph L5["AST Foundations"]
-    stylex_ast["ast"]
-  end
-
-  subgraph L6["Evaluation"]
-    stylex_evaluator["evaluator"]
-  end
-
-  subgraph L7["CSS Processing"]
-    stylex_css["css"]
-  end
-
-  subgraph L8["StyleX Transform"]
-    stylex_transform["transform"]
-  end
-
-  subgraph L9["Compilers"]
-    stylex_compiler_rs["rs-compiler"]
-  end
-
-  stylex_utils         --> stylex_regex
-
-  stylex_macros        --> stylex_constants
-
-  stylex_enums         --> stylex_macros
-  stylex_js            --> stylex_constants
-  stylex_js            --> stylex_macros
-  stylex_logs          --> stylex_macros
-  stylex_css_parser    --> stylex_macros
-  stylex_path_resolver --> stylex_macros
-
-  stylex_structures    --> stylex_constants
-  stylex_structures    --> stylex_enums
-  stylex_structures    --> stylex_macros
-
-  stylex_types         --> stylex_constants
-  stylex_types         --> stylex_enums
-  stylex_types         --> stylex_macros
-  stylex_types         --> stylex_structures
-  stylex_types         --> stylex_utils
-
-  stylex_ast           --> stylex_constants
-  stylex_ast           --> stylex_macros
-  stylex_ast           --> stylex_types
-  stylex_ast           --> stylex_utils
-
-  stylex_evaluator     --> stylex_ast
-  stylex_evaluator     --> stylex_constants
-  stylex_evaluator     --> stylex_js
-  stylex_evaluator     --> stylex_macros
-  stylex_evaluator     --> stylex_path_resolver
-  stylex_evaluator     --> stylex_types
-
-  stylex_css           --> stylex_ast
-  stylex_css           --> stylex_constants
-  stylex_css           --> stylex_css_parser
-  stylex_css           --> stylex_enums
-  stylex_css           --> stylex_evaluator
-  stylex_css           --> stylex_macros
-  stylex_css           --> stylex_regex
-  stylex_css           --> stylex_structures
-  stylex_css           --> stylex_types
-  stylex_css           --> stylex_utils
-
-  stylex_transform     --> stylex_ast
-  stylex_transform     --> stylex_constants
-  stylex_transform     --> stylex_css
-  stylex_transform     --> stylex_css_parser
-  stylex_transform     --> stylex_enums
-  stylex_transform     --> stylex_evaluator
-  stylex_transform     --> stylex_logs
-  stylex_transform     --> stylex_macros
-  stylex_transform     --> stylex_path_resolver
-  stylex_transform     --> stylex_regex
-  stylex_transform     --> stylex_structures
-  stylex_transform     --> stylex_styleq
-  stylex_transform     --> stylex_types
-  stylex_transform     --> stylex_utils
-
-  stylex_compiler_rs   --> stylex_ast
-  stylex_compiler_rs   --> stylex_enums
-  stylex_compiler_rs   --> stylex_logs
-  stylex_compiler_rs   --> stylex_macros
-  stylex_compiler_rs   --> stylex_regex
-  stylex_compiler_rs   --> stylex_structures
-  stylex_compiler_rs   --> stylex_transform
-  stylex_compiler_rs   --> stylex_types
-  stylex_compiler_rs   --> stylex_utils
-
-  classDef l0 fill:#e8e8e8,stroke:#999,color:#333
-  classDef l1 fill:#dce8ff,stroke:#6699cc,color:#333
-  classDef l2 fill:#dcf5dc,stroke:#66aa66,color:#333
-  classDef l3 fill:#fff3dc,stroke:#cc9933,color:#333
-  classDef l4 fill:#ffe8dc,stroke:#cc6633,color:#333
-  classDef l5 fill:#f5dcff,stroke:#9933cc,color:#333
-  classDef l6 fill:#dcfff5,stroke:#33aaaa,color:#333
-  classDef l7 fill:#ffdcdc,stroke:#cc3333,color:#333
-  classDef l8 fill:#fffdc0,stroke:#aaaa33,color:#333
-  classDef l9 fill:#ffc0c0,stroke:#cc0000,color:#333
-
-  class stylex_constants,stylex_regex,stylex_styleq,stylex_utils l0
-  class stylex_macros l1
-  class stylex_enums,stylex_js,stylex_logs,stylex_css_parser,stylex_path_resolver l2
-  class stylex_structures l3
-  class stylex_types l4
-  class stylex_ast l5
-  class stylex_evaluator l6
-  class stylex_css l7
-  class stylex_transform l8
-  class stylex_compiler_rs l9
-```
-
-</details>
+Use this package directly when building your own tooling: custom bundler
+plugins, codemods, or anything that needs the transformed code plus StyleX
+metadata and source maps.
 
 ## Installation
-
-To install the package, run the following command:
 
 ```bash
 npm install --save-dev @stylexswc/rs-compiler
 ```
 
-### Transformation Process
+## Usage
 
-Internally, this compiler takes your StyleX code and transforms it into a format
-optimized for further processing.
+The main entry point is `transform`. It takes a filename, the source code, and
+options, and returns the transformed code, metadata about the generated styles,
+and an optional source map:
 
 ```ts
-var { transform } = require('@stylexswc/rs-compiler');
+const { transform } = require('@stylexswc/rs-compiler');
 
-/// ...other logic
-
-const { code, metadata, sourcemap } = transform(
+const { code, metadata, map } = transform(
   filename,
   inputSourceCode,
   transformOptions
 );
-
-/// ...other logic
 ```
 
-### Path Filtering
+### Example
+
+Input StyleX code:
+
+```ts
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  root: {
+    padding: 10,
+  },
+  element: {
+    backgroundColor: 'red',
+  },
+});
+
+export const styleProps = stylex.props(styles.root, styles.element);
+```
+
+Output code:
+
+```ts
+import * as stylex from '@stylexjs/stylex';
+export const styleProps = {
+  className: 'x7z7khe xrkmrrc',
+};
+```
+
+### Output shape
+
+Transforming the example above with source maps enabled
+(`sourceMap: SourceMaps.True`) returns:
+
+```json
+{
+  "code": "import * as stylex from '@stylexjs/stylex';\nexport const styleProps = {\n    className: \"x7z7khe xrkmrrc\"\n};\n",
+  "metadata": {
+    "stylex": [
+      [
+        "x7z7khe",
+        {
+          "ltr": ".x7z7khe{padding:10px}",
+          "rtl": null
+        },
+        1000
+      ],
+      [
+        "xrkmrrc",
+        {
+          "ltr": ".xrkmrrc{background-color:red}",
+          "rtl": null
+        },
+        3000
+      ]
+    ]
+  },
+  "map": "{\"version\":3,\"sources\":[\"app/components/Button.tsx\"],\"names\":[],\"mappings\":\"AAAA;AAWA;;EAAoE\"}"
+}
+```
+
+The `metadata.stylex` rules are what bundler plugins collect to build the final
+CSS file.
+
+## Path Filtering
 
 > [!NOTE]
-> The `include` and `exclude` options are exclusive to this NAPI-RS
-> compiler implementation and are not available in the official StyleX Babel
-> plugin. They provide powerful file filtering capabilities to control which
-> files are transformed.
+> The `include` and `exclude` options are exclusive to this compiler and
+> are not available in the official StyleX Babel plugin.
 
 The compiler exports a `shouldTransformFile` function to determine whether a
 file should be transformed based on include/exclude patterns:
@@ -273,36 +151,29 @@ if (shouldTransform) {
 }
 ```
 
-#### Pattern Types
+### Pattern Types
 
-- **Glob patterns** (strings): Use standard glob syntax to match file paths
-  - `src/**/*.tsx` - All `.tsx` files in `src` directory and subdirectories
-  - `**/*.test.*` - All test files
-  - `**/node_modules/**` - All files in `node_modules`
+- **Glob patterns** (strings): standard glob syntax matched against file paths
+  - `src/**/*.tsx` — all `.tsx` files in `src` and subdirectories
+  - `**/*.test.*` — all test files
+  - `**/node_modules/**` — all files in `node_modules`
 
-- **Regular expressions**: Use RegExp objects for complex pattern matching
-  - `/\.test\./` - Files containing `.test.`
-  - `/^src\/.*\.tsx$/` - `.tsx` files directly in the `src` directory
-
-  **Advanced: Lookahead/Lookbehind Support**
+- **Regular expressions**: RegExp objects for complex matching
+  - `/\.test\./` — files containing `.test.`
+  - `/^src\/.*\.tsx$/` — `.tsx` files directly in the `src` directory
 
   The Rust regex engine fully supports lookahead and lookbehind assertions,
-  enabling sophisticated filtering patterns:
-  - **Negative Lookahead** `(?!...)`: Match if NOT followed by pattern
-    - `/node_modules(?!\/@stylexjs)/` - Exclude all node_modules except
-      @stylexjs packages
-    - `/\.tsx(?!\.test)/` - Match .tsx files that are NOT test files
+  which the JavaScript-side patterns can rely on:
+  - Negative lookahead `(?!...)`: `/node_modules(?!\/@stylexjs)/` excludes all
+    of `node_modules` except `@stylexjs` packages
+  - Positive lookahead `(?=...)`: `/.*\.test(?=\.tsx$)/` matches only
+    `.test.tsx` files
+  - Negative lookbehind `(?<!...)`: `/(?<!src\/).*\.tsx$/` excludes `.tsx` files
+    outside `src/`
+  - Positive lookbehind `(?<=...)`: `/(?<=components\/).*\.tsx$/` matches only
+    `.tsx` files in `components/`
 
-  - **Positive Lookahead** `(?=...)`: Match if followed by pattern
-    - `/.*\.test(?=\.tsx$)/` - Match only .test.tsx files
-
-  - **Negative Lookbehind** `(?<!...)`: Match if NOT preceded by pattern
-    - `/(?<!src\/).*\.tsx$/` - Exclude .tsx files not in src/
-
-  - **Positive Lookbehind** `(?<=...)`: Match if preceded by pattern
-    - `/(?<=components\/).*\.tsx$/` - Match only .tsx files in components/
-
-#### Filtering Rules
+### Filtering Rules
 
 1. If `include` patterns are specified and not empty, files must match at least
    one pattern
@@ -310,18 +181,17 @@ if (shouldTransform) {
 3. Exclude patterns take precedence over include patterns
 4. All paths are matched relative to the current working directory
 
-#### Common Use Cases
+### Common Use Cases
 
-**Exclude all node_modules except specific packages:**
+Exclude all of `node_modules` except one package:
 
 ```ts
-// Exclude all node_modules except @stylexjs/open-props
 shouldTransformFile(filePath, undefined, [
   /node_modules(?!\/@stylexjs\/open-props)/,
 ]);
 ```
 
-**Transform only specific packages from node_modules:**
+Transform only specific packages from `node_modules`:
 
 ```ts
 shouldTransformFile(
@@ -335,22 +205,10 @@ shouldTransformFile(
 );
 ```
 
-**Exclude multiple node_modules packages except a few:**
+## SWC Plugin Support
 
-```ts
-// Exclude all node_modules except @stylexjs packages
-shouldTransformFile(filePath, undefined, [/node_modules(?!\/@stylexjs)/]);
-```
-
-### SWC Plugin Support
-
-> [!NOTE]
-> **New Feature:** The compiler now supports running SWC WASM plugins
-> before StyleX transformation. This allows you to chain transformations and
-> integrate custom SWC plugins seamlessly.
-
-The `transform` function accepts an optional `swcPlugins` array in the options
-object, allowing you to run SWC WASM plugins before the StyleX transformation:
+The `transform` function accepts an optional `swcPlugins` array, allowing you to
+run SWC WASM plugins before the StyleX transformation:
 
 ```ts
 const { transform } = require('@stylexswc/rs-compiler');
@@ -380,123 +238,26 @@ const { code, metadata, map } = transform('Button.tsx', sourceCode, {
 });
 ```
 
-#### How It Works
+How it works:
 
-1. **Plugin Execution Phase**: If `swcPlugins` are provided, the source code is
+1. **Plugin execution phase**: if `swcPlugins` are provided, the source code is
    first transformed using `@swc/core`'s `transformSync` with the specified WASM
    plugins
-2. **StyleX Transformation Phase**: The plugin-transformed code is then passed
+2. **StyleX transformation phase**: the plugin-transformed code is then passed
    to the StyleX compiler
 
-#### Plugin Configuration
+Each entry in `swcPlugins` is a tuple of:
 
-Each plugin in the `swcPlugins` array is a tuple of:
-
-- **Plugin Path** (string): Can be:
-  - An absolute path to a `.wasm` file: `/path/to/plugin.wasm`
-  - An npm package name: `@swc/plugin-emotion`
-- **Plugin Config** (object): Plugin-specific configuration options
-
-#### Example: Custom Theme Plugin
-
-```ts
-transform(filename, code, {
-  dev: true,
-  swcPlugins: [
-    [
-      '/Users/me/plugins/swc_plugin_theme.wasm',
-      {
-        themeName: 'theme-name',
-        themeConfig: {
-          primaryColor: 'blue',
-          spacing: 8,
-        },
-      },
-    ],
-  ],
-});
-```
-
-#### Benefits
-
-- ✅ Chain multiple transformations seamlessly
-- ✅ Leverage the SWC plugin ecosystem
-- ✅ Custom preprocessing before StyleX transformation
-- ✅ Full compatibility with SWC WASM plugins
-- ✅ No additional build configuration needed
-
-### Output
-
-The output from the compiler includes the transformed code, metadata about the
-generated styles, and an optional source map.
-
-```json
-{
-  "code": "import * as stylex from '@stylexjs/stylex';\nexport const styles = {\n    default: {\n        backgroundColor: \"xrkmrrc\",\n        color: \"xju2f9n\",\n        $$css: true\n    }\n};\n",
-  "metadata": {
-    "stylex": {
-      "styles": [
-        [
-          "xrkmrrc",
-          {
-            "ltr": ".xrkmrrc{background-color:red}",
-            "rtl": null
-          },
-          3000
-        ],
-        [
-          "xju2f9n",
-          {
-            "ltr": ".xju2f9n{color:blue}",
-            "rtl": null
-          },
-          3000
-        ]
-      ]
-    }
-  },
-  "map": "{\"version\":3,\"sources\":[\"<anon>\"],\"names\":[],\"mappings\":\"AACE;AACA;;;;;;EAKG\"}"
-}
-```
-
-## Example
-
-Below is a simple example of input StyleX code:
-
-```ts
-import * as stylex from '@stylexjs/stylex';
-
-const styles = stylex.create({
-  root: {
-    padding: 10,
-  },
-  element: {
-    backgroundColor: 'red',
-  },
-});
-
-const styleProps = stylex.props(styles.root, styles.element);
-```
-
-Output code:
-
-```ts
-import * as stylex from '@stylexjs/stylex';
-const styleProps = {
-  className: 'x7z7khe xrkmrrc',
-};
-```
-
-## Compatibility
-
-> [!IMPORTANT]
-> The current resolution of the `exports` field from
-> `package. json` is only partially supported, so if you encounter problems,
-> please open an
-> [issue](https://github.com/Dwlad90/stylex-swc-plugin/issues/new) with an
-> attached link to reproduce the problem.
+- **Plugin path** (string): an absolute path to a `.wasm` file
+  (`/path/to/plugin.wasm`) or an npm package name (`@swc/plugin-emotion`)
+- **Plugin config** (object): plugin-specific configuration options
 
 ## Configuration Options
+
+The compiler accepts the standard StyleX options (`dev`, `debug`,
+`importSources`, `unstable_moduleResolution`, and so on — see the
+[StyleX configuration docs](https://stylexjs.com/docs/api/configuration/babel-plugin/))
+plus the compiler-specific options below.
 
 ### `injectStylexSideEffects`
 
@@ -505,10 +266,8 @@ const styleProps = {
 Automatically injects side-effect imports for `.stylex` and `.consts` files to
 prevent tree-shaking from removing them during bundling.
 
-#### Problem
-
-When using build tools that perform tree-shaking (like webpack, rollup, vite),
-imports from `.stylex` or `.consts` files may appear unused after StyleX
+The problem: when build tools perform tree-shaking (webpack, Rollup, Vite),
+imports from `.stylex` or `.consts` files may appear unused after the StyleX
 transformation and get removed:
 
 ```ts
@@ -536,13 +295,11 @@ const styles = {
 };
 ```
 
-The bundler may remove these "unused" imports, but they're needed for other
+The bundler may remove these "unused" imports, but they are needed for other
 files to resolve the same StyleX/const references correctly.
 
-#### Solution
-
-When `injectStylexSideEffects: true`, the compiler automatically adds
-side-effect imports to preserve these modules:
+With `injectStylexSideEffects: true`, the compiler adds side-effect imports to
+preserve these modules:
 
 ```ts
 // After transformation with injectStylexSideEffects: true
@@ -550,22 +307,13 @@ import { colors } from './theme.stylex';
 import { spacing } from './tokens.consts';
 import './theme.stylex'; // Side-effect import (prevents tree-shaking)
 import './tokens.consts'; // Side-effect import (prevents tree-shaking)
-
-const styles = {
-  root: {
-    backgroundColor: 'x1a2b3c',
-    padding: 'x4d5e6f',
-    $$css: true,
-  },
-};
 ```
 
-#### When to Use
+When to use:
 
-- ✅ **Use `true`** when your bundler runs StyleX transformation **before**
-  other optimizations (recommended)
-- ✅ **Use `true`** with webpack's `loaderOrder: 'first'` option
-- ❌ **Use `false`** when StyleX runs **after** tree-shaking (e.g., webpack's
+- Use `true` when your bundler runs the StyleX transformation **before** other
+  optimizations (recommended), for example with webpack's `loaderOrder: 'first'`
+- Use `false` when StyleX runs **after** tree-shaking (e.g. webpack's
   `loaderOrder: 'last'`)
 
 > [!TIP]
@@ -580,18 +328,14 @@ Source map for the incoming `code`, produced by earlier tooling — for example 
 loader chain that expands compile-time macros before the StyleX transformation
 runs.
 
-#### Source Map Problem
-
-When the compiler receives code that was already rewritten by previous tools,
-positions in that code no longer match the original authored file. Two things
-degrade as a result:
+The problem: when the compiler receives code already rewritten by previous
+tools, positions in that code no longer match the original authored file. Two
+things degrade as a result:
 
 - Debug source-map annotations (`$$css: "file.tsx:LINE"`, emitted with
   `debug: true`) point at lines of the intermediate code
 - The emitted source map resolves to the intermediate code instead of the
   original file
-
-#### Source Map Solution
 
 When `inputSourceMap` is provided, the compiler:
 
@@ -628,98 +372,41 @@ locating positions in the source text as described under
 
 **Type:** `boolean` **Default:** `true`
 
-Controls whether the compiler should read source files from disk for error
-reporting and source map generation. Only relevant when no
+Controls whether the compiler reads source files from disk for error reporting
+and source map generation. Only relevant when no
 [`inputSourceMap`](#inputsourcemap) is available — with an input map, debug
 source-map annotations are resolved from the compiler's own parse and do not
 depend on this option.
 
-#### Behavior
-
-- **`true` (default)**: The compiler reads the actual source file from disk when
+- **`true` (default)**: the compiler reads the actual source file from disk when
   generating error messages and source maps. This provides accurate line numbers
   and source context that match what you see in your editor. Style namespaces
   are located **by their key**, so positions resolve correctly even when the
   incoming code was already rewritten by earlier tooling (keys survive
   value-level transforms such as macro expansion).
 
-- **`false`**: The compiler uses the transformed AST representation for error
-  reporting. This is useful when:
-  - Working with in-memory transformations
-  - Source files are not available on disk
-  - You want faster compilation (skips file I/O)
+- **`false`**: the compiler uses the transformed AST representation for error
+  reporting. Useful for in-memory transformations, virtual file systems, or when
+  skipping file I/O matters more than exact positions.
 
-#### Source Map Example
-
-```ts
-transform(filename, code, {
-  use_real_file_for_source: true, // Use actual source files (default)
-  dev: true,
-  // ... other options
-});
-```
-
-#### Use Cases
-
-**Use `true` (recommended for development):**
-
-- Local development with files on disk
-- Accurate error messages with real line numbers
-- Better debugging experience
-- Source maps match your actual files
-
-**Use `false` (for special cases):**
-
-- In-memory transformations without disk access
-- Virtual file systems
-- Performance optimization when error accuracy is less critical
-- Build pipelines where source files are not available
-
-> [!TIP]
-> Keep the default `true` value for most use cases. Only set it to
-> `false` if you have specific requirements for in-memory transformations or
-> performance-critical scenarios where file I/O is a bottleneck.
->
 > [!WARNING]
-> When `useRealFileForSource` is set to `false`, error messages may
-> report **incorrect line numbers**. The compiler will use the transformed AST
-> representation instead of the original source code, which can lead to line
-> number mismatches. This happens because:
->
-> - The AST may have been modified by previous transformations
-> - Comments and whitespace are normalized in the AST
-> - The structure may differ from what's in your actual source file
->
-> For accurate error reporting and debugging, always use
-> `useRealFileForSource: true` (the default) during development, and provide an
-> [`inputSourceMap`](#inputsourcemap) when the incoming code was already
-> transformed by earlier tooling.
+> With `useRealFileForSource: false`, error messages may report
+> incorrect line numbers: the AST may have been modified by previous
+> transformations, comments and whitespace are normalized, and the structure may
+> differ from the file on disk. Keep the default `true` during development, and
+> provide an [`inputSourceMap`](#inputsourcemap) when the incoming code was
+> already transformed by earlier tooling.
 
-## Debug
+## Debug Logging
 
-You can enable debug logging for the StyleX compiler using the `STYLEX_DEBUG`
-environment variable. This is useful for troubleshooting and understanding the
-internal processing of StyleX code.
-
-### Log Levels
-
-The following log levels are available:
-
-- `error`: Only shows error messages
-- `warn`: Shows warnings and errors (default)
-- `info`: Shows informational messages, warnings, and errors
-- `debug`: Shows debug information and all above levels
-- `trace`: Shows very detailed execution information
-
-### Usage
-
-Set the environment variable before running your build command:
+Enable debug logging with the `STYLEX_DEBUG` environment variable. Available
+levels: `error`, `warn` (default), `info`, `debug`, `trace`.
 
 ```bash
 # Set to debug level
 STYLEX_DEBUG=debug npm run build
 
-# Set to trace for most verbose output
+# Set to trace for the most verbose output
 STYLEX_DEBUG=trace npm run dev
 ```
 
@@ -737,11 +424,9 @@ $env:STYLEX_DEBUG="debug"; npm run build
 
 ## Error Handling
 
-The compiler produces clean, structured error messages with a branded `[StyleX]`
-prefix, replacing Rust's default panic boilerplate with user-friendly
-diagnostics in both the terminal and at the NAPI boundary.
-
-### Error Format
+The compiler produces structured error messages with a branded `[StyleX]`
+prefix, replacing Rust's default panic boilerplate with readable diagnostics in
+both the terminal and at the NAPI boundary.
 
 All StyleX errors follow this format in the terminal:
 
@@ -758,6 +443,39 @@ Errors are color-coded for readability:
 | Regular error              | _(none)_          | Red prefix    |
 | Unimplemented feature      | `[UNIMPLEMENTED]` | Magenta label |
 | Internal unreachable state | `[UNREACHABLE]`   | Blue label    |
+
+## FAQ
+
+### Is this a drop-in replacement for `@stylexjs/babel-plugin`?
+
+Yes, by design. It implements the same transform, is validated against the
+official StyleX test suite, and produces compatible output. It also adds
+compiler-only capabilities: `include`/`exclude` filtering, SWC WASM plugin
+chaining, `inputSourceMap` chaining, and structured metadata output.
+
+### Do I need Rust installed to use it?
+
+No. Prebuilt native binaries are published for each supported platform and
+installed automatically as optional dependencies.
+
+### Which package should I install for my app?
+
+One of the bundler integrations listed at the top of this page. Install
+`@stylexswc/rs-compiler` directly only when building custom tooling on top of
+the `transform` API.
+
+### Known limitations?
+
+Resolution of the `exports` field in `package.json` is only partially supported.
+If you hit a problem, please open an
+[issue](https://github.com/Dwlad90/stylex-swc-plugin/issues/new) with a
+reproduction link.
+
+## Documentation
+
+- [StyleX documentation](https://stylexjs.com)
+- [NAPI-RS documentation](https://napi.rs)
+- [SWC documentation](https://swc.rs)
 
 ## License
 

--- a/crates/stylex-rs-compiler/package.json
+++ b/crates/stylex-rs-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexswc/rs-compiler",
-  "description": "NAPI-RS compiler for transform StyleX code",
+  "description": "High-performance Rust/NAPI-RS/SWC compiler for StyleX CSS-in-JS with compile-time atomic CSS extraction, metadata, source maps, and Babel-plugin replacement APIs for Node.js.",
   "version": "0.17.0",
   "private": false,
   "license": "MIT",
@@ -60,15 +60,15 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.7.2",
     "@stylexswc/ast": "0.17.0",
+    "@stylexswc/enums": "0.17.0",
     "@stylexswc/logs": "0.17.0",
     "@stylexswc/macros": "0.17.0",
-    "@stylexswc/utils": "0.17.0",
     "@stylexswc/regex": "0.17.0",
-    "@stylexswc/enums": "0.17.0",
     "@stylexswc/structures": "0.17.0",
     "@stylexswc/transform": "0.17.0",
     "@stylexswc/types": "0.17.0",
     "@stylexswc/typescript-config": "0.17.0",
+    "@stylexswc/utils": "0.17.0",
     "@swc-node/register": "^1.11.1",
     "@swc/core": "^1.15.43",
     "@taplo/cli": "^0.7.0",
@@ -101,18 +101,37 @@
       "@swc-node/register/esm-register"
     ]
   },
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
   "engines": {
-    "node": ">= 18"
+    "node": ">=20"
   },
+  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler#readme",
   "keywords": [
-    "N-API",
-    "NAPI",
+    "atomic-css",
+    "babel-plugin-alternative",
+    "compiler",
+    "css",
+    "css-extraction",
+    "css-in-js",
+    "jest",
+    "napi",
     "napi-rs",
+    "nextjs",
     "node-addon",
-    "node-addon-api",
-    "Rust",
-    "StyleX",
-    "SWC"
+    "performance",
+    "postcss",
+    "rollup",
+    "rspack",
+    "rust",
+    "source-maps",
+    "stylex",
+    "stylex-babel-plugin",
+    "stylex-compiler",
+    "stylex-swc",
+    "swc",
+    "turbopack",
+    "vite",
+    "webpack"
   ],
   "main": "dist/index.js",
   "napi": {
@@ -128,5 +147,9 @@
     ]
   },
   "packageManager": "pnpm@10.30.3",
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
+    "directory": "crates/stylex-rs-compiler"
+  }
 }

--- a/guidelines/STRUCTURE.md
+++ b/guidelines/STRUCTURE.md
@@ -5,31 +5,197 @@ Monorepo with `pnpm` workspaces (`pnpm-workspace.yaml`): `apps/*`, `crates/*`,
 
 ## Rust Crates (`crates/`)
 
-17 atomic crates arranged in a strict dependency DAG (higher layers depend only
-on lower layers):
+Atomic crates arranged in a strict dependency DAG (higher layers depend only on
+lower layers). Each crate owns exactly one concern -- no re-export facades, no
+mixed-domain files.
 
-**Layer 0 -- Primitives:** `stylex-constants`, `stylex-regex`, `stylex-utils`
+**Layer 0 -- Primitives (no internal dependencies):**
 
-**Layer 1 -- Macros:** `stylex-macros`
+- `stylex-constants` -- static lookup tables, keyword sets, and compile-time
+  constants
+- `stylex-regex` -- pre-compiled `lazy_static!` regex patterns for CSS value
+  matching
+- `stylex-styleq` -- Rust port of the runtime
+  [`styleq`](https://github.com/necolas/styleq) class-name merger
+- `stylex-utils` -- lightweight SWC AST helpers
 
-**Layer 2 -- Domain Leaves:** `stylex-enums`, `stylex-js`, `stylex-logs`,
-`stylex-css-parser`, `stylex-path-resolver`
+**Layer 1 -- Macros:**
 
-**Layer 3 -- Core Data Structures:** `stylex-structures`
+- `stylex-macros` -- error-handling and diagnostic macros (`stylex_panic!`,
+  `stylex_bail!`, `stylex_unwrap!`, etc.)
 
-**Layer 4 -- Type System:** `stylex-types`
+**Layer 2 -- Domain Leaves:**
 
-**Layer 5 -- AST Foundations:** `stylex-ast`
+- `stylex-enums` -- enum modules: `CSSSyntax`, `ValueWithDefault`,
+  `ImportPathResolution`, `StyleVarsToKeep`, and more
+- `stylex-js` -- JS runtime guard helpers (`is_valid_callee`,
+  `is_mutation_expr`, `is_invalid_method`)
+- `stylex-logs` -- structured logging with ANSI-colored `[StyleX]`-branded
+  output for the NAPI-RS pipeline
+- `stylex-css-parser` -- CSS value parser with type, property, and at-rule
+  coverage
+- `stylex-path-resolver` -- import path resolution with partial `package.json`
+  exports support
 
-**Layer 6 -- Evaluation:** `stylex-evaluator`
+**Layer 3 -- Core Data Structures:**
 
-**Layer 7 -- CSS Processing:** `stylex-css`
+- `stylex-structures` -- foundational struct modules: `StylexOptions`,
+  `UidGenerator`, `PluginPass`, `NamedImportSource`, `Order`, and more
 
-**Layer 8 -- StyleX Transform:** `stylex-transform`
+**Layer 4 -- Type System:**
 
-**Layer 9 -- Compilers:** `stylex-rs-compiler` (NAPI-RS bindings to Node.js)
+- `stylex-types` -- cross-coupled core types (`InjectableStyle*`, `MetaData`)
+  and the `StyleOptions` trait
+
+**Layer 5 -- AST Foundations:**
+
+- `stylex-ast` -- SWC AST factory and convertor functions (semantically named
+  `create_*`, `convert_*`)
+
+**Layer 6 -- Evaluation:**
+
+- `stylex-evaluator` -- pure JS expression evaluator; no transform side effects
+
+**Layer 7 -- CSS Processing:**
+
+- `stylex-css` -- unified CSS processing: generation (LTR/RTL), whitespace
+  normalization, value parsing, property ordering strategies, and pseudo-class
+  selector utilities
+
+**Layer 8 -- StyleX Transform:**
+
+- `stylex-transform` -- main SWC transform: `StyleXTransform`, `StateManager`,
+  SWC `Fold` visitor, and all injection logic
+
+**Layer 9 -- Compilers (top-level consumers):**
+
+- `stylex-rs-compiler` -- NAPI-RS compiler exposing the full pipeline to Node.js
 
 Workspace dependencies are defined in the root `Cargo.toml`.
+
+<details>
+<summary>Dependency graph</summary>
+
+```mermaid
+graph TD
+  subgraph L0["Primitives"]
+    stylex_constants["constants"]
+    stylex_regex["regex"]
+    stylex_styleq["styleq"]
+    stylex_utils["utils"]
+  end
+
+  subgraph L1["Proc Macros"]
+    stylex_macros["macros"]
+  end
+
+  subgraph L2["Domain Leaves"]
+    stylex_enums["enums"]
+    stylex_js["js"]
+    stylex_logs["logs"]
+    stylex_css_parser["css-parser"]
+    stylex_path_resolver["path-resolver"]
+  end
+
+  subgraph L3["Core Data Structures"]
+    stylex_structures["structures"]
+  end
+
+  subgraph L4["Type System"]
+    stylex_types["types"]
+  end
+
+  subgraph L5["AST Foundations"]
+    stylex_ast["ast"]
+  end
+
+  subgraph L6["Evaluation"]
+    stylex_evaluator["evaluator"]
+  end
+
+  subgraph L7["CSS Processing"]
+    stylex_css["css"]
+  end
+
+  subgraph L8["StyleX Transform"]
+    stylex_transform["transform"]
+  end
+
+  subgraph L9["Compilers"]
+    stylex_compiler_rs["rs-compiler"]
+  end
+
+  stylex_utils         --> stylex_regex
+
+  stylex_macros        --> stylex_constants
+
+  stylex_enums         --> stylex_macros
+  stylex_js            --> stylex_constants
+  stylex_js            --> stylex_macros
+  stylex_logs          --> stylex_macros
+  stylex_css_parser    --> stylex_macros
+  stylex_path_resolver --> stylex_macros
+
+  stylex_structures    --> stylex_constants
+  stylex_structures    --> stylex_enums
+  stylex_structures    --> stylex_macros
+
+  stylex_types         --> stylex_constants
+  stylex_types         --> stylex_enums
+  stylex_types         --> stylex_macros
+  stylex_types         --> stylex_structures
+  stylex_types         --> stylex_utils
+
+  stylex_ast           --> stylex_constants
+  stylex_ast           --> stylex_macros
+  stylex_ast           --> stylex_types
+  stylex_ast           --> stylex_utils
+
+  stylex_evaluator     --> stylex_ast
+  stylex_evaluator     --> stylex_constants
+  stylex_evaluator     --> stylex_js
+  stylex_evaluator     --> stylex_macros
+  stylex_evaluator     --> stylex_path_resolver
+  stylex_evaluator     --> stylex_types
+
+  stylex_css           --> stylex_ast
+  stylex_css           --> stylex_constants
+  stylex_css           --> stylex_css_parser
+  stylex_css           --> stylex_enums
+  stylex_css           --> stylex_evaluator
+  stylex_css           --> stylex_macros
+  stylex_css           --> stylex_regex
+  stylex_css           --> stylex_structures
+  stylex_css           --> stylex_types
+  stylex_css           --> stylex_utils
+
+  stylex_transform     --> stylex_ast
+  stylex_transform     --> stylex_constants
+  stylex_transform     --> stylex_css
+  stylex_transform     --> stylex_css_parser
+  stylex_transform     --> stylex_enums
+  stylex_transform     --> stylex_evaluator
+  stylex_transform     --> stylex_logs
+  stylex_transform     --> stylex_macros
+  stylex_transform     --> stylex_path_resolver
+  stylex_transform     --> stylex_regex
+  stylex_transform     --> stylex_structures
+  stylex_transform     --> stylex_styleq
+  stylex_transform     --> stylex_types
+  stylex_transform     --> stylex_utils
+
+  stylex_compiler_rs   --> stylex_ast
+  stylex_compiler_rs   --> stylex_enums
+  stylex_compiler_rs   --> stylex_logs
+  stylex_compiler_rs   --> stylex_macros
+  stylex_compiler_rs   --> stylex_regex
+  stylex_compiler_rs   --> stylex_structures
+  stylex_compiler_rs   --> stylex_transform
+  stylex_compiler_rs   --> stylex_types
+  stylex_compiler_rs   --> stylex_utils
+```
+
+</details>
 
 ## TS/JS Packages (`packages/`)
 
@@ -79,8 +245,8 @@ file).
     --ignore-filename-regex '<pattern>'
   ```
 - **100% line coverage is enforced** via `--fail-uncovered-lines 0`.
-- **Coverage exclusion:** Use `#[cfg_attr(coverage_nightly, coverage(off))]`
-  on functions/impls that cannot be meaningfully tested (e.g., panic branches,
+- **Coverage exclusion:** Use `#[cfg_attr(coverage_nightly, coverage(off))]` on
+  functions/impls that cannot be meaningfully tested (e.g., panic branches,
   mutex poisoning). On stable Rust this is a no-op; file-level exclusions via
   `--ignore-filename-regex` handle the rest. Do NOT add new exclusions without
   justification.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@stylexswc/stylexswc",
+  "description": "Community Rust/NAPI-RS/SWC compiler and build-tool plugin ecosystem for StyleX CSS-in-JS, replacing the Babel transform for faster compile-time atomic CSS extraction.",
   "version": "0.17.0",
   "private": true,
   "scripts": {
@@ -61,6 +62,26 @@
   "engines": {
     "node": ">=20"
   },
+  "keywords": [
+    "atomic-css",
+    "css-extraction",
+    "css-in-js",
+    "jest",
+    "napi-rs",
+    "nextjs",
+    "postcss",
+    "rollup",
+    "rspack",
+    "rust",
+    "stylex",
+    "stylex-babel-plugin",
+    "stylex-compiler",
+    "stylex-swc",
+    "swc",
+    "turbopack",
+    "vite",
+    "webpack"
+  ],
   "packageManager": "pnpm@10.30.3",
   "repository": "dwlad90/stylex-swc-plugin"
 }

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -1,19 +1,24 @@
-# Jest transformer with NAPI-RS StyleX compiler integration
+# @stylexswc/jest
 
-> Part of the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme) workspace
+> Jest transformer that compiles StyleX with a Rust compiler (NAPI-RS + SWC).
+> Part of the
+> [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme)
+> workspace.
 
-Jest transformer that enables StyleX SWC integration for JavaScript and
-TypeScript testing with Jest.
+Components that use [StyleX](https://stylexjs.com) cannot run in Jest without a
+transform: `stylex.create` calls must be compiled before the test executes. This
+transformer does that compilation with
+[`@stylexswc/rs-compiler`](https://www.npmjs.com/package/@stylexswc/rs-compiler),
+a Rust implementation of the StyleX transform, so tests see the same compiled
+class names your production build produces — without pulling Babel into your
+test pipeline.
 
-## Overview
-
-The `@stylexswc/jest` package provides a Jest transformer that integrates with
-the StyleX RS compiler. This allows to transform source code using StyleX during
-Jest tests, ensuring that styles are correctly processed and applied.
+This is a community project and is not affiliated with Meta. It tracks the
+official StyleX releases
+<!-- stylex-compatibility:start -->(currently compatible with StyleX v0.19.0)<!-- stylex-compatibility:end -->
+and requires Node.js 20 or newer.
 
 ## Installation
-
-To install the package, run the following command:
 
 ```bash
 npm install --save-dev @stylexswc/jest
@@ -21,10 +26,9 @@ npm install --save-dev @stylexswc/jest
 
 ## Configuration
 
-To use the transformer, add it to Jest configuration. Here is an example
-configuration:
+Add the transformer to your Jest configuration:
 
-```javascript
+```js
 // jest.config.js
 const path = require('path');
 
@@ -55,35 +59,38 @@ module.exports = {
 
 - Type: `Partial<StyleXOptions>`
 - Optional
-- Description: StyleX compiler options that will be passed to the transformer.
-  For standard StyleX options, see the [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
+- Description: StyleX compiler options passed to the transformer. For the
+  standard options, see the
+  [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
 
 > [!NOTE]
-> **New Features:** The `include` and `exclude` options are exclusive to this NAPI-RS compiler implementation and are not available in the official StyleX Babel plugin.
+> The `include` and `exclude` options are exclusive to the Rust compiler
+> and are not available in the official StyleX Babel plugin.
 
 #### `rsOptions.include`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular expressions to include specific files for StyleX transformation.
-  When specified, only files matching at least one of these patterns will be transformed.
-  Patterns are matched against paths relative to the current working directory.
-  Supports regex lookahead/lookbehind for advanced filtering.
+- Description: Glob patterns or regular expressions selecting the files to
+  transform. When specified, only files matching at least one pattern are
+  transformed. Patterns are matched against paths relative to the current
+  working directory. Regular expressions support lookahead and lookbehind.
 
 #### `rsOptions.exclude`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular expressions to exclude specific files from StyleX transformation.
-  Files matching any of these patterns will not be transformed, even if they match an `include` pattern.
-  Patterns are matched against paths relative to the current working directory.
-  Supports regex lookahead/lookbehind for advanced filtering.
+- Description: Glob patterns or regular expressions excluding files from the
+  transform. A file matching any exclude pattern is skipped even if it matches
+  an `include` pattern. Patterns are matched against paths relative to the
+  current working directory. Regular expressions support lookahead and
+  lookbehind.
 
 ### Path Filtering Examples
 
-**Include only specific directories:**
+Include only specific directories:
 
-```javascript
+```js
 {
   rsOptions: {
     include: ['src/**/*.{ts,tsx}', 'app/**/*.{ts,tsx}'],
@@ -91,9 +98,9 @@ module.exports = {
 }
 ```
 
-**Exclude test files:**
+Exclude test files:
 
-```javascript
+```js
 {
   rsOptions: {
     exclude: ['**/*.test.*', '**/*.spec.*', '**/__tests__/**'],
@@ -101,42 +108,27 @@ module.exports = {
 }
 ```
 
-**Using RegExp with lookahead/lookbehind - exclude node_modules except specific packages:**
+Exclude `node_modules` except specific packages (negative lookahead):
 
-```javascript
+```js
 {
   rsOptions: {
-    // Exclude all node_modules except @stylexjs/open-props
     exclude: [/node_modules(?!\/@stylexjs\/open-props)/],
   },
 }
 ```
 
-**Combined include and exclude:**
+## Chaining with other transformers
 
-```javascript
-{
-  rsOptions: {
-    include: ['src/**/*.{ts,tsx}'],
-    exclude: ['**/*.test.*', '**/*.stories.*'],
-  },
-}
-```
+This transformer only compiles StyleX — TypeScript and JSX still need their own
+transform. Chain it with `@swc/jest` (or another transformer) using
+`jest-chain-transform`:
 
-## Example
-
-Here is an example of how to use `@swc/jest` with other transformers:
-
-```javascript
+```js
 // jest.config.js
-const nextJest = require('next/jest');
 const path = require('path');
 
-const createJestConfig = nextJest({
-  dir: process.cwd(),
-});
-
-const customJestConfig = {
+module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jsdom',
   transform: {
@@ -160,34 +152,21 @@ const customJestConfig = {
           [
             '@swc/jest',
             {
-              $schema: 'https://json.schemastore.org/swcrc',
               jsc: {
                 parser: {
                   syntax: 'typescript',
                   tsx: true,
-                  dynamicImport: true,
-                  decorators: true,
-                  dts: true,
                 },
                 transform: {
                   react: {
-                    useBuiltins: true,
                     runtime: 'automatic',
                   },
                 },
                 target: 'esnext',
-                loose: false,
-                externalHelpers: false,
-                keepClassNames: true,
-                baseUrl: './',
-                paths: {
-                  '@/*': ['./*'],
-                },
               },
               module: {
                 type: 'es6',
               },
-              minify: false,
             },
           ],
         ],
@@ -195,13 +174,40 @@ const customJestConfig = {
     ],
   },
 };
-
-module.exports = customJestConfig;
 ```
 
-Real example can be found in the
-[@stylexswc/next-example](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/apps/nextjs-example/jest.config.js)
+A complete working configuration lives in the
+[Next.js example app](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/apps/nextjs-example/jest.config.js).
+
+## FAQ
+
+### Why do my tests fail with "stylex.create should never be called"?
+
+That error means the StyleX code reached the runtime uncompiled. Check that this
+transformer is registered for the failing file's extension and that the file is
+not excluded by your `rsOptions.include`/`exclude` patterns.
+
+### Do I still need `babel-jest` or `@stylexjs/babel-plugin`?
+
+No. This transformer replaces the Babel-based StyleX setup in Jest. For
+TypeScript/JSX, chain it with `@swc/jest` as shown above instead of Babel.
+
+### My theme tokens from `.stylex.ts` files don't resolve in tests
+
+Set `unstable_moduleResolution` (usually `{ type: 'commonJS' }`) and mirror your
+path aliases in `rsOptions.aliases`, exactly as in your build config.
+
+### Is this an official StyleX package?
+
+No. It is a community-maintained alternative to the official tooling and is not
+affiliated with or supported by Meta.
+
+## Documentation
+
+- [StyleX documentation](https://stylexjs.com)
+- [`@stylexswc/rs-compiler` compiler options](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
 
 ## License
 
-MIT — see [LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)
+MIT — see
+[LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexswc/jest",
-  "description": "Jest transformer for Stylex SWC",
+  "description": "Jest transformer for StyleX that compiles CSS-in-JS with the Rust NAPI-RS/SWC compiler, enabling Babel-free StyleX component tests.",
   "version": "0.17.0",
   "private": false,
   "license": "MIT",
@@ -40,11 +40,27 @@
     "@stylexswc/typescript-config": "0.17.0",
     "@types/node": "^26.1.0"
   },
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
+  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/jest#readme",
   "keywords": [
+    "babel-free",
+    "css-in-js",
+    "css-in-js-testing",
     "jest",
+    "jest-transform",
+    "jest-transformer",
+    "napi-rs",
+    "react-testing",
+    "rust",
     "stylex",
-    "swc"
+    "stylex-jest",
+    "swc",
+    "testing"
   ],
   "main": "dist/index.js",
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
+    "directory": "packages/jest"
+  }
 }

--- a/packages/nextjs-plugin/README.md
+++ b/packages/nextjs-plugin/README.md
@@ -1,55 +1,47 @@
-# Next.js plugin with NAPI-RS StyleX compiler integration
+# @stylexswc/nextjs-plugin
 
-> Part of the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme) workspace
+> StyleX plugin for Next.js, powered by a Rust compiler (NAPI-RS + SWC).
+> Supports Webpack, Rspack, and Turbopack builds. Part of the
+> [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme)
+> workspace.
 
-Next.js plugin for an unofficial
-[`napi-rs`](https://github.com/dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
-compiler that includes the StyleX SWC code transformation under the hood.
+This plugin integrates [StyleX](https://stylexjs.com) into Next.js using
+[`@stylexswc/rs-compiler`](https://www.npmjs.com/package/@stylexswc/rs-compiler),
+a Rust implementation of the StyleX transform, instead of the official Babel
+plugin. That means you keep Next.js's fast SWC toolchain — no `.babelrc`, no
+Babel fallback — and your StyleX code stays exactly the same. Per-file
+transforms are 2x to 5x faster than with Babel — see
+[performance](https://github.com/Dwlad90/stylex-swc-plugin#performance).
 
-## Overview
-
-This package combines two solutions to enhance your Next.js development
-experience with StyleX:
-
-### StyleX SWC Plugin
-
-- Integrates StyleX with the SWC compiler, potentially leading to faster build
-  times compared to using Babel.
-- Maintains high compatibility with official StyleX tests, ensuring a reliable
-  experience.
-- Integrates seamlessly with Next.js SWC Compiler for a streamlined workflow.
-
-### StyleX NAPI-RS Compiler
-
-- Utilizes NAPI-RS to compile StyleX code, offering advantages over the SWC
-  plugin approach.
-- Provides access to StyleX metadata and source maps, enabling advanced plugin
-  and tool development.
-
-## Why choose this approach?
-
-- Leverage SWC's speed: Benefit from Next.js's default SWC compiler for
-  potentially faster build times.
-- Maintain StyleX familiarity: The usage of StyleX remains unchanged for
-  developers.
+This is a community project and is not affiliated with Meta. It tracks the
+official StyleX releases
+<!-- stylex-compatibility:start -->(currently compatible with StyleX v0.19.0)<!-- stylex-compatibility:end -->,
+requires Node.js 20 or newer, and supports Next.js 15+ (App Router and Pages
+Router).
 
 ## Installation
-
-To install the package, run the following command:
 
 ```bash
 npm install --save-dev @stylexswc/nextjs-plugin
 ```
 
+Your application still needs the StyleX runtime:
+
+```bash
+npm install @stylexjs/stylex
+```
+
 ## Usage
 
-This plugin supports Webpack, Rspack, and Turbopack configurations in Next.js.
+The plugin supports all three Next.js bundlers. Pick the export that matches
+your setup.
 
 ### Using with Webpack
 
 For standard Next.js Webpack builds, use the default import:
 
-```javascript
+```js
+// next.config.js
 const stylexPlugin = require('@stylexswc/nextjs-plugin');
 
 module.exports = stylexPlugin({
@@ -61,11 +53,12 @@ module.exports = stylexPlugin({
 
 ### Using with Rspack
 
-For Next.js with [Rspack](https://rspack.rs), use the `/rspack` export. It applies the
-experimental [`next-rspack`](https://www.npmjs.com/package/next-rspack) adapter for you —
-no manual `withRspack` composition needed:
+For Next.js with [Rspack](https://rspack.rs), use the `/rspack` export. It
+applies the experimental
+[`next-rspack`](https://www.npmjs.com/package/next-rspack) adapter for you — no
+manual `withRspack` composition needed:
 
-```typescript
+```ts
 import stylexPlugin from '@stylexswc/nextjs-plugin/rspack';
 
 module.exports = stylexPlugin({
@@ -76,27 +69,33 @@ module.exports = stylexPlugin({
 ```
 
 > [!NOTE]
-> Run `next dev` and `next build` without the `--webpack`/`--turbopack` flags. For
-> `next start`, set `NEXT_RSPACK=true` in the environment (the production server only
-> serves prebuilt output, but it still evaluates the config).
+> Run `next dev` and `next build` without the `--webpack`/`--turbopack`
+> flags. For `next start`, set `NEXT_RSPACK=true` in the environment (the
+> production server only serves prebuilt output, but it still evaluates the
+> config).
 
-The Rspack integration extracts StyleX CSS from both Server and Client Components, with
-the same options as the Webpack plugin, plus `stylexPackages` from
+The Rspack integration extracts StyleX CSS from both Server and Client
+Components, with the same options as the Webpack plugin, plus `stylexPackages`
+from
 [`@stylexswc/rspack-plugin`](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/rspack-plugin).
 
 > [!NOTE]
-> Packages listed in `transpilePackages` are automatically added to the `stylexPackages`
-> allowlist, so StyleX source shipped in `node_modules` (e.g. `@stylexjs/open-props`) is
-> picked up without extra configuration.
+> Packages listed in `transpilePackages` are automatically added to the
+> `stylexPackages` allowlist, so StyleX source shipped in `node_modules` (e.g.
+> `@stylexjs/open-props`) is picked up without extra configuration.
 
 ### Using with Turbopack
 
 > [!IMPORTANT]
-> **Turbopack Limitation**: Turbopack does not support webpack plugins ([see Next.js docs](https://nextjs.org/docs/app/api-reference/turbopack#webpack-plugins)). When using Turbopack, the loader only compiles StyleX code but **does not extract CSS**.
+> Turbopack does not support webpack plugins
+> ([see Next.js docs](https://nextjs.org/docs/app/api-reference/turbopack#webpack-plugins)).
+> When using Turbopack, the loader only compiles StyleX code but does not
+> extract CSS.
 >
-> **You must configure the PostCSS plugin for CSS extraction.** Install `@stylexswc/postcss-plugin` and configure it in `postcss.config.js`:
+> You must configure the PostCSS plugin for CSS extraction. Install
+> `@stylexswc/postcss-plugin` and configure it in `postcss.config.js`:
 >
-> ```javascript
+> ```js
 > // postcss.config.js
 > module.exports = {
 >   plugins: {
@@ -112,26 +111,22 @@ the same options as the Webpack plugin, plus `stylexPackages` from
 
 For Next.js with Turbopack, use the `/turbopack` export:
 
-```typescript
+```ts
 import withStylexTurbopack from '@stylexswc/nextjs-plugin/turbopack';
 
 export default withStylexTurbopack({
-  // StyleX options here same as postcss-plugin
+  // StyleX options here, same as postcss-plugin
   rsOptions: {
-      dev: process.env.NODE_ENV === 'development',
+    dev: process.env.NODE_ENV === 'development',
   },
 })({
   // Next.js config here
-  experimental: {
-    turbopack: {
-      // Additional Turbopack configuration if needed
-    },
-  },
 });
 ```
 
 > [!NOTE]
-> When using Turbopack, the following options are not supported and will be ignored:
+> When using Turbopack, the following options are not supported and will
+> be ignored:
 >
 > - `useCSSLayers`
 > - `nextjsMode`
@@ -146,20 +141,20 @@ export default withStylexTurbopack({
 
 - Type: `Partial<StyleXOptions>`
 - Optional
-- Description: StyleX compiler options that will be passed to the NAPI-RS
-  compiler. For standard StyleX options, see the
+- Description: StyleX compiler options passed to `@stylexswc/rs-compiler`. For
+  the standard options, see the
   [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
 
 > [!NOTE]
-> **New Features:** The `include` and `exclude` options are exclusive to this NAPI-RS compiler implementation and are not available in the official StyleX Babel plugin.
+> The `include` and `exclude` options are exclusive to the Rust compiler
+> and are not available in the official StyleX Babel plugin.
 
 ##### `rsOptions.include`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular
-  expressions to include specific files for StyleX transformation. When
-  specified, only files matching at least one of these patterns will be
+- Description: Glob patterns or regular expressions selecting the files to
+  transform. When specified, only files matching at least one pattern are
   transformed. Patterns are matched against paths relative to the current
   working directory.
 
@@ -167,31 +162,32 @@ export default withStylexTurbopack({
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular
-  expressions to exclude specific files from StyleX transformation. Files
-  matching any of these patterns will not be transformed, even if they match an
-  `include` pattern. Patterns are matched against paths relative to the current
-  working directory.
+- Description: Glob patterns or regular expressions excluding files from the
+  transform. A file matching any exclude pattern is skipped even if it matches
+  an `include` pattern. Patterns are matched against paths relative to the
+  current working directory.
 
 #### `stylexImports`
 
 - Type: `Array<string | { as: string, from: string }>`
 - Default: `['stylex', '@stylexjs/stylex']`
-- Description: Specifies where StyleX will be imported from. Supports both
-  string paths and import aliases.
+- Description: Specifies where StyleX is imported from. Supports both string
+  paths and import aliases.
 
 #### `useCSSLayers`
 
 - Type: `UseLayersType`
 - Default: `false`
-- Description: Enables CSS cascade layers support for better style isolation.
+- Description: Wraps the generated CSS in cascade layers for better style
+  isolation.
 
 #### `extractCSS`
 
 - Type: `boolean`
 - Optional
 - Default: `true`
-- Description: Controls whether CSS should be extracted into a separate file
+- Description: Controls whether the generated CSS is extracted into a separate
+  file. Set to `false` when `@stylexswc/postcss-plugin` owns extraction.
 
 ### Advanced Options
 
@@ -200,20 +196,19 @@ export default withStylexTurbopack({
 - Type:
   `(css: string, filePath: string | undefined) => string | Buffer | Promise<string | Buffer>`
 - Optional
-- Description: Custom CSS transformation function. Since the plugin injects CSS
-  after all loaders, use this to apply PostCSS or other CSS transformations.
+- Description: Custom CSS post-processing. The plugin injects CSS after all
+  loaders have run, so use this to apply PostCSS or other CSS transformations.
 
 ### Example Configuration
 
 #### Webpack Configuration
 
-```javascript
+```js
 const path = require('path');
 const stylexPlugin = require('@stylexswc/nextjs-plugin');
 const rootDir = __dirname;
 
 module.exports = stylexPlugin({
-  // Add any StyleX options here
   rsOptions: {
     dev: process.env.NODE_ENV !== 'production',
     // Include only specific directories
@@ -252,14 +247,13 @@ module.exports = stylexPlugin({
 
 #### Turbopack Configuration
 
-```typescript
+```ts
 import path from 'path';
 import withStylexTurbopack from '@stylexswc/nextjs-plugin/turbopack';
 
 const rootDir = __dirname;
 
 export default withStylexTurbopack({
-  // Add any StyleX options here
   rsOptions: {
     dev: process.env.NODE_ENV !== 'production',
     aliases: {
@@ -272,28 +266,20 @@ export default withStylexTurbopack({
   stylexImports: ['@stylexjs/stylex'],
 })({
   transpilePackages: ['@stylexjs/open-props'],
-  experimental: {
-    turbopack: {
-      // Additional Turbopack configuration if needed
-    },
-  },
   // Optionally, add any other Next.js config below
 });
 ```
 
-##### Required: PostCSS Configuration for CSS Extraction
+Required PostCSS configuration for CSS extraction under Turbopack:
 
-```javascript
+```js
 // postcss.config.js
 const path = require('path');
 
 module.exports = {
   plugins: {
     '@stylexswc/postcss-plugin': {
-      include: [
-        'app/**/*.{js,jsx,ts,tsx}',
-        'components/**/*.{js,jsx,ts,tsx}',
-      ],
+      include: ['app/**/*.{js,jsx,ts,tsx}', 'components/**/*.{js,jsx,ts,tsx}'],
       rsOptions: {
         aliases: {
           '@/*': [path.join(__dirname, '*')],
@@ -311,9 +297,9 @@ module.exports = {
 
 ### Path Filtering Examples
 
-**Include only specific directories:**
+Include only specific directories:
 
-```javascript
+```js
 stylexPlugin({
   rsOptions: {
     include: ['app/**/*.tsx', 'components/**/*.tsx'],
@@ -321,19 +307,19 @@ stylexPlugin({
 });
 ```
 
-**Exclude test and build files:**
+Exclude test files and API routes:
 
-```javascript
+```js
 stylexPlugin({
   rsOptions: {
-    exclude: ['**/*.test.*', '**/*.spec.*', '**/dist/**', '**/node_modules/**'],
+    exclude: ['**/*.test.*', '**/*.stories.*', '**/__tests__/**', 'app/api/**'],
   },
 });
 ```
 
-**Using regular expressions:**
+Using regular expressions (exclude always takes precedence over include):
 
-```javascript
+```js
 stylexPlugin({
   rsOptions: {
     include: [/app\/.*\.tsx$/, /components\/.*\.tsx$/],
@@ -342,31 +328,19 @@ stylexPlugin({
 });
 ```
 
-**Combined include and exclude (exclude takes precedence):**
+Exclude `node_modules` except specific packages (negative lookahead):
 
-```javascript
+```js
 stylexPlugin({
   rsOptions: {
-    include: ['app/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
-    exclude: ['**/__tests__/**', '**/__mocks__/**', 'app/api/**'],
-  },
-});
-```
-
-**Exclude node_modules except specific packages:**
-
-```javascript
-stylexPlugin({
-  rsOptions: {
-    // Exclude all node_modules except @stylexjs/open-props
     exclude: [/node_modules(?!\/@stylexjs\/open-props)/],
   },
 });
 ```
 
-**Transform only specific packages from node_modules:**
+Transform only specific packages from `node_modules`:
 
-```javascript
+```js
 stylexPlugin({
   rsOptions: {
     include: [
@@ -380,6 +354,35 @@ stylexPlugin({
 });
 ```
 
+## FAQ
+
+### Which bundler mode should I pick?
+
+Webpack (the default export) is the most battle-tested path and supports every
+option. Turbopack gives the fastest dev server but needs the PostCSS plugin for
+CSS extraction. Rspack is experimental in Next.js itself but works end to end
+through the `/rspack` export.
+
+### Do I still need `@stylexjs/babel-plugin` or a `.babelrc`?
+
+No — that is the point of this plugin. StyleX is compiled by the Rust compiler
+inside the SWC pipeline, so Next.js never falls back to Babel.
+
+### My styles from `@stylexjs/open-props` (or another library) are missing
+
+Add the package to `transpilePackages` in your Next.js config. It is then
+transpiled by Next.js and automatically allowlisted for the StyleX transform.
+
+### Does this work with React Server Components?
+
+Yes. Styles are extracted at build time from both Server and Client Components
+into static CSS, so there is no runtime cost either way.
+
+### Is this an official StyleX package?
+
+No. It is a community-maintained alternative to the official tooling and is not
+affiliated with or supported by Meta.
+
 ## Examples
 
 - [Example repo](https://github.com/Dwlad90/nextjs-app-dir-stylex)
@@ -387,8 +390,8 @@ stylexPlugin({
 
 ## Documentation
 
-- [StyleX Documentation](https://stylexjs.com)
-- [NAPI-RS compiler for StyleX](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
+- [StyleX documentation](https://stylexjs.com)
+- [`@stylexswc/rs-compiler` compiler options](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
 
 ## Acknowledgments
 
@@ -397,4 +400,5 @@ This plugin was inspired by
 
 ## License
 
-MIT — see [LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)
+MIT — see
+[LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)

--- a/packages/nextjs-plugin/package.json
+++ b/packages/nextjs-plugin/package.json
@@ -1,7 +1,48 @@
 {
   "name": "@stylexswc/nextjs-plugin",
-  "description": "StyleX NextJS plugin with NAPI-RS compiler",
+  "description": "StyleX plugin for Next.js powered by a Rust NAPI-RS/SWC compiler. Supports Webpack, Rspack, and Turbopack builds with CSS extraction.",
   "version": "0.17.0",
+  "private": false,
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    "./turbopack": {
+      "types": "./dist/turbopack.d.ts",
+      "import": "./dist/turbopack.js",
+      "require": "./dist/turbopack.js"
+    },
+    "./rspack": {
+      "types": "./dist/rspack.d.ts",
+      "import": "./dist/rspack.js",
+      "require": "./dist/rspack.js"
+    },
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "scripts": {
+    "build": "scripty --ts",
+    "check:artifacts": "scripty",
+    "clean": "del-cli dist",
+    "lint": "eslint . --color",
+    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
+    "postbuild": "pnpm run check:artifacts",
+    "precommit": "lint-staged",
+    "prepublishOnly": "pnpm run build",
+    "prepush": "lint-prepush",
+    "test": "echo \"Error: no test specified\" && exit 0",
+    "typecheck": "scripty --ts"
+  },
   "config": {
     "scripty": {
       "path": "../../scripts/packages"
@@ -24,63 +65,36 @@
     "react-dom": "^19.2.7",
     "webpack": "^5.108.3"
   },
-  "exports": {
-    "./turbopack": {
-      "types": "./dist/turbopack.d.ts",
-      "import": "./dist/turbopack.js",
-      "require": "./dist/turbopack.js"
-    },
-    "./rspack": {
-      "types": "./dist/rspack.d.ts",
-      "import": "./dist/rspack.js",
-      "require": "./dist/rspack.js"
-    },
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
-    },
-    "./package.json": "./package.json"
-  },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "next",
-    "nextjs",
-    "nextjs-plugin",
-    "stylex",
-    "swc"
-  ],
-  "license": "MIT",
-  "main": "dist/index.js",
   "peerDependencies": {
     "next": ">=15.0.0",
     "next-rspack": "^16.2.9"
   },
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
+  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/nextjs-plugin#readme",
+  "keywords": [
+    "app-router",
+    "atomic-css",
+    "css-in-js",
+    "napi-rs",
+    "next",
+    "nextjs",
+    "nextjs-plugin",
+    "react",
+    "rspack",
+    "rust",
+    "stylex",
+    "swc",
+    "turbopack"
+  ],
+  "main": "dist/index.js",
   "peerDependenciesMeta": {
     "next-rspack": {
       "optional": true
     }
   },
-  "private": false,
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin",
-  "scripts": {
-    "build": "scripty --ts",
-    "check:artifacts": "scripty",
-    "clean": "del-cli dist",
-    "lint": "eslint . --color",
-    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
-    "postbuild": "pnpm run check:artifacts",
-    "precommit": "lint-staged",
-    "prepublishOnly": "pnpm run build",
-    "prepush": "lint-prepush",
-    "test": "echo \"Error: no test specified\" && exit 0",
-    "typecheck": "scripty --ts"
-  },
-  "sideEffects": false
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
+    "directory": "packages/nextjs-plugin"
+  }
 }

--- a/packages/postcss-plugin/README.md
+++ b/packages/postcss-plugin/README.md
@@ -1,16 +1,24 @@
-# PostCSS plugin with NAPI-RS StyleX compiler integration
+# @stylexswc/postcss-plugin
 
-> Part of the
+> PostCSS plugin that extracts StyleX styles with a Rust compiler (NAPI-RS +
+> SWC). Part of the
 > [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme)
-> workspace
+> workspace.
 
-`PostCSS plugin` for an unofficial
-[`napi-rs`](https://github.com/dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
-compiler that includes the StyleX SWC code transformation under the hood.
+This plugin scans your source files for [StyleX](https://stylexjs.com) code,
+compiles it with
+[`@stylexswc/rs-compiler`](https://www.npmjs.com/package/@stylexswc/rs-compiler)
+— a Rust implementation of the StyleX transform — and replaces an `@stylex;`
+directive in your CSS with the generated rules. Because it plugs into any
+PostCSS pipeline, it is the standard way to get CSS extraction where bundler
+plugins cannot run, most notably Next.js with Turbopack.
+
+This is a community project and is not affiliated with Meta. It tracks the
+official StyleX releases
+<!-- stylex-compatibility:start -->(currently compatible with StyleX v0.19.0)<!-- stylex-compatibility:end -->
+and requires Node.js 20 or newer.
 
 ## Installation
-
-To install the package, run the following command:
 
 ```bash
 npm install --save-dev @stylexswc/postcss-plugin
@@ -18,7 +26,7 @@ npm install --save-dev @stylexswc/postcss-plugin
 
 ## Usage
 
-Modify `postcss.config.js`. For example:
+Add the plugin to `postcss.config.js`:
 
 ```js
 module.exports = {
@@ -31,16 +39,34 @@ module.exports = {
 };
 ```
 
-Use on of the plugins to process JS/TS files with StyleX code. For example:
+Add a CSS file containing the `@stylex` directive to your project:
+
+```css
+/* stylex.css */
+
+/**
+ * The @stylex directive is replaced with the generated CSS during builds.
+ */
+@stylex;
+```
+
+And import it in your JS/TS entry point:
 
 ```js
-/// next.config.js
+import './stylex.css';
+```
+
+The JS/TS files themselves still need a StyleX transform so the class names
+exist at runtime — pair this plugin with one of the `@stylexswc` bundler
+plugins. For example with Next.js:
+
+```js
+// next.config.js
 const path = require('path');
 const stylexPlugin = require('@stylexswc/nextjs-plugin');
 const rootDir = __dirname;
 
 module.exports = stylexPlugin({
-  // Add any StyleX options here
   rsOptions: {
     aliases: {
       '@/*': [path.join(rootDir, '*')],
@@ -49,78 +75,39 @@ module.exports = stylexPlugin({
       type: 'commonJS',
     },
   },
-  // It's important to prevent creating a new CSS file with StyleX classes twice
+  // Important: prevents generating the StyleX CSS twice
   extractCSS: false,
 })({
   transpilePackages: ['@stylexjs/open-props'],
-  // Optionally, add any other Next.js config below
 });
 ```
 
 > [!WARNING]
-> Each plugin of `@stylexswc` namespace accepts an `extractCSS`
-> option to control CSS extraction. When using the `postcss` plugin, this option
-> should be set to `false` to avoid double generation of CSS files with StyleX
-> styles.
-
-&nbsp;
+> Every `@stylexswc` bundler plugin accepts an `extractCSS` option.
+> When this PostCSS plugin owns extraction, set `extractCSS: false` on the
+> bundler plugin to avoid generating the StyleX CSS twice.
 
 > [!NOTE]
-> This approach requires transpiling JS/TS files with StyleX code twice:
-> first the source code and then using the PostCSS plugin. To avoid this
-> behavior when using `NextJS`, use the regular `@stylexswc/nextjs-plugin`
-> passing the `transformCss` parameter to transform the generated CSS if it's
-> possible, for example:
->
-> ```js
-> /// next.config.js
->
-> //...other code
-> transformCss: async css => {
->   const postcss = require('postcss');
->   const result = await postcss([require('autoprefixer')]).process(css);
->   return result.css;
-> },
-> //...other code
-> ```
-
-Add the following CSS file to your project:
-
-```css
-/*[fileName].css*/
-
-/**
- * The @stylex directive is used by the @stylexswc/postcss-plugin.
- * It is automatically replaced with generated CSS during builds.
- */
-@stylex;
-```
-
-And import it in your JS/TS files:
-
-```js
-import '[fileName].css';
-```
+> This approach transforms JS/TS files with StyleX code twice: once for
+> the bundle and once inside the PostCSS plugin. On Next.js with Webpack you can
+> avoid that by skipping this plugin entirely and passing a `transformCss`
+> function to `@stylexswc/nextjs-plugin` instead. With Turbopack, the double
+> transform is currently the only way to extract CSS.
 
 ## Plugin Options
 
-The plugin accepts the following configuration options:
-
 > [!NOTE]
-> **Features:** The `include` and `exclude` options are exclusive to
-> this NAPI-RS compiler implementation and are not available in the official
-> StyleX Babel plugin.
+> The `include` and `exclude` options are exclusive to the Rust compiler
+> and are not available in the official StyleX Babel plugin.
 
 ### `include`
 
 - Type: `(string | RegExp)[]`
 - Default: auto-discovered
-- Description: **RS-compiler Only** An array of glob patterns or regular
-  expressions to include specific files for StyleX transformation. When
-  specified, only files matching at least one of these patterns will be
-  discovered and transformed. Patterns are matched against paths relative to the
-  current working directory. Supports regex lookahead/lookbehind for advanced
-  filtering.
+- Description: Glob patterns or regular expressions selecting the files to scan
+  and transform. When specified, only files matching at least one pattern are
+  processed. Patterns are matched against paths relative to the current working
+  directory. Regular expressions support lookahead and lookbehind.
 
 When omitted, the plugin auto-discovers source files in the project `cwd` and
 direct dependencies that use StyleX.
@@ -129,11 +116,11 @@ direct dependencies that use StyleX.
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular
-  expressions to exclude specific files from StyleX transformation. Files
-  matching any of these patterns will not be transformed, even if they match an
-  `include` pattern. Patterns are matched against paths relative to the current
-  working directory. Supports regex lookahead/lookbehind for advanced filtering.
+- Description: Glob patterns or regular expressions excluding files from the
+  transform. A file matching any exclude pattern is skipped even if it matches
+  an `include` pattern. Patterns are matched against paths relative to the
+  current working directory. Regular expressions support lookahead and
+  lookbehind.
 
 When `include` is omitted, the plugin automatically excludes common build and
 dependency folders (for example `node_modules`, `.next`, `dist`, `build`) to
@@ -144,8 +131,8 @@ keep discovery focused on source files.
 - Type: `StyleXOptions`
 - Optional
 - Default: `{}`
-- Description: StyleX compiler options passed to the StyleX compiler. For
-  standard StyleX options, see the
+- Description: StyleX compiler options passed to the compiler. For the standard
+  options, see the
   [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
 
 ### `useCSSLayers`
@@ -153,27 +140,28 @@ keep discovery focused on source files.
 - Type: `boolean`
 - Optional
 - Default: `false`
-- Description: Whether to use CSS layers for better style isolation
+- Description: Wraps the generated CSS in cascade layers for better style
+  isolation.
 
 ### `cwd`
 
 - Type: `string`
 - Optional
 - Default: `process.cwd()`
-- Description: Current working directory for resolving files. Dependency paths
-  and config resolution use this value.
+- Description: Working directory for resolving files. Dependency paths and
+  config resolution use this value.
 
 ### `isDev`
 
 - Type: `boolean`
 - Optional
-- Description: Whether the plugin is running in development mode
+- Description: Whether the plugin is running in development mode.
 
 ### `importSources`
 
 - Type: `Array<string | { from: string, as: string }>`
 - Optional
-- Description: Override import sources at the PostCSS plugin level.
+- Description: Overrides import sources at the PostCSS plugin level.
 
 When provided, takes precedence over `rsOptions.importSources`. When omitted,
 falls back to `rsOptions.importSources`, then the built-in defaults
@@ -181,9 +169,9 @@ falls back to `rsOptions.importSources`, then the built-in defaults
 
 ## Path Filtering Examples
 
-**Include only specific directories:**
+Include only specific directories:
 
-```javascript
+```js
 {
   '@stylexswc/postcss-plugin': {
     include: ['src/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
@@ -191,9 +179,9 @@ falls back to `rsOptions.importSources`, then the built-in defaults
 }
 ```
 
-**Exclude test and story files:**
+Exclude test and story files:
 
-```javascript
+```js
 {
   '@stylexswc/postcss-plugin': {
     include: ['src/**/*.{ts,tsx}'],
@@ -202,9 +190,9 @@ falls back to `rsOptions.importSources`, then the built-in defaults
 }
 ```
 
-**Using regular expressions:**
+Using regular expressions:
 
-```javascript
+```js
 {
   '@stylexswc/postcss-plugin': {
     include: ['src/**/*.{ts,tsx}', /components\/.*\.tsx$/],
@@ -213,29 +201,13 @@ falls back to `rsOptions.importSources`, then the built-in defaults
 }
 ```
 
-**Exclude node_modules except specific packages (using lookahead):**
+Exclude `node_modules` except specific packages (negative lookahead):
 
-```javascript
+```js
 {
   '@stylexswc/postcss-plugin': {
     include: ['src/**/*.{ts,tsx}', 'node_modules/**/*.js'],
-    // Exclude all node_modules except @stylexjs/open-props
     exclude: [/node_modules(?!\/@stylexjs\/open-props)/],
-  },
-}
-```
-
-**Transform only specific packages from node_modules:**
-
-```javascript
-{
-  '@stylexswc/postcss-plugin': {
-    include: [
-      'src/**/*.{ts,tsx}',
-      'node_modules/@stylexjs/open-props/**/*.js',
-      'node_modules/@my-org/design-system/**/*.js',
-    ],
-    exclude: ['**/*.test.*'],
   },
 }
 ```
@@ -247,6 +219,37 @@ Set `STYLEX_POSTCSS_DEBUG=1` to print resolved plugin inputs, including:
 - resolved `importSources` and where they came from
 - final `include` and `exclude` globs
 - discovered dependency directories
+
+## FAQ
+
+### When do I need this plugin instead of a bundler plugin?
+
+Whenever your bundler cannot extract CSS itself: Next.js with Turbopack is the
+main case, and any pipeline where CSS is produced exclusively through PostCSS
+(for example alongside Tailwind). If you build with Webpack, Rspack, Rollup, or
+Vite, the corresponding `@stylexswc` plugin extracts CSS on its own and this
+plugin is unnecessary.
+
+### My generated CSS appears twice. What happened?
+
+Both the bundler plugin and this plugin extracted it. Set `extractCSS: false` on
+the bundler plugin so the PostCSS plugin is the only producer.
+
+### Nothing is injected in place of `@stylex;`. What should I check?
+
+Confirm the CSS file with the directive is actually imported by your app, that
+your `include` globs match the files defining styles, and run with
+`STYLEX_POSTCSS_DEBUG=1` to see which files the plugin discovered.
+
+### Is this an official StyleX package?
+
+No. It is a community-maintained alternative to the official tooling and is not
+affiliated with or supported by Meta.
+
+## Documentation
+
+- [StyleX documentation](https://stylexjs.com)
+- [`@stylexswc/rs-compiler` compiler options](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
 
 ## License
 

--- a/packages/postcss-plugin/package.json
+++ b/packages/postcss-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexswc/postcss-plugin",
-  "description": "StyleX PostCSS plugin with NAPI-RS compiler",
+  "description": "PostCSS plugin that collects and extracts StyleX styles using a Rust NAPI-RS/SWC compiler. Ideal for Turbopack and custom CSS pipelines.",
   "version": "0.17.0",
   "private": false,
   "license": "MIT",
@@ -50,12 +50,24 @@
     "jest-chain-transform": "^0.0.8",
     "ts-jest": "^29.4.9"
   },
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
+  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/postcss-plugin#readme",
   "keywords": [
+    "atomic-css",
+    "css-extraction",
+    "css-in-js",
+    "napi-rs",
     "postcss",
     "postcss-plugin",
+    "rust",
     "stylex",
-    "swc"
+    "swc",
+    "turbopack"
   ],
   "main": "dist/index.js",
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
+    "directory": "packages/postcss-plugin"
+  }
 }

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -1,123 +1,174 @@
-# Rollup plugin with NAPI-RS StyleX compiler integration
+# @stylexswc/rollup-plugin
 
-> Part of the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme) workspace
+> StyleX plugin for Rollup, powered by a Rust compiler (NAPI-RS + SWC). Part of
+> the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme)
+> workspace.
 
-`Rollup plugin` for an unofficial
-[`napi-rs`](https://github.com/dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
-compiler that includes the StyleX SWC code transformation under the hood.
+This plugin compiles [StyleX](https://stylexjs.com) code in your Rollup build
+with
+[`@stylexswc/rs-compiler`](https://www.npmjs.com/package/@stylexswc/rs-compiler),
+a Rust implementation of the StyleX transform, instead of the official Babel
+plugin. Your StyleX code stays exactly the same — only the build step changes,
+with per-file transforms 2x to 5x faster than Babel
+([performance](https://github.com/Dwlad90/stylex-swc-plugin#performance)).
+The extracted CSS is processed with [Lightning CSS](https://lightningcss.dev)
+before it is written to disk.
+
+This is a community project and is not affiliated with Meta. It tracks the
+official StyleX releases
+<!-- stylex-compatibility:start -->(currently compatible with StyleX v0.19.0)<!-- stylex-compatibility:end -->
+and requires Node.js 20 or newer.
 
 ## Installation
 
-To install the package, run the following command:
-
 ```bash
-npm install --save-dev @stylexswc/webpack-plugin
+npm install --save-dev @stylexswc/rollup-plugin
 ```
 
-Please install `@stylexswc/rs-compiler` if you haven't done so already:
+The Rust compiler (`@stylexswc/rs-compiler`) is installed automatically as a
+dependency. Your application still needs the StyleX runtime:
 
 ```bash
-npm install --save-dev @stylexswc/rs-compiler
+npm install @stylexjs/stylex
 ```
 
 ## Usage
 
-Modify Webpack config. For example:
+Add the plugin to your Rollup config:
 
 ```js
-const StylexPlugin = require('@stylexswc/webpack-plugin');
-const path = require('path');
+// rollup.config.mjs
+import stylexPlugin from '@stylexswc/rollup-plugin';
 
-const config = (env, argv) => ({
-  entry: {
-    main: './js/index.js',
-  },
+export default {
+  input: 'src/index.js',
   output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js',
+    file: 'dist/bundle.js',
+    format: 'cjs',
   },
   plugins: [
-    new StylexPlugin({
-      filename: 'styles.[contenthash].css',
-      dev: argv.mode === 'development',
+    stylexPlugin.default({
+      fileName: 'stylex.css',
+      rsOptions: {
+        dev: process.env.NODE_ENV !== 'production',
+      },
     }),
   ],
-  cache: true,
-});
-
-module.exports = config;
+};
 ```
 
-## Plugin Options
+> [!NOTE]
+> In an ESM config file the plugin is exposed on the `default` property
+> because the package is compiled to CommonJS — hence
+> `stylexPlugin.default(...)`. With a CommonJS config
+> (`const stylexPlugin = require('@stylexswc/rollup-plugin')`), call
+> `stylexPlugin(...)` directly.
 
-The plugin accepts the following configuration options:
+A complete working setup, including JSX handling via `@rollup/plugin-swc`, lives
+in the
+[`rollup-example` app](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/apps/rollup-example).
+
+## Plugin Options
 
 ### `rsOptions`
 
 - Type: `StyleXOptions`
 - Optional
 - Default: `{}`
-- Description: StyleX compiler options that extend from `@stylexswc/rs-compiler`.
-  For standard StyleX options, see the [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
+- Description: StyleX compiler options passed to `@stylexswc/rs-compiler`. For
+  the standard options, see the
+  [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
 
 > [!NOTE]
-> **New Features:** The `include` and `exclude` options are exclusive to this NAPI-RS compiler implementation and are not available in the official StyleX Babel plugin.
+> The `include` and `exclude` options are exclusive to the Rust compiler
+> and are not available in the official StyleX Babel plugin.
 
 #### `rsOptions.include`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular expressions to include specific files for StyleX transformation.
-  When specified, only files matching at least one of these patterns will be transformed.
-  Patterns are matched against paths relative to the current working directory.
-  Supports regex lookahead/lookbehind for advanced filtering.
+- Description: Glob patterns or regular expressions selecting the files to
+  transform. When specified, only files matching at least one pattern are
+  transformed. Patterns are matched against paths relative to the current
+  working directory. Regular expressions support lookahead and lookbehind.
 
 #### `rsOptions.exclude`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular expressions to exclude specific files from StyleX transformation.
-  Files matching any of these patterns will not be transformed, even if they match an `include` pattern.
-  Patterns are matched against paths relative to the current working directory.
-  Supports regex lookahead/lookbehind for advanced filtering.
+- Description: Glob patterns or regular expressions excluding files from the
+  transform. A file matching any exclude pattern is skipped even if it matches
+  an `include` pattern. Patterns are matched against paths relative to the
+  current working directory. Regular expressions support lookahead and
+  lookbehind.
 
-### Path Filtering Examples
+### `fileName`
 
-**Include only specific directories:**
+- Type: `string`
+- Optional
+- Default: `'stylex.css'`
+- Description: Name of the emitted CSS asset.
 
-```javascript
-stylexPlugin({
+### `useCSSLayers`
+
+- Type: `boolean`
+- Optional
+- Default: `false`
+- Description: Wraps the generated CSS in cascade layers for better style
+  isolation.
+
+### `lightningcssOptions`
+
+- Type: `TransformOptions`
+- Optional
+- Description: Options forwarded to the Lightning CSS transform that
+  post-processes the extracted CSS (everything except `code`, `filename`, and
+  `visitor`).
+
+### `extractCSS`
+
+- Type: `boolean`
+- Optional
+- Default: `true`
+- Description: Controls whether the generated CSS is extracted into a separate
+  file.
+
+## Path Filtering Examples
+
+Include only specific directories:
+
+```js
+stylexPlugin.default({
   rsOptions: {
     include: ['src/**/*.{ts,tsx,js,jsx}'],
   },
-})
+});
 ```
 
-**Exclude test and build files:**
+Exclude test and build files:
 
-```javascript
-stylexPlugin({
+```js
+stylexPlugin.default({
   rsOptions: {
     exclude: ['**/*.test.*', '**/*.spec.*', '**/dist/**'],
   },
-})
+});
 ```
 
-**Using RegExp with lookahead/lookbehind - exclude node_modules except specific packages:**
+Exclude all of `node_modules` except specific packages (negative lookahead):
 
-```javascript
-stylexPlugin({
+```js
+stylexPlugin.default({
   rsOptions: {
-    // Exclude all node_modules except @stylexjs packages
     exclude: [/node_modules(?!\/@stylexjs)/],
   },
-})
+});
 ```
 
-**Transform only specific packages from node_modules:**
+Transform only specific packages from `node_modules`:
 
-```javascript
-stylexPlugin({
+```js
+stylexPlugin.default({
   rsOptions: {
     include: [
       'src/**/*.{ts,tsx,js,jsx}',
@@ -125,42 +176,40 @@ stylexPlugin({
     ],
     exclude: ['**/*.test.*'],
   },
-})
+});
 ```
 
-### `fileName`
+## FAQ
 
-- Type: `string`
-- Optional
-- Default: `'stylex.css'`
-- Description: Name of the output CSS file
+### Do I still need `@stylexjs/babel-plugin`?
 
-### `useCSSLayers`
+No. This plugin replaces the Babel plugin in your build. You only keep
+`@stylexjs/stylex` as your app's runtime dependency, and your `stylex.create` /
+`stylex.props` code does not change.
 
-- Type: `boolean`
-- Optional
-- Default: `false`
-- Description: Enable CSS Layers support for better style isolation
+### Does this work together with other Rollup plugins?
 
-### `lightningcssOptions`
+Yes. Run StyleX after resolution/commonjs plugins and alongside your transpiler
+plugin (SWC or Babel). The
+[example app](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/apps/rollup-example)
+shows a full pipeline with `@rollup/plugin-swc`.
 
-- Type: `TransformOptions`
-- Optional
-- Description: LightningCSS transform options (excluding code, filename, and
-  visitor properties)
+### How do I post-process the generated CSS?
 
-### `extractCSS`
+The plugin already runs Lightning CSS on the extracted stylesheet; tune it with
+`lightningcssOptions` (for example `targets` from a browserslist query).
 
-- Type: `boolean`
-- Optional
-- Default: `true`
-- Description: Controls whether CSS should be extracted into a separate file
+### Is this an official StyleX package?
+
+No. It is a community-maintained alternative to the official tooling and is not
+affiliated with or supported by Meta.
 
 ## Documentation
 
-- [StyleX Documentation](https://stylexjs.com)
-- [NAPI-RS compiler for StyleX](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
+- [StyleX documentation](https://stylexjs.com)
+- [`@stylexswc/rs-compiler` compiler options](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
 
 ## License
 
-MIT — see [LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)
+MIT — see
+[LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexswc/rollup-plugin",
-  "description": "StyleX rollup plugin with NAPI-RS compiler",
+  "description": "StyleX plugin for Rollup powered by a Rust NAPI-RS/SWC compiler. Fast StyleX transforms and CSS extraction without Babel.",
   "version": "0.17.0",
   "private": false,
   "license": "MIT",
@@ -45,12 +45,24 @@
     "jest-chain-transform": "^0.0.8",
     "rollup": "^4.62.2"
   },
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
+  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/rollup-plugin#readme",
   "keywords": [
+    "atomic-css",
+    "css-extraction",
+    "css-in-js",
+    "lightningcss",
+    "napi-rs",
+    "rollup",
     "rollup-plugin",
-    "rolup",
+    "rust",
     "stylex",
     "swc"
   ],
   "main": "dist/index.js",
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
+    "directory": "packages/rollup-plugin"
+  }
 }

--- a/packages/rspack-plugin/README.md
+++ b/packages/rspack-plugin/README.md
@@ -1,33 +1,42 @@
-# Rspack plugin with NAPI-RS StyleX compiler integration
+# @stylexswc/rspack-plugin
 
-> Part of the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme) workspace
+> StyleX plugin for Rspack, powered by a Rust compiler (NAPI-RS + SWC). Part of
+> the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme)
+> workspace.
 
-`Rspack plugin` for an unofficial
-[`napi-rs`](https://github.com/dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
-compiler that includes the StyleX SWC code transformation under the hood.
-
+This plugin compiles [StyleX](https://stylexjs.com) code in your Rspack build
+with
+[`@stylexswc/rs-compiler`](https://www.npmjs.com/package/@stylexswc/rs-compiler),
+a Rust implementation of the StyleX transform, instead of the official Babel
+plugin. Your StyleX code stays exactly the same — only the build step changes,
+with per-file transforms 2x to 5x faster than Babel
+([performance](https://github.com/Dwlad90/stylex-swc-plugin#performance)).
 StyleX rules are extracted through virtual CSS imports and appended to a
-dedicated CSS chunk. For Next.js projects use
-[`@stylexswc/nextjs-plugin/rspack`](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/nextjs-plugin),
-which wires this plugin into `next-rspack`.
+dedicated CSS chunk.
+
+This is a community project and is not affiliated with Meta. It tracks the
+official StyleX releases
+<!-- stylex-compatibility:start -->(currently compatible with StyleX v0.19.0)<!-- stylex-compatibility:end -->
+and requires Node.js 20 or newer. For Next.js projects, use
+[`@stylexswc/nextjs-plugin/rspack`](https://www.npmjs.com/package/@stylexswc/nextjs-plugin),
+which wires this plugin into `next-rspack` for you.
 
 ## Installation
-
-To install the package, run the following command:
 
 ```bash
 npm install --save-dev @stylexswc/rspack-plugin
 ```
 
-Please install `@stylexswc/rs-compiler` if you haven't done so already:
+The Rust compiler (`@stylexswc/rs-compiler`) is installed automatically as a
+dependency. Your application still needs the StyleX runtime:
 
 ```bash
-npm install --save-dev @stylexswc/rs-compiler
+npm install @stylexjs/stylex
 ```
 
 ## Usage
 
-Modify Rspack config. For example:
+Add the plugin to your Rspack config:
 
 ```js
 const StylexPlugin = require('@stylexswc/rspack-plugin');
@@ -43,17 +52,8 @@ const config = (env, argv) => ({
   },
   plugins: [
     new StylexPlugin({
-      // ... Other StyleX options
-      transformCss: async (css, filePath) => {
-        const postcss = require('postcss');
-        const result = await postcss([require('autoprefixer')]).process(css, {
-          from: filePath,
-          map: {
-            inline: false,
-            annotation: false,
-          },
-        });
-        return result.css;
+      rsOptions: {
+        dev: argv.mode === 'development',
       },
     }),
   ],
@@ -70,7 +70,7 @@ rule with its StyleX loader. Two user-visible consequences:
 - `loaderOrder` maps to `Rule.enforce`: `'first'` (default) runs the StyleX
   transform before normal loaders (`enforce: 'pre'`), `'last'` runs it after
   (`enforce: 'post'`).
-- `node_modules` is **excluded by default**. Rspack invokes JS loaders across a
+- `node_modules` is excluded by default. Rspack invokes JS loaders across a
   native boundary, so touching every module just to bail out is not free.
   Packages that ship untransformed StyleX source must be allowlisted via the
   `stylexPackages` option (path fragments, default `['@stylexjs/']`):
@@ -83,11 +83,11 @@ new StylexPlugin({
 
 ### Source maps
 
-The StyleX loader automatically forwards the previous loader's source map to
-the compiler as `inputSourceMap`. With `loaderOrder: 'last'` — where the
-loader receives code already rewritten by earlier loaders — this keeps debug
-source-map annotations (`debug: true`) and the emitted source map pointing at
-the original authored file. See the
+The StyleX loader automatically forwards the previous loader's source map to the
+compiler as `inputSourceMap`. With `loaderOrder: 'last'` — where the loader
+receives code already rewritten by earlier loaders — this keeps debug source-map
+annotations (`debug: true`) and the emitted source map pointing at the original
+authored file. See the
 [`inputSourceMap` compiler option](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler#inputsourcemap)
 for details.
 
@@ -108,14 +108,14 @@ for the shared option semantics.
 - Type: `StyleXOptions['importSources']`
 - Default: `['stylex', '@stylexjs/stylex']`
 
-Specify where StyleX will be imported from.
+Specify where StyleX is imported from.
 
 ### `useCSSLayers`
 
 - Type: `UseLayersType`
 - Default: `false`
 
-Whether to use CSS layers.
+Whether to wrap the generated CSS in cascade layers.
 
 ### `nextjsMode`
 
@@ -129,9 +129,20 @@ Enable when the plugin is driven by the Next.js integration.
 - Type:
   `(css: string, filePath: string | undefined) => string | Buffer | Promise<string | Buffer>`
 
-Post-process the extracted CSS. Since the plugin only injects CSS after all
-loaders, `postcss-loader` cannot be used on it — invoke `postcss()` here
-instead.
+Post-process the extracted CSS. The plugin injects CSS after all loaders have
+run, so `postcss-loader` cannot be used on it — invoke `postcss()` here instead:
+
+```js
+new StylexPlugin({
+  transformCss: async (css, filePath) => {
+    const postcss = require('postcss');
+    const result = await postcss([require('autoprefixer')]).process(css, {
+      from: filePath,
+    });
+    return result.css;
+  },
+});
+```
 
 ### `extractCSS`
 
@@ -145,8 +156,8 @@ Whether to extract CSS into the dedicated StyleX chunk.
 - Type: `'first' | 'last'`
 - Default: `'first'`
 
-When the StyleX transformation is applied relative to other rspack loaders —
-see [Loader behavior](#loader-behavior).
+When the StyleX transformation runs relative to other Rspack loaders — see
+[Loader behavior](#loader-behavior).
 
 ### `cacheGroup`
 
@@ -163,8 +174,44 @@ split into files, cached, or grouped.
 
 `node_modules` path fragments that must be processed by the StyleX loader.
 
+## FAQ
+
+### Do I still need `@stylexjs/babel-plugin`?
+
+No. This plugin replaces the Babel plugin in your build. You only keep
+`@stylexjs/stylex` as your app's runtime dependency, and your `stylex.create` /
+`stylex.props` code does not change.
+
+### My styles from a component library are missing. Why?
+
+`node_modules` is excluded by default for performance. Add the package to
+`stylexPackages` (for example
+`stylexPackages: ['@stylexjs/', 'my-design-system']`) so the StyleX loader
+processes it.
+
+### How is this different from `@stylexswc/webpack-plugin`?
+
+Same options, same compiler — but this package registers its loader through
+Rspack's native rule system instead of patching the webpack loader chain, which
+is both faster and more predictable in Rspack.
+
+### Can I use this with Next.js?
+
+Yes, through `@stylexswc/nextjs-plugin/rspack`, which composes this plugin with
+the `next-rspack` adapter for you.
+
+### Is this an official StyleX package?
+
+No. It is a community-maintained alternative to the official tooling and is not
+affiliated with or supported by Meta.
+
 ## Documentation
 
-- [StyleX Documentation](https://stylexjs.com)
-- [SWC Documentation](https://swc.rs)
-- [Rspack Documentation](https://rspack.rs)
+- [StyleX documentation](https://stylexjs.com)
+- [Rspack documentation](https://rspack.rs)
+- [`@stylexswc/rs-compiler` compiler options](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
+
+## License
+
+MIT — see
+[LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -1,7 +1,38 @@
 {
   "name": "@stylexswc/rspack-plugin",
-  "description": "StyleX Rspack plugin with NAPI-RS compiler",
+  "description": "StyleX plugin for Rspack powered by a Rust NAPI-RS/SWC compiler. Fast StyleX transforms and CSS extraction without Babel.",
   "version": "0.17.0",
+  "private": false,
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "scripts": {
+    "build": "scripty --ts",
+    "check:artifacts": "scripty",
+    "clean": "del-cli dist",
+    "lint": "eslint . --color",
+    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
+    "postbuild": "pnpm run check:artifacts",
+    "precommit": "lint-staged",
+    "prepublishOnly": "pnpm run build",
+    "prepush": "lint-prepush",
+    "test": "vitest run",
+    "typecheck": "scripty --ts"
+  },
   "config": {
     "scripty": {
       "path": "../../scripts/packages"
@@ -21,43 +52,24 @@
     "@types/node": "^26.1.0",
     "vitest": "^4.1.9"
   },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
-    },
-    "./package.json": "./package.json"
-  },
-  "files": [
-    "dist"
-  ],
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
+  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/rspack-plugin#readme",
   "keywords": [
+    "atomic-css",
+    "css-extraction",
+    "css-in-js",
+    "napi-rs",
+    "react",
     "rspack",
     "rspack-plugin",
+    "rust",
     "stylex",
     "swc"
   ],
-  "license": "MIT",
   "main": "dist/index.js",
-  "private": false,
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin",
-  "scripts": {
-    "build": "scripty --ts",
-    "check:artifacts": "scripty",
-    "clean": "del-cli dist",
-    "lint": "eslint . --color",
-    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
-    "postbuild": "pnpm run check:artifacts",
-    "precommit": "lint-staged",
-    "prepublishOnly": "pnpm run build",
-    "prepush": "lint-prepush",
-    "test": "vitest run",
-    "typecheck": "scripty --ts"
-  },
-  "sideEffects": false
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
+    "directory": "packages/rspack-plugin"
+  }
 }

--- a/packages/turbopack-plugin/README.md
+++ b/packages/turbopack-plugin/README.md
@@ -1,37 +1,50 @@
-# Turbopack loader with NAPI-RS StyleX compiler integration
+# @stylexswc/turbopack-plugin
 
-> Part of the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme) workspace
+> StyleX loader for Next.js Turbopack, powered by a Rust compiler (NAPI-RS +
+> SWC). Part of the
+> [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme)
+> workspace.
 
-`Turbopack loader` for an unofficial
-[`napi-rs`](https://github.com/dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
-compiler that includes the StyleX SWC code transformation under the hood.
+This loader compiles [StyleX](https://stylexjs.com) code in Turbopack builds
+with
+[`@stylexswc/rs-compiler`](https://www.npmjs.com/package/@stylexswc/rs-compiler),
+a Rust implementation of the StyleX transform, instead of the official Babel
+plugin. Your StyleX code stays exactly the same — only the build step changes,
+with per-file transforms 2x to 5x faster than Babel
+([performance](https://github.com/Dwlad90/stylex-swc-plugin#performance)).
+
+This is a community project and is not affiliated with Meta. It tracks the
+official StyleX releases
+<!-- stylex-compatibility:start -->(currently compatible with StyleX v0.19.0)<!-- stylex-compatibility:end -->
+and requires Node.js 20 or newer. Most Next.js projects should reach for
+[`@stylexswc/nextjs-plugin`](https://www.npmjs.com/package/@stylexswc/nextjs-plugin),
+whose `/turbopack` export configures this loader for you.
 
 ## Installation
-
-To install the package, run the following command:
 
 ```bash
 npm install --save-dev @stylexswc/turbopack-plugin
 ```
 
-Please install `@stylexswc/rs-compiler` if you haven't done so already:
+The Rust compiler (`@stylexswc/rs-compiler`) is installed automatically as a
+dependency. Your application still needs the StyleX runtime:
 
 ```bash
-npm install --save-dev @stylexswc/rs-compiler
+npm install @stylexjs/stylex
 ```
 
 ## Usage
 
 > [!IMPORTANT]
-> **Turbopack Limitation**: Turbopack does not support webpack
-> plugins
-> ([see Next.js docs](https://nextjs.org/docs/app/api-reference/turbopack#webpack-plugins)).
-> This loader only compiles StyleX code but **does not extract CSS**.
+> Turbopack does not support webpack plugins
+> ([see Next.js docs](https://nextjs.org/docs/app/api-reference/turbopack#webpack-plugins)),
+> so this loader only compiles StyleX code — it does not extract CSS.
 >
-> For CSS extraction, you must use the
-> [`@stylexswc/postcss-plugin`](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/postcss-plugin#readme) in your `postcss.config.js`:
+> For CSS extraction, configure
+> [`@stylexswc/postcss-plugin`](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/postcss-plugin#readme)
+> in your `postcss.config.js`:
 >
-> ```javascript
+> ```js
 > // postcss.config.js
 > module.exports = {
 >   plugins: {
@@ -83,22 +96,20 @@ export default nextConfig;
 
 - Type: `Partial<StyleXOptions>`
 - Optional
-- Description: StyleX compiler options that will be passed to the NAPI-RS
-  compiler. For standard StyleX options, see the
+- Description: StyleX compiler options passed to `@stylexswc/rs-compiler`. For
+  the standard options, see the
   [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
 
 > [!NOTE]
-> **New Features:** The `include` and `exclude` options are exclusive to
-> this NAPI-RS compiler implementation and are not available in the official
-> StyleX Babel plugin.
+> The `include` and `exclude` options are exclusive to the Rust compiler
+> and are not available in the official StyleX Babel plugin.
 
 ##### `rsOptions.include`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular
-  expressions to include specific files for StyleX transformation. When
-  specified, only files matching at least one of these patterns will be
+- Description: Glob patterns or regular expressions selecting the files to
+  transform. When specified, only files matching at least one pattern are
   transformed. Patterns are matched against paths relative to the current
   working directory.
 
@@ -106,24 +117,24 @@ export default nextConfig;
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular
-  expressions to exclude specific files from StyleX transformation. Files
-  matching any of these patterns will not be transformed, even if they match an
-  `include` pattern. Patterns are matched against paths relative to the current
-  working directory.
+- Description: Glob patterns or regular expressions excluding files from the
+  transform. A file matching any exclude pattern is skipped even if it matches
+  an `include` pattern. Patterns are matched against paths relative to the
+  current working directory.
 
 #### `stylexImports`
 
 - Type: `Array<string | { as: string, from: string }>`
 - Default: `['stylex', '@stylexjs/stylex']`
-- Description: Specifies where StyleX will be imported from. Supports both
-  string paths and import aliases.
+- Description: Specifies where StyleX is imported from. Supports both string
+  paths and import aliases.
 
 #### `useCSSLayers`
 
 - Type: `UseLayersType`
 - Default: `false`
-- Description: Enables CSS cascade layers support for better style isolation.
+- Description: Wraps the generated CSS in cascade layers for better style
+  isolation.
 
 #### `nextjsMode`
 
@@ -137,7 +148,9 @@ export default nextConfig;
 - Type: `boolean`
 - Optional
 - Default: `true`
-- Description: Controls whether CSS should be extracted into a separate file
+- Description: Controls whether CSS should be extracted into a separate file.
+  Under Turbopack the loader cannot extract CSS itself (see the note above), so
+  extraction is handled by the PostCSS plugin.
 
 ### Advanced Options
 
@@ -146,12 +159,12 @@ export default nextConfig;
 - Type:
   `(css: string, filePath: string | undefined) => string | Buffer | Promise<string | Buffer>`
 - Optional
-- Description: Custom CSS transformation function. Since the loader injects CSS
-  after all loaders, use this to apply PostCSS or other CSS transformations.
+- Description: Custom CSS post-processing hook, applied when the loader emits
+  CSS. Use it to run PostCSS or other CSS transformations.
 
 ### Example Configuration
 
-```typescript
+```ts
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
@@ -163,9 +176,7 @@ const nextConfig: NextConfig = {
           options: {
             rsOptions: {
               dev: process.env.NODE_ENV !== 'production',
-              // Include only specific directories
               include: ['app/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
-              // Exclude test files and stories
               exclude: ['**/*.test.*', '**/*.stories.*', '**/__tests__/**'],
             },
             stylexImports: ['@stylexjs/stylex'],
@@ -179,114 +190,68 @@ const nextConfig: NextConfig = {
 export default nextConfig;
 ```
 
-#### Path Filtering Examples
+### Path Filtering Examples
 
-**Include only specific directories:**
+Include only specific directories:
 
-```typescript
-import type { NextConfig } from 'next';
-
-const nextConfig: NextConfig = {
-  experimental: {
-    turbo: {
-      rules: {
-        '*.tsx': {
-          loaders: ['@stylexswc/turbopack-plugin/loader'],
-          options: {
-            rsOptions: {
-              include: ['app/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
-            },
-          },
-        },
-      },
-    },
+```ts
+options: {
+  rsOptions: {
+    include: ['app/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
   },
-};
-
-export default nextConfig;
+},
 ```
 
-**Exclude test and build files:**
+Exclude test and build files:
 
-```typescript
-import type { NextConfig } from 'next';
-
-const nextConfig: NextConfig = {
-  experimental: {
-    turbo: {
-      rules: {
-        '*.tsx': {
-          loaders: ['@stylexswc/turbopack-plugin/loader'],
-          options: {
-            rsOptions: {
-              exclude: ['**/*.test.*', '**/*.spec.*', '**/dist/**'],
-            },
-          },
-        },
-      },
-    },
+```ts
+options: {
+  rsOptions: {
+    exclude: ['**/*.test.*', '**/*.spec.*', '**/dist/**'],
   },
-};
-
-export default nextConfig;
+},
 ```
 
-**Using regular expressions:**
+Using regular expressions (exclude always takes precedence over include):
 
-```typescript
-import type { NextConfig } from 'next';
-
-const nextConfig: NextConfig = {
-  experimental: {
-    turbo: {
-      rules: {
-        '*.tsx': {
-          loaders: ['@stylexswc/turbopack-plugin/loader'],
-          options: {
-            rsOptions: {
-              include: [/app\/.*\.tsx$/, /components\/.*\.tsx$/],
-              exclude: [/\.test\./, /\.stories\./],
-            },
-          },
-        },
-      },
-    },
+```ts
+options: {
+  rsOptions: {
+    include: [/app\/.*\.tsx$/, /components\/.*\.tsx$/],
+    exclude: [/\.test\./, /\.stories\./],
   },
-};
-
-export default nextConfig;
+},
 ```
 
-**Combined include and exclude (exclude takes precedence):**
+## FAQ
 
-```typescript
-import type { NextConfig } from 'next';
+### Why are my styles missing in the browser?
 
-const nextConfig: NextConfig = {
-  experimental: {
-    turbo: {
-      rules: {
-        '*.tsx': {
-          loaders: ['@stylexswc/turbopack-plugin/loader'],
-          options: {
-            rsOptions: {
-              include: ['app/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
-              exclude: ['**/__tests__/**', '**/__mocks__/**'],
-            },
-          },
-        },
-      },
-    },
-  },
-};
+The loader compiles StyleX code but cannot extract CSS under Turbopack. Make
+sure `@stylexswc/postcss-plugin` is configured in `postcss.config.js` and that
+your app imports a CSS file containing the `@stylex;` directive.
 
-export default nextConfig;
-```
+### Should I use this package directly or `@stylexswc/nextjs-plugin`?
+
+Prefer `@stylexswc/nextjs-plugin` — its `/turbopack` export sets up this loader
+and keeps one config surface across Webpack, Rspack, and Turbopack. Use this
+package directly only if you need raw control over Turbopack rules.
+
+### Do I still need `@stylexjs/babel-plugin`?
+
+No. The loader replaces the Babel plugin in your build. You only keep
+`@stylexjs/stylex` as your app's runtime dependency, and your `stylex.create` /
+`stylex.props` code does not change.
+
+### Is this an official StyleX package?
+
+No. It is a community-maintained alternative to the official tooling and is not
+affiliated with or supported by Meta.
 
 ## Documentation
 
-- [StyleX Documentation](https://stylexjs.com)
-- [NAPI-RS compiler for StyleX](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
+- [StyleX documentation](https://stylexjs.com)
+- [`@stylexswc/rs-compiler` compiler options](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
 
 ## Acknowledgments
 
@@ -295,4 +260,5 @@ This loader was inspired by
 
 ## License
 
-MIT — see [LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)
+MIT — see
+[LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)

--- a/packages/turbopack-plugin/package.json
+++ b/packages/turbopack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylexswc/turbopack-plugin",
-  "description": "StyleX turbopack loader with NAPI-RS compiler",
+  "description": "StyleX loader for Next.js Turbopack powered by a Rust NAPI-RS/SWC compiler.",
   "version": "0.17.0",
   "private": false,
   "license": "MIT",
@@ -54,12 +54,25 @@
     "@types/node": "^26.1.0",
     "webpack": "^5.108.3"
   },
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
+  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/turbopack-plugin#readme",
   "keywords": [
+    "atomic-css",
+    "css-in-js",
+    "napi-rs",
+    "nextjs",
+    "react",
+    "rust",
     "stylex",
     "swc",
     "turbopack",
+    "turbopack-loader",
     "turbopack-plugin"
   ],
   "main": "dist/index.js",
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
+    "directory": "packages/turbopack-plugin"
+  }
 }

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -1,28 +1,43 @@
-# Unplugin with NAPI-RS StyleX compiler integration
+# @stylexswc/unplugin
 
-> Part of the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme) workspace
+> Universal StyleX plugin for Vite, webpack, Rspack, Rollup, esbuild, Farm,
+> Rsbuild, Nuxt, and Astro — powered by a Rust compiler (NAPI-RS + SWC). Part of
+> the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme)
+> workspace.
 
-`Unplugin` for an unofficial
-[`napi-rs`](https://github.com/dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
-compiler that includes the StyleX SWC code transformation under the hood.
+Built on [unplugin](https://unplugin.unjs.io/), this package gives every major
+bundler the same [StyleX](https://stylexjs.com) integration: it compiles your
+StyleX code with
+[`@stylexswc/rs-compiler`](https://www.npmjs.com/package/@stylexswc/rs-compiler),
+a Rust implementation of the StyleX transform, and extracts the generated CSS.
+Your StyleX code stays exactly the same — only the build step changes, with
+per-file transforms 2x to 5x faster than Babel
+([performance](https://github.com/Dwlad90/stylex-swc-plugin#performance)).
+
+This is a community project and is not affiliated with Meta. It tracks the
+official StyleX releases
+<!-- stylex-compatibility:start -->(currently compatible with StyleX v0.19.0)<!-- stylex-compatibility:end -->
+and requires Node.js 20 or newer.
 
 ## Installation
-
-To install the package, run the following command:
 
 ```bash
 npm install --save-dev @stylexswc/unplugin
 ```
 
+The Rust compiler (`@stylexswc/rs-compiler`) is installed automatically as a
+dependency. Your application still needs the StyleX runtime:
+
+```bash
+npm install @stylexjs/stylex
+```
+
 ## Usage
 
-To use the plugin, you need to add it to your build tool configuration.
-
-For every plugin have an example of how to use it in
+Import the entry point matching your build tool and add it to the plugin list. A
+working example for each bundler lives in the
 [`apps/{pluginName}-unplugin-example`](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/apps)
-folder.
-
-## Plugins
+folders.
 
 <details>
 <summary>Vite</summary><br>
@@ -32,11 +47,7 @@ folder.
 import StylexRsPlugin from '@stylexswc/unplugin/vite';
 
 export default defineConfig({
-  plugins: [
-    StylexRsPlugin({
-      /* options */
-    }),
-  ],
+  plugins: [StylexRsPlugin({/* options */})],
 });
 ```
 
@@ -50,11 +61,7 @@ export default defineConfig({
 import StylexRsPlugin from '@stylexswc/unplugin/rollup';
 
 export default {
-  plugins: [
-    StylexRsPlugin({
-      /* options */
-    }),
-  ],
+  plugins: [StylexRsPlugin({/* options */})],
 };
 ```
 
@@ -67,11 +74,7 @@ export default {
 // webpack.config.js
 module.exports = {
   /* ... */
-  plugins: [
-    require('@stylexswc/unplugin/webpack')({
-      /* options */
-    }),
-  ],
+  plugins: [require('@stylexswc/unplugin/webpack')({/* options */})],
 };
 ```
 
@@ -84,11 +87,7 @@ module.exports = {
 // rspack.config.js
 module.exports = {
   /* ... */
-  plugins: [
-    require('@stylexswc/unplugin/rspack')({
-      /* options */
-    }),
-  ],
+  plugins: [require('@stylexswc/unplugin/rspack')({/* options */})],
 };
 ```
 
@@ -100,14 +99,7 @@ module.exports = {
 ```ts
 // nuxt.config.js
 export default defineNuxtConfig({
-  modules: [
-    [
-      '@stylexswc/unplugin/nuxt',
-      {
-        /* options */
-      },
-    ],
-  ],
+  modules: [['@stylexswc/unplugin/nuxt', {/* options */}]],
 });
 ```
 
@@ -123,11 +115,7 @@ export default defineNuxtConfig({
 // vue.config.js
 module.exports = {
   configureWebpack: {
-    plugins: [
-      require('@stylexswc/unplugin/webpack')({
-        /* options */
-      }),
-    ],
+    plugins: [require('@stylexswc/unplugin/webpack')({/* options */})],
   },
 };
 ```
@@ -157,27 +145,31 @@ build({
 
 - Type: `Partial<StyleXOptions>`
 - Optional
-- Description: StyleX compiler options that will be passed to the NAPI-RS compiler.
-  For standard StyleX options, see the [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
+- Description: StyleX compiler options passed to `@stylexswc/rs-compiler`. For
+  the standard options, see the
+  [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
 
 > [!NOTE]
-> **New Features:** The `include` and `exclude` options are exclusive to this NAPI-RS compiler implementation and are not available in the official StyleX Babel plugin.
+> The `include` and `exclude` options are exclusive to the Rust compiler
+> and are not available in the official StyleX Babel plugin.
 
 ##### `rsOptions.include`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular expressions to include specific files for StyleX transformation.
-  When specified, only files matching at least one of these patterns will be transformed.
-  Patterns are matched against paths relative to the current working directory.
+- Description: Glob patterns or regular expressions selecting the files to
+  transform. When specified, only files matching at least one pattern are
+  transformed. Patterns are matched against paths relative to the current
+  working directory.
 
 ##### `rsOptions.exclude`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular expressions to exclude specific files from StyleX transformation.
-  Files matching any of these patterns will not be transformed, even if they match an `include` pattern.
-  Patterns are matched against paths relative to the current working directory.
+- Description: Glob patterns or regular expressions excluding files from the
+  transform. A file matching any exclude pattern is skipped even if it matches
+  an `include` pattern. Patterns are matched against paths relative to the
+  current working directory.
 
 #### `fileName`
 
@@ -189,13 +181,15 @@ build({
 
 - Type: `UseLayersType`
 - Default: `false`
-- Description: Enables CSS cascade layers support for better style isolation.
+- Description: Wraps the generated CSS in cascade layers for better style
+  isolation.
 
 #### `extractCSS`
 
 - Type: `boolean`
 - Default: `true`
-- Description: Controls whether CSS should be extracted into a separate file.
+- Description: Controls whether the generated CSS is extracted into a separate
+  file.
 
 #### `pageExtensions`
 
@@ -209,7 +203,7 @@ build({
 - Optional
 - Description: Transforms the extracted StyleX CSS before it is emitted or
   injected. Matches the `@stylexswc/webpack-plugin` API. Use it to run the
-  generated CSS through PostCSS, LightningCSS, a minifier, or any custom
+  generated CSS through PostCSS, Lightning CSS, a minifier, or any custom
   post-processing step.
 
 ```ts
@@ -219,7 +213,7 @@ type CSSTransformer = (
 ) => string | Buffer | Promise<string | Buffer>;
 ```
 
-```typescript
+```ts
 import postcss from 'postcss';
 import autoprefixer from 'autoprefixer';
 
@@ -230,45 +224,46 @@ StylexRsPlugin({
     });
     return result.css;
   },
-})
+});
 ```
 
-The `filePath` argument identifies the CSS destination and is
-bundler-specific:
+The `filePath` argument identifies the CSS destination and is bundler-specific:
 
 - webpack/rspack/rollup injection: the output asset name (e.g. `app.css`)
 - esbuild disk writes: the absolute path of the written file
 - Vite placeholder replacement: the id of the CSS module being loaded
 - generated assets: the configured `fileName`, with `[hash]` left unresolved
-  (the hash is computed from the transformed CSS, so it cannot be known
-  earlier)
+  (the hash is computed from the transformed CSS, so it cannot be known earlier)
 - `undefined` when no destination is known
 
 > [!NOTE]
-> `Buffer` results are decoded as UTF-8. Results are memoized per `filePath`
-> while the input CSS is unchanged, so the callback must be a pure function of
-> its arguments — the same input may be served from cache instead of invoking
-> the callback again.
+> `Buffer` results are decoded as UTF-8. Results are memoized per
+> `filePath` while the input CSS is unchanged, so the callback must be a pure
+> function of its arguments — the same input may be served from cache instead of
+> invoking the callback again.
 
 #### `useCssPlaceholder`
 
 - Type: `boolean | string`
 - Default: `false`
-- Description: Enable CSS injection into CSS files via placeholder marker.
-  - When set to `true`, the plugin will look for the default `@stylex;` marker
-  - When set to a string, the plugin will use that string as the custom marker
+- Description: Injects the generated CSS into an existing CSS file via a
+  placeholder marker.
+  - When set to `true`, the plugin looks for the default `@stylex;` marker
+  - When set to a string, the plugin uses that string as the custom marker
 
-##### Benefits
+Routing the StyleX output through a real CSS file has practical benefits:
 
-- **CSS Processing**: Generated StyleX CSS goes through the bundler's CSS pipeline (PostCSS, LightningCSS, css-loader, etc.)
-- **Deterministic Builds**: No race conditions or hash instability from virtual modules
-- **Consistent Output**: All CSS follows the same processing rules and bundling strategy
-- **Build Optimization**: CSS can be code-split and optimized alongside other stylesheets
-- **Works Everywhere**: Same approach works for Vite, Webpack, Rspack, esbuild, Rollup, and Farm
+- The generated CSS goes through the bundler's CSS pipeline (PostCSS, Lightning
+  CSS, css-loader, and so on)
+- Deterministic builds — no race conditions or hash instability from virtual
+  modules
+- All CSS follows the same processing rules and bundling strategy
+- CSS can be code-split and optimized alongside other stylesheets
+- The same approach works for Vite, webpack, Rspack, esbuild, Rollup, and Farm
 
-##### How to Use
+How to use it:
 
-1. Create a CSS file with a marker (e.g., `global.css`):
+1. Create a CSS file with a marker (e.g. `global.css`):
 
 ```css
 /* global.css */
@@ -286,7 +281,7 @@ body {
 
 2. Import the CSS file in your entry point:
 
-```typescript
+```ts
 // src/main.ts
 import './global.css';
 import { App } from './App';
@@ -294,7 +289,7 @@ import { App } from './App';
 
 3. Configure the plugin with `useCssPlaceholder`:
 
-```typescript
+```ts
 // vite.config.ts (or webpack.config.js, rspack.config.js, etc.)
 import StylexRsPlugin from '@stylexswc/unplugin/vite';
 import { defineConfig } from 'vite';
@@ -309,9 +304,7 @@ export default defineConfig({
 });
 ```
 
-##### Using a Custom Marker
-
-You can specify a custom marker string:
+Or with a custom marker string:
 
 ```css
 /* global.css */
@@ -322,33 +315,33 @@ You can specify a custom marker string:
 /* INJECT_STYLEX_HERE */
 ```
 
-```typescript
+```ts
 StylexRsPlugin({
   useCssPlaceholder: '/* INJECT_STYLEX_HERE */',
   useCSSLayers: true,
-})
+});
 ```
 
-The plugin will replace the marker with the generated StyleX CSS during the build process.
+The plugin replaces the marker with the generated StyleX CSS during the build.
 
 > [!NOTE]
-> When `useCssPlaceholder` is enabled, the plugin will no longer inject CSS automatically into HTML or emit a separate `stylex.css` file. The CSS is injected into your specified CSS file.
+> When `useCssPlaceholder` is enabled, the plugin no longer injects CSS
+> automatically into HTML or emits a separate `stylex.css` file. The CSS goes
+> into your specified CSS file instead.
 
 > [!IMPORTANT]
 > **Migration from `useViteCssPipeline`**
 >
-> The `useViteCssPipeline` option (which used virtual CSS modules) has been replaced with the `useCssPlaceholder` approach.
-> The new approach uses real CSS files instead of virtual modules, which provides:
->
-> - Better compatibility across all bundlers
-> - No race conditions or timing issues
-> - Deterministic builds with stable hashes
->
-> To migrate, simply create a CSS file with a marker and set `useCssPlaceholder: true` (or use a custom marker string).
+> The `useViteCssPipeline` option (which used virtual CSS modules) has been
+> replaced by `useCssPlaceholder`. The new approach uses real CSS files instead
+> of virtual modules, which provides better compatibility across all bundlers,
+> no race conditions or timing issues, and deterministic builds with stable
+> hashes. To migrate, create a CSS file with a marker and set
+> `useCssPlaceholder: true` (or use a custom marker string).
 
 ### Example Configuration
 
-```typescript
+```ts
 // vite.config.ts
 import StylexRsPlugin from '@stylexswc/unplugin/vite';
 import { defineConfig } from 'vite';
@@ -358,9 +351,7 @@ export default defineConfig({
     StylexRsPlugin({
       rsOptions: {
         dev: process.env.NODE_ENV !== 'production',
-        // Include only specific directories
         include: ['src/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
-        // Exclude test files and stories
         exclude: ['**/*.test.*', '**/*.stories.*', '**/__tests__/**'],
       },
       useCSSLayers: true,
@@ -372,40 +363,39 @@ export default defineConfig({
 
 ### Path Filtering Examples
 
-**Include only specific directories:**
+Include only specific directories:
 
-```typescript
+```ts
 StylexRsPlugin({
   rsOptions: {
     include: ['src/**/*.tsx', 'app/**/*.tsx'],
   },
-})
+});
 ```
 
-**Exclude test and build files:**
+Exclude test and build files:
 
-```typescript
+```ts
 StylexRsPlugin({
   rsOptions: {
-    exclude: ['**/*.test.*', '**/*.spec.*', '**/dist/**', '**/node_modules/**'],
+    exclude: ['**/*.test.*', '**/*.spec.*', '**/dist/**'],
   },
-})
+});
 ```
 
-**Using RegExp with lookahead/lookbehind - exclude node_modules except specific packages:**
+Exclude `node_modules` except specific packages (negative lookahead):
 
-```typescript
+```ts
 StylexRsPlugin({
   rsOptions: {
-    // Exclude all node_modules except @stylexjs packages
     exclude: [/node_modules(?!\/@stylexjs)/],
   },
-})
+});
 ```
 
-**Transform only specific packages from node_modules:**
+Transform only specific packages from `node_modules`:
 
-```typescript
+```ts
 StylexRsPlugin({
   rsOptions: {
     include: [
@@ -415,31 +405,59 @@ StylexRsPlugin({
     ],
     exclude: ['**/*.test.*'],
   },
-})
+});
 ```
 
-**Using regular expressions:**
+Combined include and exclude (exclude takes precedence):
 
-```typescript
-StylexRsPlugin({
-  rsOptions: {
-    include: [/src\/.*\.tsx$/],
-    exclude: [/\.test\./, /\.stories\./],
-  },
-})
-```
-
-**Combined include and exclude (exclude takes precedence):**
-
-```typescript
+```ts
 StylexRsPlugin({
   rsOptions: {
     include: ['src/**/*.{ts,tsx}'],
     exclude: ['**/__tests__/**', '**/__mocks__/**'],
   },
-})
+});
 ```
+
+## FAQ
+
+### Should I use this package or the bundler-specific plugin?
+
+If you are on Vite, esbuild, Farm, Rsbuild, Nuxt, or Astro, this is the package
+to use. For webpack and Rspack, the dedicated `@stylexswc/webpack-plugin` and
+`@stylexswc/rspack-plugin` packages offer a few deeper integrations (loader
+ordering, cache groups); this plugin covers the common cases with one consistent
+API. For Next.js, use `@stylexswc/nextjs-plugin`.
+
+### Do I still need `@stylexjs/babel-plugin`?
+
+No. This plugin replaces the Babel plugin in your build. You only keep
+`@stylexjs/stylex` as your app's runtime dependency, and your `stylex.create` /
+`stylex.props` code does not change.
+
+### How do I run the generated CSS through PostCSS or Tailwind pipelines?
+
+Either pass a `transformCss` function, or enable `useCssPlaceholder` so the
+generated CSS lands in a real CSS file and flows through your bundler's normal
+CSS pipeline.
+
+### Does hot module replacement work?
+
+Yes. The plugin participates in each bundler's standard transform pipeline, so
+style changes update through the dev server like any other module.
+
+### Is this an official StyleX package?
+
+No. It is a community-maintained alternative to the official tooling and is not
+affiliated with or supported by Meta.
+
+## Documentation
+
+- [StyleX documentation](https://stylexjs.com)
+- [unplugin documentation](https://unplugin.unjs.io/)
+- [`@stylexswc/rs-compiler` compiler options](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
 
 ## License
 
-MIT — see [LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)
+MIT — see
+[LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,32 +1,12 @@
 {
   "name": "@stylexswc/unplugin",
-  "description": "Unplugin for StyleX RS compiler",
+  "description": "Universal StyleX plugin for Vite, webpack, Rspack, Rollup, esbuild, Farm, Rsbuild, Nuxt, and Astro, powered by a Rust NAPI-RS/SWC compiler.",
   "version": "0.17.0",
-  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
-  "config": {
-    "scripty": {
-      "path": "../../scripts/packages"
-    }
-  },
-  "dependencies": {
-    "@stylexjs/babel-plugin": "^0.19.0",
-    "@stylexswc/rs-compiler": "0.17.0",
-    "unplugin": "^3.0.0",
-    "vite": "^8.1.2"
-  },
-  "devDependencies": {
-    "@nuxt/kit": "^4.4.8",
-    "@nuxt/schema": "^4.4.8",
-    "@rollup/plugin-commonjs": "^29.0.3",
-    "@rollup/plugin-node-resolve": "^16.0.3",
-    "@types/node": "^26.1.0",
-    "eslint": "^10.6.0",
-    "esno": "^4.7.0",
-    "rollup": "^4.62.2",
-    "tsup": "^8.5.1",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.9"
-  },
+  "private": false,
+  "license": "MIT",
+  "sideEffects": false,
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -83,24 +63,49 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/unplugin#readme",
-  "keywords": [
-    "esbuild",
-    "farm",
-    "rollup",
-    "rsbuild",
-    "rspack",
-    "stylex",
-    "swc",
-    "transform",
-    "unplugin",
-    "vite",
-    "webpack"
-  ],
-  "license": "MIT",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "packageManager": "pnpm@10.30.3",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "build:fix": "esno scripts/postbuild.ts",
+    "check:artifacts": "scripty",
+    "dev": "tsup --watch src",
+    "lint": "eslint . --color",
+    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
+    "play": "pnpm -C playground run dev",
+    "postbuild": "pnpm run check:artifacts",
+    "prepublishOnly": "pnpm run build",
+    "start": "esno src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
+    "typecheck": "scripty --ts"
+  },
+  "config": {
+    "scripty": {
+      "path": "../../scripts/packages"
+    }
+  },
+  "dependencies": {
+    "@stylexjs/babel-plugin": "^0.19.0",
+    "@stylexswc/rs-compiler": "0.17.0",
+    "unplugin": "^3.0.0",
+    "vite": "^8.1.2"
+  },
+  "devDependencies": {
+    "@nuxt/kit": "^4.4.8",
+    "@nuxt/schema": "^4.4.8",
+    "@rollup/plugin-commonjs": "^29.0.3",
+    "@rollup/plugin-node-resolve": "^16.0.3",
+    "@types/node": "^26.1.0",
+    "eslint": "^10.6.0",
+    "esno": "^4.7.0",
+    "rollup": "^4.62.2",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  },
   "peerDependencies": {
     "@farmfe/core": ">=1.7.11 <2.0.0",
     "@nuxt/kit": ">=3.0.0",
@@ -110,6 +115,29 @@
     "vite": ">=4.0.0",
     "webpack": ">=5.0.0"
   },
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
+  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/unplugin#readme",
+  "keywords": [
+    "astro",
+    "atomic-css",
+    "css-extraction",
+    "css-in-js",
+    "esbuild",
+    "farm",
+    "napi-rs",
+    "nuxt",
+    "rollup",
+    "rsbuild",
+    "rspack",
+    "rust",
+    "stylex",
+    "swc",
+    "unplugin",
+    "vite",
+    "webpack"
+  ],
+  "main": "./dist/index.js",
+  "packageManager": "pnpm@10.30.3",
   "peerDependenciesMeta": {
     "@farmfe/core": {
       "optional": true
@@ -133,30 +161,12 @@
       "optional": true
     }
   },
-  "private": false,
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
+    "directory": "packages/unplugin"
   },
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin",
-  "scripts": {
-    "build": "tsup",
-    "build:fix": "esno scripts/postbuild.ts",
-    "check:artifacts": "scripty",
-    "dev": "tsup --watch src",
-    "lint": "eslint . --color",
-    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
-    "play": "pnpm -C playground run dev",
-    "postbuild": "pnpm run check:artifacts",
-    "prepublishOnly": "pnpm run build",
-    "start": "esno src/index.ts",
-    "test": "vitest run",
-    "test:watch": "vitest --watch",
-    "typecheck": "scripty --ts"
-  },
-  "sideEffects": false,
   "type": "module",
-  "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
       "*": [

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -1,28 +1,42 @@
-# Webpack plugin with NAPI-RS StyleX compiler integration
+# @stylexswc/webpack-plugin
 
-> Part of the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme) workspace
+> StyleX plugin for webpack, powered by a Rust compiler (NAPI-RS + SWC). Part of
+> the [StyleX SWC Plugin](https://github.com/Dwlad90/stylex-swc-plugin#readme)
+> workspace.
 
-`Webpack plugin` for an unofficial
-[`napi-rs`](https://github.com/dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
-compiler that includes the StyleX SWC code transformation under the hood.
+This plugin compiles [StyleX](https://stylexjs.com) code in your webpack build
+with
+[`@stylexswc/rs-compiler`](https://www.npmjs.com/package/@stylexswc/rs-compiler),
+a Rust implementation of the StyleX transform, instead of the official Babel
+plugin. Your StyleX code stays exactly the same — only the build step changes,
+with per-file transforms 2x to 5x faster than Babel
+([performance](https://github.com/Dwlad90/stylex-swc-plugin#performance)).
+The plugin transforms your source files, collects the generated rules, and
+extracts them into a dedicated CSS chunk.
+
+This is a community project and is not affiliated with Meta. It tracks the
+official StyleX releases
+<!-- stylex-compatibility:start -->(currently compatible with StyleX v0.19.0)<!-- stylex-compatibility:end -->
+and requires Node.js 20 or newer. For Next.js projects, use
+[`@stylexswc/nextjs-plugin`](https://www.npmjs.com/package/@stylexswc/nextjs-plugin)
+instead — it wires this plugin into the Next.js build for you.
 
 ## Installation
-
-To install the package, run the following command:
 
 ```bash
 npm install --save-dev @stylexswc/webpack-plugin
 ```
 
-Please install `@stylexswc/rs-compiler` if you haven't done so already:
+The Rust compiler (`@stylexswc/rs-compiler`) is installed automatically as a
+dependency. Your application still needs the StyleX runtime:
 
 ```bash
-npm install --save-dev @stylexswc/rs-compiler
+npm install @stylexjs/stylex
 ```
 
 ## Usage
 
-Modify Webpack config. For example:
+Add the plugin to your webpack config:
 
 ```js
 const StylexPlugin = require('@stylexswc/webpack-plugin');
@@ -38,17 +52,8 @@ const config = (env, argv) => ({
   },
   plugins: [
     new StylexPlugin({
-      // ... Other StyleX options
-      transformCss: async (css, filePath) => {
-        const postcss = require('postcss');
-        const result = await postcss([require('autoprefixer')]).process(css, {
-          from: filePath,
-          map: {
-            inline: false,
-            annotation: false,
-          },
-        });
-        return result.css;
+      rsOptions: {
+        dev: argv.mode === 'development',
       },
     }),
   ],
@@ -66,95 +71,105 @@ module.exports = config;
 
 - Type: `Partial<StyleXOptions>`
 - Optional
-- Description: StyleX compiler options that will be passed to the NAPI-RS compiler.
-  For standard StyleX options, see the [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
+- Description: StyleX compiler options passed to `@stylexswc/rs-compiler`. For
+  the standard options, see the
+  [official StyleX documentation](https://stylexjs.com/docs/api/configuration/babel-plugin/).
 
 > [!NOTE]
-> **New Features:** The `include` and `exclude` options are exclusive to this NAPI-RS compiler implementation and are not available in the official StyleX Babel plugin.
+> The `include` and `exclude` options are exclusive to the Rust compiler
+> and are not available in the official StyleX Babel plugin.
 
 ##### `rsOptions.include`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular expressions to include specific files for StyleX transformation.
-  When specified, only files matching at least one of these patterns will be transformed.
-  Patterns are matched against paths relative to the current working directory.
+- Description: Glob patterns or regular expressions selecting the files to
+  transform. When specified, only files matching at least one pattern are
+  transformed. Patterns are matched against paths relative to the current
+  working directory.
 
 ##### `rsOptions.exclude`
 
 - Type: `(string | RegExp)[]`
 - Optional
-- Description: **RS-compiler Only** An array of glob patterns or regular expressions to exclude specific files from StyleX transformation.
-  Files matching any of these patterns will not be transformed, even if they match an `include` pattern.
-  Patterns are matched against paths relative to the current working directory.
+- Description: Glob patterns or regular expressions excluding files from the
+  transform. A file matching any exclude pattern is skipped even if it matches
+  an `include` pattern. Patterns are matched against paths relative to the
+  current working directory.
 
 #### `stylexImports`
 
 - Type: `Array<string | { as: string, from: string }>`
 - Default: `['stylex', '@stylexjs/stylex']`
-- Description: Specifies where StyleX will be imported from. Supports both
-  string paths and import aliases.
+- Description: Specifies where StyleX is imported from. Supports both string
+  paths and import aliases.
 
 #### `useCSSLayers`
 
 - Type: `boolean`
 - Default: `false`
-- Description: Enables CSS cascade layers support for better style isolation.
+- Description: Wraps the generated CSS in cascade layers for better style
+  isolation.
 
 #### `nextjsMode`
 
 - Type: `boolean`
 - Default: `false`
 - Description: Enables Next.js-specific optimizations and compatibility
-  features.
+  features. Leave off unless the plugin is driven by the Next.js integration.
 
 #### `extractCSS`
 
 - Type: `boolean`
 - Optional
 - Default: `true`
-- Description: Controls whether CSS should be extracted into a separate file
+- Description: Controls whether the generated CSS is extracted into a separate
+  file.
 
 #### `loaderOrder`
 
 - Type: `'first' | 'last'`
 - Optional
 - Default: `'first'`
-- Description: Determines when the StyleX transformation is applied relative to other webpack loaders.
-  - `'first'` (recommended): StyleX processes the source code before any other loaders run.
-    Automatically enables `injectStylexSideEffects` to prevent tree-shaking from removing `.stylex` and `.consts` imports.
-  - `'last'`: StyleX processes after all other loaders have completed.
-    Use this if you need other loaders (like TypeScript or SWC plugins) to transform your code before StyleX processing.
+- Description: When the StyleX transformation runs relative to other webpack
+  loaders.
+  - `'first'` (recommended): StyleX processes the source code before any other
+    loaders run. Automatically enables `injectStylexSideEffects` so tree-shaking
+    cannot remove `.stylex` and `.consts` imports.
+  - `'last'`: StyleX processes after all other loaders have completed. Use this
+    if other loaders (TypeScript, SWC plugins) must transform your code before
+    StyleX sees it.
 
-  **Why `'first'` is recommended:**
-  When StyleX transforms your code first, imports from `.stylex` and `.consts` files may appear unused to subsequent loaders/bundlers and get removed by tree-shaking. The plugin automatically injects side-effect imports to prevent this issue.
+  Why `'first'` is recommended: after StyleX rewrites your code, imports from
+  `.stylex` and `.consts` files can look unused to subsequent loaders and
+  bundler passes and get tree-shaken away:
 
-  **Example of the problem:**
   ```ts
   // Before transformation
   import { colors } from './theme.stylex';
   const styles = stylex.create({
-    root: { backgroundColor: colors.primary }
+    root: { backgroundColor: colors.primary },
   });
 
-  // After StyleX transformation (appears unused to bundler)
-  import { colors } from './theme.stylex';  // ← May be tree-shaken!
+  // After StyleX transformation (appears unused to the bundler)
+  import { colors } from './theme.stylex'; // may be tree-shaken!
   const styles = { root: { backgroundColor: 'x1a2b3c', $$css: true } };
   ```
 
-  With `loaderOrder: 'first'`, the plugin automatically preserves these imports by injecting side-effect imports.
+  With `loaderOrder: 'first'`, the plugin preserves these imports by injecting
+  side-effect imports automatically.
 
 #### `stylexPackages`
 
 - Type: `string[]`
 - Optional
 - Default: `['@stylexjs/']`
-- Description: `node_modules` is **excluded by default**, even for files that
-  reference a StyleX import. Packages that ship untransformed StyleX source
-  (e.g. component libraries) must be allowlisted here with path fragments so
-  the StyleX loader still processes them:
+- Description: `node_modules` is excluded from the transform by default, even
+  for files that reference a StyleX import. Packages that ship untransformed
+  StyleX source (component libraries, token packages) must be allowlisted here
+  with path fragments:
 
-```javascript
+```js
 new StylexPlugin({
   stylexPackages: ['@stylexjs/', 'my-design-system'],
 });
@@ -167,19 +182,34 @@ new StylexPlugin({
 - Type:
   `(css: string, filePath: string | undefined) => string | Buffer | Promise<string | Buffer>`
 - Optional
-- Description: Custom CSS transformation function. Since the plugin injects CSS
-  after all loaders, use this to apply PostCSS or other CSS transformations.
+- Description: Custom CSS post-processing. The plugin injects CSS after all
+  loaders have run, so `postcss-loader` never sees it — apply PostCSS,
+  autoprefixer, or a minifier here instead:
+
+```js
+new StylexPlugin({
+  transformCss: async (css, filePath) => {
+    const postcss = require('postcss');
+    const result = await postcss([require('autoprefixer')]).process(css, {
+      from: filePath,
+    });
+    return result.css;
+  },
+});
+```
 
 #### `cacheGroup`
 
 - Type: `CacheGroupOptions` (webpack cache group configuration)
 - Optional
-- Description: Allows overriding the default webpack cache group parameters for StyleX CSS extraction.
-  By default, the plugin creates a dedicated cache group named `stylex` for extracted StyleX CSS.
-  Use this option to customize cache group behavior such as chunk naming, priority, or other split chunks options.
+- Description: Overrides the default webpack cache group used for StyleX CSS
+  extraction. By default the plugin creates a dedicated cache group named
+  `stylex`. Use this to customize chunk naming, priority, or other split chunks
+  options.
 
-**Default cache group configuration:**
-```javascript
+Default cache group configuration:
+
+```js
 {
   name: 'stylex',
   test: /\.stylex\.virtual\.css$/,
@@ -189,8 +219,9 @@ new StylexPlugin({
 }
 ```
 
-**Example - Custom cache group:**
-```javascript
+Custom cache group:
+
+```js
 new StylexPlugin({
   cacheGroup: {
     name: 'my-stylex-bundle',
@@ -198,12 +229,12 @@ new StylexPlugin({
     priority: 20,
     enforce: true,
   },
-})
+});
 ```
 
 ### Example Configuration
 
-```javascript
+```js
 const StylexPlugin = require('@stylexswc/webpack-plugin');
 
 module.exports = {
@@ -211,95 +242,110 @@ module.exports = {
     new StylexPlugin({
       rsOptions: {
         dev: process.env.NODE_ENV !== 'production',
-        // Include only specific directories
         include: ['src/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
-        // Exclude test files and stories
         exclude: ['**/*.test.*', '**/*.stories.*', '**/__tests__/**'],
       },
       stylexImports: ['@stylexjs/stylex', { from: './theme', as: 'tokens' }],
       useCSSLayers: true,
-      nextjsMode: false,
-      loaderOrder: 'first', // Process before other loaders (default)
+      loaderOrder: 'first',
       transformCss: async css => {
         const postcss = require('postcss');
         const result = await postcss([require('autoprefixer')]).process(css);
         return result.css;
-      },
-      // Optional: Override cache group settings
-      cacheGroup: {
-        name: 'stylex',
-        priority: 30,
       },
     }),
   ],
 };
 ```
 
-#### Path Filtering Examples
+### Path Filtering Examples
 
-**Include only specific directories:**
+Include only specific directories:
 
-```javascript
+```js
 new StylexPlugin({
   rsOptions: {
     include: ['src/**/*.tsx', 'app/**/*.tsx'],
   },
-})
+});
 ```
 
-**Exclude test and build files:**
+Exclude test and build files:
 
-```javascript
+```js
 new StylexPlugin({
   rsOptions: {
-    exclude: ['**/*.test.*', '**/*.spec.*', '**/dist/**', '**/node_modules/**'],
+    exclude: ['**/*.test.*', '**/*.spec.*', '**/dist/**'],
   },
-})
+});
 ```
 
-**Using regular expressions:**
+Using regular expressions:
 
-```javascript
+```js
 new StylexPlugin({
   rsOptions: {
     include: [/src\/.*\.tsx$/],
     exclude: [/\.test\./, /\.stories\./],
   },
-})
+});
 ```
 
-**Combined include and exclude (exclude takes precedence):**
+Transform only specific packages from `node_modules` — note that `node_modules`
+is excluded regardless of `rsOptions.include`/`exclude`, so allowlist packages
+with `stylexPackages` instead:
 
-```javascript
-new StylexPlugin({
-  rsOptions: {
-    include: ['src/**/*.{ts,tsx}'],
-    exclude: ['**/__tests__/**', '**/__mocks__/**'],
-  },
-})
-```
-
-**Transform only specific packages from node_modules:**
-
-`node_modules` is excluded by default regardless of `rsOptions.include`/
-`exclude` — allowlist packages with `stylexPackages` instead:
-
-```javascript
+```js
 new StylexPlugin({
   rsOptions: {
     include: ['src/**/*.{ts,tsx}'],
     exclude: ['**/*.test.*'],
   },
   stylexPackages: ['@stylexjs/open-props', '@my-org/design-system'],
-})
+});
 ```
+
+## FAQ
+
+### Do I still need `@stylexjs/babel-plugin`?
+
+No. This plugin replaces the Babel plugin in your build. You only keep
+`@stylexjs/stylex` as your app's runtime dependency, and your `stylex.create` /
+`stylex.props` code does not change.
+
+### My styles from a component library are missing. Why?
+
+`node_modules` is excluded by default. Add the package to `stylexPackages` (for
+example `stylexPackages: ['@stylexjs/', 'my-design-system']`) so the StyleX
+loader processes it.
+
+### Imports from my `.stylex.ts` token files disappear after the build
+
+That is tree-shaking removing imports that look unused after the transform. Keep
+the default `loaderOrder: 'first'`, which injects side-effect imports to protect
+them.
+
+### Can I run PostCSS on the generated CSS?
+
+Yes — through the `transformCss` option. The StyleX CSS is produced after the
+regular loader pipeline, so `postcss-loader` alone will not see it.
+
+### Is this an official StyleX package?
+
+No. It is a community-maintained alternative to the official tooling and is not
+affiliated with or supported by Meta.
 
 ## Documentation
 
-- [StyleX Documentation](https://stylexjs.com)
-- [NAPI-RS compiler for StyleX](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
+- [StyleX documentation](https://stylexjs.com)
+- [`@stylexswc/rs-compiler` compiler options](https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/crates/stylex-rs-compiler)
 
 ## Acknowledgments
 
 This plugin was inspired by
 [`stylex-webpack`](https://github.com/SukkaW/stylex-webpack).
+
+## License
+
+MIT — see
+[LICENSE](https://github.com/Dwlad90/stylex-swc-plugin/blob/develop/LICENSE)

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,7 +1,43 @@
 {
   "name": "@stylexswc/webpack-plugin",
-  "description": "StyleX webpack plugin with NAPI-RS compiler",
+  "description": "StyleX plugin for webpack powered by a Rust NAPI-RS/SWC compiler. Fast StyleX transforms and CSS extraction without Babel.",
   "version": "0.17.0",
+  "private": false,
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./shared": {
+      "types": "./dist/shared.d.ts",
+      "import": "./dist/shared.js",
+      "require": "./dist/shared.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "scripts": {
+    "build": "scripty --ts",
+    "check:artifacts": "scripty",
+    "clean": "del-cli dist",
+    "lint": "eslint . --color",
+    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
+    "postbuild": "pnpm run check:artifacts",
+    "precommit": "lint-staged",
+    "prepublishOnly": "pnpm run build",
+    "prepush": "lint-prepush",
+    "test": "vitest run",
+    "typecheck": "scripty --ts"
+  },
   "config": {
     "scripty": {
       "path": "../../scripts/packages"
@@ -21,48 +57,24 @@
     "vitest": "^4.1.9",
     "webpack": "^5.108.3"
   },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
-    },
-    "./shared": {
-      "types": "./dist/shared.d.ts",
-      "import": "./dist/shared.js",
-      "require": "./dist/shared.js"
-    },
-    "./package.json": "./package.json"
-  },
-  "files": [
-    "dist"
-  ],
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
+  "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/webpack-plugin#readme",
   "keywords": [
+    "atomic-css",
+    "css-extraction",
+    "css-in-js",
+    "napi-rs",
+    "react",
+    "rust",
     "stylex",
     "swc",
     "webpack",
     "webpack-plugin"
   ],
-  "license": "MIT",
   "main": "dist/index.js",
-  "private": false,
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "repository": "https://github.com/Dwlad90/stylex-swc-plugin",
-  "scripts": {
-    "build": "scripty --ts",
-    "check:artifacts": "scripty",
-    "clean": "del-cli dist",
-    "lint": "eslint . --color",
-    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
-    "postbuild": "pnpm run check:artifacts",
-    "precommit": "lint-staged",
-    "prepublishOnly": "pnpm run build",
-    "prepush": "lint-prepush",
-    "test": "vitest run",
-    "typecheck": "scripty --ts"
-  },
-  "sideEffects": false
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
+    "directory": "packages/webpack-plugin"
+  }
 }

--- a/scripts/git/update-stylex-compatibility.sh
+++ b/scripts/git/update-stylex-compatibility.sh
@@ -7,6 +7,16 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 ROOT_README="README.md"
 RS_COMPILER_README="crates/stylex-rs-compiler/README.md"
+PLUGIN_READMES=(
+  "packages/jest/README.md"
+  "packages/nextjs-plugin/README.md"
+  "packages/postcss-plugin/README.md"
+  "packages/rollup-plugin/README.md"
+  "packages/rspack-plugin/README.md"
+  "packages/turbopack-plugin/README.md"
+  "packages/unplugin/README.md"
+  "packages/webpack-plugin/README.md"
+)
 STYLEX_BLOG_URL="https://stylexjs.com/blog"
 MARKER_START="<!-- stylex-compatibility:start -->"
 MARKER_END="<!-- stylex-compatibility:end -->"
@@ -154,10 +164,19 @@ write_rs_compiler_callout() {
 
   cat >"$output_file" <<EOF
 
+
 > [!NOTE]
 > Compatibility target: this package has been updated through official
 > StyleX v${version}. This is not an official Meta support guarantee.
+
 EOF
+}
+
+write_plugin_phrase() {
+  local version="$1"
+  local output_file="$2"
+
+  printf '(currently compatible with StyleX v%s)' "$version" >"$output_file"
 }
 
 replace_marker_block() {
@@ -232,40 +251,55 @@ update_readmes() {
   local version="$1"
   local root_badge
   local rs_compiler_callout
+  local plugin_phrase
   local root_output
   local rs_compiler_output
-  local root_backup
-  local rs_compiler_backup
+  local readme
+  local index
 
   temp_dir=$(create_temp_dir) || error "Failed to create temporary directory."
   root_badge="$temp_dir/root-badge.md"
   rs_compiler_callout="$temp_dir/rs-compiler-callout.md"
+  plugin_phrase="$temp_dir/plugin-phrase.md"
   root_output="$temp_dir/root-readme.md"
   rs_compiler_output="$temp_dir/rs-compiler-readme.md"
-  root_backup="$temp_dir/root-readme.backup.md"
-  rs_compiler_backup="$temp_dir/rs-compiler-readme.backup.md"
 
   write_root_badge "$version" "$root_badge"
   write_rs_compiler_callout "$version" "$rs_compiler_callout"
+  write_plugin_phrase "$version" "$plugin_phrase"
+
+  # Generate every replacement before writing anything back, so a marker
+  # problem in any README aborts the run with all files untouched.
   replace_marker_block "$ROOT_README" "$root_badge" "$root_output"
   replace_marker_block "$RS_COMPILER_README" "$rs_compiler_callout" "$rs_compiler_output"
+
+  index=0
+  for readme in "${PLUGIN_READMES[@]}"; do
+    replace_marker_block "$readme" "$plugin_phrase" "$temp_dir/plugin-readme-$index.md"
+    index=$((index + 1))
+  done
 
   if [ "$dry_run" = true ]; then
     echo "Dry run: proposed StyleX compatibility update to v${version}"
     diff -u "$ROOT_README" "$root_output" || true
     diff -u "$RS_COMPILER_README" "$rs_compiler_output" || true
+    index=0
+    for readme in "${PLUGIN_READMES[@]}"; do
+      diff -u "$readme" "$temp_dir/plugin-readme-$index.md" || true
+      index=$((index + 1))
+    done
   else
-    cp "$ROOT_README" "$root_backup"
-    cp "$RS_COMPILER_README" "$rs_compiler_backup"
-
     mv "$root_output" "$ROOT_README" ||
       error "Failed to update $ROOT_README."
-
-    if ! mv "$rs_compiler_output" "$RS_COMPILER_README"; then
-      cp "$root_backup" "$ROOT_README" ||
-        echo "Warning: failed to restore $ROOT_README after update failure." >&2
+    mv "$rs_compiler_output" "$RS_COMPILER_README" ||
       error "Failed to update $RS_COMPILER_README."
-    fi
+
+    index=0
+    for readme in "${PLUGIN_READMES[@]}"; do
+      mv "$temp_dir/plugin-readme-$index.md" "$readme" ||
+        error "Failed to update $readme."
+      index=$((index + 1))
+    done
 
     echo "Updated StyleX compatibility indicators to v${version}."
   fi


### PR DESCRIPTION
- Revised the README files for the StyleX compiler, Next.js plugin, and Jest transformer to clarify their functionalities and usage.
- Enhanced descriptions to reflect the high-performance nature of the Rust-based compiler and its integration with various build tools.
- Updated installation instructions and configuration examples for better user guidance.
- Improved documentation on performance metrics, compatibility, and community-driven aspects of the project.
- Added details on the new features and options available in the NAPI-RS compiler, including `include` and `exclude` patterns for file transformations.

## Description

This pull request makes significant improvements to the documentation, configuration, and packaging for the Jest transformer and the Rust compiler integration for StyleX. The main changes include enhanced and clarified documentation for both the Jest transformer and the Rust compiler crate, improved package metadata and configuration, and a more detailed description of the Rust crate dependency structure.

**Documentation improvements:**

* [`packages/jest/README.md`](diffhunk://#diff-6d9855bd254530a8d7ddfa27370444d3cc8dfc68ea320e4b3d5c312e0086fccdL1-R30): Completely rewrites and expands the Jest transformer documentation with a clearer introduction, modern configuration examples, new FAQ section, and explicit explanations of the Rust compiler integration and options. [[1]](diffhunk://#diff-6d9855bd254530a8d7ddfa27370444d3cc8dfc68ea320e4b3d5c312e0086fccdL1-R30) [[2]](diffhunk://#diff-6d9855bd254530a8d7ddfa27370444d3cc8dfc68ea320e4b3d5c312e0086fccdL58-R130) [[3]](diffhunk://#diff-6d9855bd254530a8d7ddfa27370444d3cc8dfc68ea320e4b3d5c312e0086fccdL163-R212)
* [`guidelines/STRUCTURE.md`](diffhunk://#diff-419a1519a5ea39e29f1b9307995cf7b3b9e84ae0b8492fc097b4d730abbd7adaL8-R199): Expands the Rust crate layering and dependency documentation, including a detailed breakdown of each crate's responsibility and a new dependency graph in Mermaid syntax.

**Package metadata and configuration:**

* [`crates/stylex-rs-compiler/package.json`](diffhunk://#diff-f156afdf6246ccb2a97ca19963838efdd319ebeb6db6e8cdbd455f4c749ae29dL3-R17): Updates the package description, keywords, license, and files list for npm publishing. Restores and organizes the `scripts`, `publishConfig`, and `peerDependencies` sections, and reorders devDependencies for clarity. [[1]](diffhunk://#diff-f156afdf6246ccb2a97ca19963838efdd319ebeb6db6e8cdbd455f4c749ae29dL3-R17) [[2]](diffhunk://#diff-f156afdf6246ccb2a97ca19963838efdd319ebeb6db6e8cdbd455f4c749ae29dR30-R38) [[3]](diffhunk://#diff-f156afdf6246ccb2a97ca19963838efdd319ebeb6db6e8cdbd455f4c749ae29dL87-R79) [[4]](diffhunk://#diff-f156afdf6246ccb2a97ca19963838efdd319ebeb6db6e8cdbd455f4c749ae29dL131-R135)
* [`packages/jest/package.json`](diffhunk://#diff-d3257785ed94f98f3ff84c30fead7c7147b8efc2091ea70f8c32a9c2aa68ac6dL3-L27): Updates the package description to clarify its purpose and removes unnecessary fields for a cleaner package manifest.

**Other improvements:**

* [`guidelines/STRUCTURE.md`](diffhunk://#diff-419a1519a5ea39e29f1b9307995cf7b3b9e84ae0b8492fc097b4d730abbd7adaL82-R249): Minor formatting and clarity improvements in test coverage documentation.

These changes collectively improve usability, discoverability, and maintainability for users integrating StyleX with Jest and for contributors working on the Rust compiler or the monorepo.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
