### PR TITLE
feat(rollup-plugin, unplugin): optimize source map handling and performance

### DIFF
--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -106,11 +106,20 @@ export default function stylexPlugin({
       }
 
       // The combined map of all previous plugins lets the compiler resolve
-      // debug source-map annotations to the original authored file, and lets
-      // it chain its emitted map onto it. Rollup resets the sourcemap chain
-      // when `getCombinedSourcemap` is used, so returning the chained map is
-      // the expected contract.
-      if (normalizedRsOptions.inputSourceMap === undefined) {
+      // debug source-map annotations to the original authored file. The
+      // compiler only reads it for those annotations (`debug` +
+      // `enableDebugDataProp`); plain map chaining is handled by Rollup
+      // itself when the plugin returns its own map. Fetching it
+      // unconditionally is expensive: with no previous maps Rollup
+      // synthesizes a hi-res map of the whole module, which then gets
+      // stringified, re-parsed and cloned per module. Rollup resets the
+      // sourcemap chain when `getCombinedSourcemap` is used, so returning
+      // the chained map is the expected contract.
+      const needsInputSourceMap =
+        (normalizedRsOptions.debug ?? normalizedRsOptions.dev) === true &&
+        normalizedRsOptions.enableDebugDataProp !== false;
+
+      if (needsInputSourceMap && normalizedRsOptions.inputSourceMap === undefined) {
         try {
           const combinedMap = this.getCombinedSourcemap();
 

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -241,10 +241,20 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
       try {
         // Only Rollup-compatible hosts (Rollup, Vite) expose the combined
         // source map of previous plugins; other bundlers fall back to
-        // locating positions in the source text.
+        // locating positions in the source text. The compiler only reads
+        // the input map for debug source-map annotations (`debug` +
+        // `enableDebugDataProp`) — plain map chaining is handled by the
+        // host — and fetching it unconditionally is expensive: with no
+        // previous maps Rollup synthesizes a hi-res map of the whole
+        // module, which then gets stringified, re-parsed and cloned per
+        // module.
         let inputSourceMap: string | undefined;
 
-        if (hasCombinedSourcemap(this)) {
+        const needsInputSourceMap =
+          (normalizedOptions.rsOptions.debug ?? normalizedOptions.rsOptions.dev) === true &&
+          normalizedOptions.rsOptions.enableDebugDataProp !== false;
+
+        if (needsInputSourceMap && hasCombinedSourcemap(this)) {
           try {
             const combinedMap = this.getCombinedSourcemap();
 


### PR DESCRIPTION
- Enhanced the logic for determining the need for input source maps in both the Rollup and Unplugin packages.
- Updated comments to clarify the handling of debug source-map annotations and the implications of fetching input source maps.
- Improved performance by avoiding unnecessary fetching of high-resolution maps when not required.
- Ensured consistent behavior across different bundlers by refining the source map integration process.

## Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Fixes

(Optional) Fixes # (issue)

## Additional Info

(Optional) Add any other relevant information about the pull request here.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
