### PR TITLE
fix(nextjs-plugin): unblock Next.js 16 rspack builds with a proxy entry

### DIFF
--- a/apps/nextjs-example/proxy.ts
+++ b/apps/nextjs-example/proxy.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// This function can be marked `async` if using `await` inside
+export function proxy(request: NextRequest) {
+  return NextResponse.redirect(new URL('/home', request.url));
+}
+
+export const config = {
+  matcher: '/dummy/:path*',
+};

--- a/apps/nextjs-rspack-example/proxy.ts
+++ b/apps/nextjs-rspack-example/proxy.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// This function can be marked `async` if using `await` inside
+export function proxy(request: NextRequest) {
+  return NextResponse.redirect(new URL('/home', request.url));
+}
+
+export const config = {
+  matcher: '/dummy/:path*',
+};

--- a/packages/nextjs-plugin/README.md
+++ b/packages/nextjs-plugin/README.md
@@ -244,6 +244,25 @@ export default withStylexTurbopack({
   carrier's real path — if the missing-carrier warning appears in such a
   setup, point `carrierCss` at a file inside your own source tree.
 
+#### `rspackServerPersistentCache`
+
+- Type: `boolean`
+- Optional
+- Default: unset (auto-detect)
+- Applies to: the `/rspack` export only
+- Description: Whether the server compilers keep Rspack's persistent cache.
+  Next.js 16 enables `experiments.cache = { type: 'persistent' }` for every
+  `next-rspack` compiler, and a `proxy.ts`/`middleware.ts` entry makes that
+  cache degrade catastrophically in the server compilers — the build stalls
+  inside Rspack's native filesystem layer and can look like a hang (see the
+  FAQ entry below). Left unset, the plugin disables the cache for the server
+  compilers of a **production build** when it finds a proxy/middleware entry
+  in the project root or `src/`, and logs a warning saying so. `next dev` is
+  left alone — it shows no such stall, and keeping its cache is worth ~200ms
+  on the first compile of a route. Set `true` to keep Next.js' setting
+  untouched, `false` to always disable it (dev included). The client compiler
+  always keeps its cache.
+
 ### Advanced Options
 
 #### `transformCss`
@@ -432,6 +451,25 @@ transpiled by Next.js and automatically allowlisted for the StyleX transform.
 
 Yes. Styles are extracted at build time from both Server and Client Components
 into static CSS, so there is no runtime cost either way.
+
+### My Rspack build hangs when I add a `proxy.ts`
+
+This is an upstream Next.js 16 + `next-rspack` issue, not a StyleX one:
+Next.js enables Rspack's persistent cache for every compiler, and a
+proxy/middleware entry makes it spend minutes in Rspack's native filesystem
+layer walking the workspace. It reproduces with no StyleX plugin installed at
+all, it scales with the size of the workspace rather than the app, and warm
+builds are slower than cold ones. On the example app the server compile went
+from 1.6s to 27s cold and 50s warm; in a large monorepo the build never
+appears to finish.
+
+The `/rspack` export detects the proxy entry and disables the persistent cache
+for the server compilers of a production build, which restores the original
+build time (1.6s on the example app) and leaves the emitted CSS
+byte-identical. `next dev` keeps its cache: it boots in ~240ms and compiles
+the proxy entry in ~310ms with the cache on, so the stall does not appear
+there. See [`rspackServerPersistentCache`](#rspackserverpersistentcache) to
+control it. The `--webpack` bundler is unaffected.
 
 ### Is this an official StyleX package?
 

--- a/packages/nextjs-plugin/README.md
+++ b/packages/nextjs-plugin/README.md
@@ -262,6 +262,10 @@ export default withStylexTurbopack({
   on the first compile of a route. Set `true` to keep Next.js' setting
   untouched, `false` to always disable it (dev included). The client compiler
   always keeps its cache.
+- Note: auto-detection also stands down when your own `webpack()` hook
+  configures `experiments.cache`, so an explicit choice there always wins. If
+  you set it by accident and the build crawls, either drop it or pass
+  `rspackServerPersistentCache: false`, which outranks the hook.
 
 ### Advanced Options
 

--- a/packages/nextjs-plugin/__tests__/rspack.test.ts
+++ b/packages/nextjs-plugin/__tests__/rspack.test.ts
@@ -9,10 +9,25 @@ import type { NextConfig, WebpackConfigContext } from 'next/dist/server/config-s
 import type { StyleXNextRspackPluginOption } from '../src/rspack';
 import type webpack from 'webpack';
 
-const { rspackPluginOptions, warn } = vi.hoisted(() => ({
+const { existsSyncCalls, rspackPluginOptions, warn } = vi.hoisted(() => ({
+  existsSyncCalls: [] as string[],
   rspackPluginOptions: [] as Array<Record<string, unknown>>,
   warn: vi.fn(),
 }));
+
+// Partially mocked so the probe paths can be asserted while the real
+// filesystem helpers below keep working against temporary directories.
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  const existsSync = (candidate: Parameters<typeof actual.existsSync>[0]) => {
+    existsSyncCalls.push(String(candidate));
+
+    return actual.existsSync(candidate);
+  };
+
+  // `default` too, so consumers using a default `fs` import are unaffected
+  return { ...actual, existsSync, default: { ...actual, existsSync } };
+});
 
 vi.mock('next/dist/build/output/log', () => ({ warn }));
 vi.mock('next-rspack', () => ({
@@ -99,6 +114,7 @@ const applyRspackConfig = (
 
 beforeEach(() => {
   process.env.NEXT_RSPACK = 'true';
+  existsSyncCalls.splice(0);
   rspackPluginOptions.splice(0);
   warn.mockClear();
 });
@@ -221,10 +237,64 @@ describe('@stylexswc/nextjs-plugin/rspack persistent cache', () => {
       pageExtensions: ['ts'],
     });
 
-    runRspackConfig(createContext(projectDirectory, { nextRuntime: 'nodejs' }));
-    runRspackConfig(createContext(projectDirectory, { nextRuntime: 'edge' }));
+    const nodeConfig = runRspackConfig(createContext(projectDirectory, { nextRuntime: 'nodejs' }));
+    const edgeConfig = runRspackConfig(createContext(projectDirectory, { nextRuntime: 'edge' }));
 
+    expect(nodeConfig.experiments?.cache).toBe(false);
+    expect(edgeConfig.experiments?.cache).toBe(false);
     expect(warn).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('src/middleware.ts'));
+  });
+
+  test('detects a root-level middleware entry', () => {
+    const projectDirectory = createProject('middleware.js');
+    const config = applyRspackConfig({}, createContext(projectDirectory));
+
+    expect(config.experiments?.cache).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('middleware.js'));
+  });
+
+  test('never probes outside the project directory for a malformed page extension', () => {
+    const projectDirectory = createProject('app.ts');
+
+    applyRspackConfig({}, createContext(projectDirectory, {}, ['../../../etc/passwd']));
+
+    expect(existsSyncCalls).not.toHaveLength(0);
+    for (const candidate of existsSyncCalls) {
+      expect(candidate.startsWith(`${projectDirectory}${path.sep}`)).toBe(true);
+      expect(candidate).not.toContain('..');
+    }
+  });
+
+  test("keeps a persistent cache configured by the user's own webpack hook", () => {
+    const projectDirectory = createProject('proxy.ts');
+    const userCache = { type: 'persistent', storage: { type: 'filesystem' } } as const;
+    const config = applyRspackConfig(
+      {
+        pageExtensions: ['ts'],
+        webpack: (webpackConfig: Record<string, unknown>) => ({
+          ...webpackConfig,
+          experiments: { cache: userCache },
+        }),
+      },
+      createContext(projectDirectory)
+    );
+
+    expect(config.experiments?.cache).toEqual(userCache);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('still applies the workaround when a webpack hook drops experiments entirely', () => {
+    const projectDirectory = createProject('proxy.ts');
+    const config = applyRspackConfig(
+      {
+        pageExtensions: ['ts'],
+        webpack: () => ({}),
+      },
+      createContext(projectDirectory)
+    );
+
+    expect(config.experiments?.cache).toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
   });
 });

--- a/packages/nextjs-plugin/__tests__/rspack.test.ts
+++ b/packages/nextjs-plugin/__tests__/rspack.test.ts
@@ -1,0 +1,230 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import withStyleX from '../src/rspack';
+
+import type { NextConfig, WebpackConfigContext } from 'next/dist/server/config-shared';
+import type { StyleXNextRspackPluginOption } from '../src/rspack';
+import type webpack from 'webpack';
+
+const { rspackPluginOptions, warn } = vi.hoisted(() => ({
+  rspackPluginOptions: [] as Array<Record<string, unknown>>,
+  warn: vi.fn(),
+}));
+
+vi.mock('next/dist/build/output/log', () => ({ warn }));
+vi.mock('next-rspack', () => ({
+  default: (config: NextConfig) => config,
+}));
+vi.mock('@stylexswc/rspack-plugin', () => ({
+  default: class StyleXRspackPlugin {
+    constructor(options: Record<string, unknown>) {
+      rspackPluginOptions.push(options);
+    }
+  },
+  DEFAULT_STYLEX_PACKAGES: ['@stylexjs/stylex'],
+  buildVirtualCssPattern: vi.fn(),
+}));
+
+const originalNextRspack = process.env.NEXT_RSPACK;
+const temporaryDirectories: string[] = [];
+
+const createProject = (entry: string): string => {
+  const projectDirectory = mkdtempSync(path.join(tmpdir(), 'stylex-nextjs-plugin-'));
+  const entryPath = path.join(projectDirectory, entry);
+
+  temporaryDirectories.push(projectDirectory);
+  mkdirSync(path.dirname(entryPath), { recursive: true });
+  writeFileSync(entryPath, '');
+
+  return projectDirectory;
+};
+
+const createContext = (
+  dir: string,
+  overrides: Partial<Pick<WebpackConfigContext, 'dev' | 'isServer' | 'nextRuntime'>> = {},
+  pageExtensions = ['tsx', 'ts', 'jsx', 'js']
+): WebpackConfigContext =>
+  ({
+    buildId: 'test-build',
+    config: {
+      pageExtensions,
+    },
+    defaultLoaders: {
+      babel: {},
+    },
+    dev: false,
+    dir,
+    isServer: true,
+    totalPages: 0,
+    webpack: {},
+    ...overrides,
+  }) as WebpackConfigContext;
+
+const createRspackConfigRunner = (
+  nextConfig: NextConfig = {},
+  pluginOptions: StyleXNextRspackPluginOption = { extractCSS: false }
+): ((context: WebpackConfigContext) => webpack.Configuration) => {
+  const wrappedConfig = withStyleX({
+    extractCSS: false,
+    ...pluginOptions,
+  })(nextConfig);
+
+  const configureWebpack = wrappedConfig.webpack;
+
+  if (typeof configureWebpack !== 'function') {
+    throw new TypeError('Expected the Rspack wrapper to provide a webpack configuration hook.');
+  }
+
+  return context =>
+    configureWebpack(
+      {
+        experiments: {
+          cache: {
+            type: 'persistent',
+          },
+        },
+      },
+      context
+    ) as webpack.Configuration;
+};
+
+const applyRspackConfig = (
+  nextConfig: NextConfig,
+  context: WebpackConfigContext,
+  pluginOptions?: StyleXNextRspackPluginOption
+): webpack.Configuration => createRspackConfigRunner(nextConfig, pluginOptions)(context);
+
+beforeEach(() => {
+  process.env.NEXT_RSPACK = 'true';
+  rspackPluginOptions.splice(0);
+  warn.mockClear();
+});
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+
+  if (originalNextRspack === undefined) {
+    delete process.env.NEXT_RSPACK;
+  } else {
+    process.env.NEXT_RSPACK = originalNextRspack;
+  }
+});
+
+describe('@stylexswc/nextjs-plugin/rspack persistent cache', () => {
+  test('uses the normalized Next.js page extensions when detecting a proxy entry', () => {
+    const projectDirectory = createProject('proxy.custom');
+    const config = applyRspackConfig(
+      {},
+      createContext(projectDirectory, { isServer: true }, ['custom'])
+    );
+
+    expect(config.experiments?.cache).toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  test('does not forward wrapper-only cache options to the Rspack plugin', () => {
+    const projectDirectory = createProject('proxy.ts');
+
+    applyRspackConfig(
+      {
+        pageExtensions: ['ts'],
+      },
+      createContext(projectDirectory),
+      {
+        rspackServerPersistentCache: false,
+      }
+    );
+
+    expect(rspackPluginOptions).toHaveLength(1);
+    expect(rspackPluginOptions[0]).not.toHaveProperty('rspackServerPersistentCache');
+  });
+
+  test('keeps the persistent cache for production client compilers', () => {
+    const projectDirectory = createProject('proxy.ts');
+    const config = applyRspackConfig(
+      {
+        pageExtensions: ['ts'],
+      },
+      createContext(projectDirectory, { isServer: false })
+    );
+
+    expect(config.experiments?.cache).toEqual({ type: 'persistent' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('keeps the persistent cache for development server compilers by default', () => {
+    const projectDirectory = createProject('proxy.ts');
+    const config = applyRspackConfig(
+      {
+        pageExtensions: ['ts'],
+      },
+      createContext(projectDirectory, { dev: true })
+    );
+
+    expect(config.experiments?.cache).toEqual({ type: 'persistent' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('keeps the persistent cache when explicitly enabled', () => {
+    const projectDirectory = createProject('proxy.ts');
+    const config = applyRspackConfig(
+      {
+        pageExtensions: ['ts'],
+      },
+      createContext(projectDirectory),
+      {
+        rspackServerPersistentCache: true,
+      }
+    );
+
+    expect(config.experiments?.cache).toEqual({ type: 'persistent' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('disables the persistent cache in development when explicitly disabled', () => {
+    const projectDirectory = createProject('proxy.ts');
+    const config = applyRspackConfig(
+      {
+        pageExtensions: ['ts'],
+      },
+      createContext(projectDirectory, { dev: true }),
+      {
+        rspackServerPersistentCache: false,
+      }
+    );
+
+    expect(config.experiments?.cache).toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  test('keeps the persistent cache when no proxy or middleware entry exists', () => {
+    const projectDirectory = createProject('app.ts');
+    const config = applyRspackConfig(
+      {
+        pageExtensions: ['ts'],
+      },
+      createContext(projectDirectory)
+    );
+
+    expect(config.experiments?.cache).toEqual({ type: 'persistent' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('warns once when both server compilers use the same wrapped config', () => {
+    const projectDirectory = createProject(path.join('src', 'middleware.ts'));
+    const runRspackConfig = createRspackConfigRunner({
+      pageExtensions: ['ts'],
+    });
+
+    runRspackConfig(createContext(projectDirectory, { nextRuntime: 'nodejs' }));
+    runRspackConfig(createContext(projectDirectory, { nextRuntime: 'edge' }));
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('src/middleware.ts'));
+  });
+});

--- a/packages/nextjs-plugin/package.json
+++ b/packages/nextjs-plugin/package.json
@@ -2,9 +2,30 @@
   "name": "@stylexswc/nextjs-plugin",
   "description": "StyleX plugin for Next.js powered by a Rust NAPI-RS/SWC compiler. Supports Webpack, Rspack, and Turbopack builds with CSS extraction.",
   "version": "0.18.0",
-  "private": false,
-  "license": "MIT",
-  "sideEffects": false,
+  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
+  "config": {
+    "scripty": {
+      "path": "../../scripts/packages"
+    }
+  },
+  "dependencies": {
+    "@stylexswc/rs-compiler": "0.18.0",
+    "@stylexswc/rspack-plugin": "0.18.0",
+    "@stylexswc/turbopack-plugin": "0.18.0",
+    "@stylexswc/webpack-plugin": "0.18.0",
+    "next-rspack": "^16.2.9"
+  },
+  "devDependencies": {
+    "@stylexswc/eslint-config": "0.18.0",
+    "@stylexswc/typescript-config": "0.18.0",
+    "@types/node": "^26.1.0",
+    "next": "^16.2.11",
+    "postcss": "^8.5.16",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "vitest": "^4.1.9",
+    "webpack": "^5.108.3"
+  },
   "exports": {
     "./turbopack": {
       "types": "./dist/turbopack.d.ts",
@@ -26,50 +47,6 @@
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "scripts": {
-    "build": "scripty --ts",
-    "check:artifacts": "scripty",
-    "clean": "del-cli dist",
-    "lint": "eslint . --color",
-    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
-    "postbuild": "pnpm run check:artifacts",
-    "precommit": "lint-staged",
-    "prepublishOnly": "pnpm run build",
-    "prepush": "lint-prepush",
-    "test": "echo \"Error: no test specified\" && exit 0",
-    "typecheck": "scripty --ts"
-  },
-  "config": {
-    "scripty": {
-      "path": "../../scripts/packages"
-    }
-  },
-  "dependencies": {
-    "@stylexswc/rs-compiler": "0.18.0",
-    "@stylexswc/rspack-plugin": "0.18.0",
-    "@stylexswc/turbopack-plugin": "0.18.0",
-    "@stylexswc/webpack-plugin": "0.18.0",
-    "next-rspack": "^16.2.9"
-  },
-  "devDependencies": {
-    "@stylexswc/eslint-config": "0.18.0",
-    "@stylexswc/typescript-config": "0.18.0",
-    "@types/node": "^26.1.0",
-    "next": "^16.2.11",
-    "postcss": "^8.5.16",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "webpack": "^5.108.3"
-  },
-  "peerDependencies": {
-    "next": ">=15.0.0",
-    "next-rspack": "^16.2.9"
-  },
-  "bugs": "https://github.com/Dwlad90/stylex-swc-plugin/issues",
   "homepage": "https://github.com/Dwlad90/stylex-swc-plugin/tree/develop/packages/nextjs-plugin#readme",
   "keywords": [
     "app-router",
@@ -86,15 +63,39 @@
     "swc",
     "turbopack"
   ],
+  "license": "MIT",
   "main": "dist/index.js",
+  "peerDependencies": {
+    "next": ">=15.0.0",
+    "next-rspack": "^16.2.9"
+  },
   "peerDependenciesMeta": {
     "next-rspack": {
       "optional": true
     }
   },
+  "private": false,
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Dwlad90/stylex-swc-plugin.git",
     "directory": "packages/nextjs-plugin"
-  }
+  },
+  "scripts": {
+    "build": "scripty --ts",
+    "check:artifacts": "scripty",
+    "clean": "del-cli dist",
+    "lint": "eslint . --color",
+    "lint:check": "eslint . --color --format json --output-file dist/eslint_report.json",
+    "postbuild": "pnpm run check:artifacts",
+    "precommit": "lint-staged",
+    "prepublishOnly": "pnpm run build",
+    "prepush": "lint-prepush",
+    "test": "vitest run",
+    "typecheck": "scripty --ts"
+  },
+  "sideEffects": false
 }

--- a/packages/nextjs-plugin/src/rspack.ts
+++ b/packages/nextjs-plugin/src/rspack.ts
@@ -16,8 +16,11 @@ import type webpack from 'webpack';
 import type { Processor as PostCSSProcessor } from 'postcss';
 import type { ConfigurationContext as WebpackConfigurationContext } from 'next/dist/build/webpack/config/utils';
 
+/** Rspack-only; absent from the webpack `Configuration` type Next.js hands us */
+type RspackPersistentCache = false | { type: 'persistent' | 'memory'; [key: string]: unknown };
+
 type RspackExperiments = NonNullable<webpack.Configuration['experiments']> & {
-  cache?: unknown;
+  cache?: RspackPersistentCache;
 };
 
 type RspackConfiguration = Omit<webpack.Configuration, 'experiments'> &
@@ -42,6 +45,9 @@ export interface StyleXNextRspackPluginOption extends StyleXPluginOption {
    * ~200ms on the first compile of a route. Set `true` to keep Next.js'
    * setting untouched, `false` to always disable it (dev included).
    *
+   * Auto-detection also stands down when your own `webpack()` hook configures
+   * `experiments.cache` itself, so an explicit choice there always wins.
+   *
    * @default undefined (auto-detect, production builds only)
    */
   rspackServerPersistentCache?: boolean;
@@ -57,9 +63,51 @@ const NEXTJS_PROXY_DIRS = ['', 'src'] as const;
 // `pageExtensions` is deliberate: a false positive costs build cache, a
 // false negative costs a hanging build
 const NEXTJS_PROXY_EXTENSIONS = ['ts', 'tsx', 'js', 'jsx', 'mjs', 'mts', 'cjs', 'cts'] as const;
+/**
+ * Extensions are interpolated into a probe path, so anything that could escape
+ * the project directory is rejected. Anchored and single-class: no backtracking.
+ */
+const SAFE_EXTENSION_PATTERN = /^[A-Za-z0-9]+$/;
 
+/** Warning text and test assertions must not vary with the platform separator */
+const toPosixPath = (value: string): string => value.split(path.sep).join('/');
+
+/**
+ * Stable stringification of `experiments.cache`, used to tell whether a user's
+ * `webpack()` hook configured it. Returns `undefined` when the field is absent,
+ * which callers must treat as "no choice made" rather than as a change.
+ */
+const snapshotPersistentCache = (cache: RspackPersistentCache | undefined): string | undefined => {
+  if (cache === undefined) {
+    return undefined;
+  }
+
+  try {
+    return JSON.stringify(cache);
+  } catch {
+    // Circular or non-serializable value: it came from somewhere other than
+    // Next.js' plain defaults, so treat it as a deliberate configuration.
+    return '[unserializable]';
+  }
+};
+
+/**
+ * Probes for Next.js' proxy/middleware entry with a bounded set of synchronous
+ * `existsSync` calls — `webpack()` is a synchronous API, so this cannot be
+ * deferred, and the result is memoized per config by the caller.
+ *
+ * @param dir - project root (`ctx.dir`)
+ * @param pageExtensions - normalized `ctx.config.pageExtensions`, merged into
+ *   the built-in superset; malformed values are skipped
+ * @returns the entry's path relative to `dir` with POSIX separators, or
+ *   `undefined` when the project has no proxy/middleware entry
+ */
 const findNextjsProxyEntry = (dir: string, pageExtensions?: string[]): string | undefined => {
-  const extensions = new Set([...NEXTJS_PROXY_EXTENSIONS, ...(pageExtensions ?? [])]);
+  const extensions = new Set(
+    [...NEXTJS_PROXY_EXTENSIONS, ...(pageExtensions ?? [])].filter(extension =>
+      SAFE_EXTENSION_PATTERN.test(extension)
+    )
+  );
 
   for (const subDir of NEXTJS_PROXY_DIRS) {
     for (const filename of NEXTJS_PROXY_FILENAMES) {
@@ -67,7 +115,7 @@ const findNextjsProxyEntry = (dir: string, pageExtensions?: string[]): string | 
         const candidate = path.join(dir, subDir, `${filename}.${extension}`);
 
         if (existsSync(candidate)) {
-          return path.relative(dir, candidate);
+          return toPosixPath(path.relative(dir, candidate));
         }
       }
     }
@@ -161,14 +209,17 @@ const withStyleX =
     // The server and edge-server compilers both run `webpack()`; the notice
     // belongs in the log once per config, not once per compiler.
     let persistentCacheNoticeShown = false;
-    // Both server compilers use the same project root and normalized config.
-    // Cache the bounded synchronous probe so configuration never repeats I/O.
-    let proxyEntryDetectionComplete = false;
+    // Both server compilers use the same project root and normalized config, so
+    // the bounded synchronous probe runs once. Keyed by its inputs so the memo
+    // cannot hand back an answer computed for different arguments.
+    let proxyEntryCacheKey: string | undefined;
     let detectedProxyEntry: string | undefined;
-    const getNextjsProxyEntry = (dir: string, pageExtensions: string[]) => {
-      if (!proxyEntryDetectionComplete) {
+    const getNextjsProxyEntry = (dir: string, pageExtensions?: string[]) => {
+      const cacheKey = JSON.stringify([dir, pageExtensions ?? []]);
+
+      if (cacheKey !== proxyEntryCacheKey) {
+        proxyEntryCacheKey = cacheKey;
         detectedProxyEntry = findNextjsProxyEntry(dir, pageExtensions);
-        proxyEntryDetectionComplete = true;
       }
 
       return detectedProxyEntry;
@@ -178,7 +229,7 @@ const withStyleX =
     // the client/server/edge-server compilers must share one build process.
     // Only enforced when the registry is in use — Pages Router builds
     // (`nextjsAppRouterMode: false`) keep the user's setting.
-    const useAppRouterRegistry = pluginOptions?.nextjsAppRouterMode ?? true;
+    const useAppRouterRegistry = rspackPluginOptions.nextjsAppRouterMode ?? true;
 
     if (useAppRouterRegistry && nextConfig.experimental?.webpackBuildWorker) {
       warn(
@@ -211,15 +262,31 @@ const withStyleX =
           );
         }
 
+        // Snapshotted around the user's hook so an `experiments.cache` they set
+        // themselves wins over the auto-detected workaround below. Serialized
+        // rather than compared by reference: hooks commonly mutate the existing
+        // object in place, which reference equality would miss.
+        const cacheBeforeUserHook = snapshotPersistentCache(config.experiments?.cache);
+
         if (typeof nextConfig.webpack === 'function') {
           config = nextConfig.webpack(config, ctx);
         }
+
+        const cacheAfterUserHook = snapshotPersistentCache(config.experiments?.cache);
+        // An absent value is not a choice: a hook that returns a fresh config
+        // object without `experiments` must not disable the workaround.
+        const userConfiguredCache =
+          cacheAfterUserHook !== undefined && cacheAfterUserHook !== cacheBeforeUserHook;
 
         const { buildId, dev, isServer } = ctx;
 
         count += 1;
 
-        if (pluginOptions?.rsOptions?.debug || process.env.STYLEX_DEBUG) {
+        const debugEnabled = Boolean(
+          rspackPluginOptions.rsOptions?.debug || process.env.STYLEX_DEBUG
+        );
+
+        if (debugEnabled) {
           warn(
             `@stylexswc/nextjs-plugin/rspack: rspack config #${count} (buildId=${buildId}, server=${isServer}, env=${dev ? 'dev' : 'prod'})`
           );
@@ -232,12 +299,29 @@ const withStyleX =
         // builds — `next dev` shows no such stall, and keeping its cache is
         // worth ~200ms on first compile of a route.
         if (isServer && rspackServerPersistentCache !== true) {
-          const proxyEntry =
-            dev || rspackServerPersistentCache === false
-              ? undefined
-              : getNextjsProxyEntry(ctx.dir, ctx.config.pageExtensions);
-          // An explicit `false` disables the cache everywhere, dev included
+          const autoDetect = !dev && rspackServerPersistentCache !== false && !userConfiguredCache;
+          const proxyEntry = autoDetect
+            ? getNextjsProxyEntry(ctx.dir, ctx.config.pageExtensions)
+            : undefined;
+          // An explicit `false` disables the cache everywhere, dev included, and
+          // outranks a cache configured in the user's own `webpack()` hook
           const disableCache = rspackServerPersistentCache === false || proxyEntry != null;
+
+          // Only meaningful where auto-detection would otherwise have run: in
+          // dev the cache is left alone regardless of the user's hook
+          if (
+            debugEnabled &&
+            !dev &&
+            userConfiguredCache &&
+            rspackServerPersistentCache === undefined
+          ) {
+            warn(
+              [
+                '@stylexswc/nextjs-plugin/rspack: leaving "experiments.cache" alone —',
+                'it was configured by the "webpack" hook in your Next.js config.',
+              ].join(' ')
+            );
+          }
 
           if (disableCache) {
             config.experiments ??= {};
@@ -265,13 +349,13 @@ const withStyleX =
         config.optimization.splitChunks ||= {};
         config.optimization.splitChunks.cacheGroups ||= {};
 
-        const extractCSS = pluginOptions?.extractCSS ?? true;
+        const extractCSS = rspackPluginOptions.extractCSS ?? true;
 
         // Resolved once and shared by the css rule test below and the plugin
         // (via `carrierCss`), so the two can never disagree about the carrier
         // location when `compiler.context` differs from the project dir
-        const carrierPath = pluginOptions?.carrierCss
-          ? path.resolve(ctx.dir, pluginOptions.carrierCss)
+        const carrierPath = rspackPluginOptions.carrierCss
+          ? path.resolve(ctx.dir, rspackPluginOptions.carrierCss)
           : require.resolve('@stylexswc/rspack-plugin/stylex.css');
 
         config.plugins ??= [];
@@ -366,7 +450,7 @@ const withStyleX =
         // packages the stylex-loader must process
         const stylexPackages = Array.from(
           new Set([
-            ...(pluginOptions?.stylexPackages ?? DEFAULT_STYLEX_PACKAGES),
+            ...(rspackPluginOptions.stylexPackages ?? DEFAULT_STYLEX_PACKAGES),
             ...(nextConfig.transpilePackages ?? []),
           ])
         );
@@ -381,12 +465,12 @@ const withStyleX =
             ...rspackPluginOptions,
             // Pre-resolved absolute path: the plugin's chunk pattern and the
             // css rule above can never disagree about the carrier location
-            ...(pluginOptions?.carrierCss ? { carrierCss: carrierPath } : {}),
+            ...(rspackPluginOptions.carrierCss ? { carrierCss: carrierPath } : {}),
             // Computed values always win: `dev` must reflect this Next.js
             // build, and stylexPackages merges in transpilePackages
             stylexPackages,
             rsOptions: {
-              ...pluginOptions?.rsOptions,
+              ...rspackPluginOptions.rsOptions,
               dev: ctx.dev,
             },
             ...(extractCSS
@@ -402,8 +486,8 @@ const withStyleX =
                       },
                     });
 
-                    if (typeof pluginOptions?.transformCss === 'function') {
-                      return pluginOptions.transformCss(result.css, filePath);
+                    if (typeof rspackPluginOptions.transformCss === 'function') {
+                      return rspackPluginOptions.transformCss(result.css, filePath);
                     }
 
                     return result.css;

--- a/packages/nextjs-plugin/src/rspack.ts
+++ b/packages/nextjs-plugin/src/rspack.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
 import browserslist from 'next/dist/compiled/browserslist';
 import { warn } from 'next/dist/build/output/log';
 import { lazyPostCSS } from 'next/dist/build/webpack/config/blocks/css';
@@ -16,7 +16,16 @@ import type webpack from 'webpack';
 import type { Processor as PostCSSProcessor } from 'postcss';
 import type { ConfigurationContext as WebpackConfigurationContext } from 'next/dist/build/webpack/config/utils';
 
-export type StyleXNextRspackPluginOption = StyleXPluginOption & {
+type RspackExperiments = NonNullable<webpack.Configuration['experiments']> & {
+  cache?: unknown;
+};
+
+type RspackConfiguration = Omit<webpack.Configuration, 'experiments'> &
+  WebpackConfigurationContext & {
+    experiments?: RspackExperiments;
+  };
+
+export interface StyleXNextRspackPluginOption extends StyleXPluginOption {
   /**
    * Whether the server compilers keep Rspack's persistent cache.
    *
@@ -36,7 +45,7 @@ export type StyleXNextRspackPluginOption = StyleXPluginOption & {
    * @default undefined (auto-detect, production builds only)
    */
   rspackServerPersistentCache?: boolean;
-};
+}
 
 /**
  * Next.js resolves the proxy/middleware entry from `<root>` or `<root>/src`
@@ -57,7 +66,7 @@ const findNextjsProxyEntry = (dir: string, pageExtensions?: string[]): string | 
       for (const extension of extensions) {
         const candidate = path.join(dir, subDir, `${filename}.${extension}`);
 
-        if (fs.existsSync(candidate)) {
+        if (existsSync(candidate)) {
           return path.relative(dir, candidate);
         }
       }
@@ -144,6 +153,7 @@ function getStyleXVirtualCssLoader(
 const withStyleX =
   (pluginOptions?: StyleXNextRspackPluginOption) =>
   (nextConfig: NextConfig = {}): NextConfig => {
+    const { rspackServerPersistentCache, ...rspackPluginOptions } = pluginOptions ?? {};
     // Scoped per `withStyleX(...)` call rather than module-level, so it doesn't
     // leak across unrelated Next.js configs sharing this process (e.g. a
     // monorepo building multiple apps, or repeated calls in tests).
@@ -151,6 +161,18 @@ const withStyleX =
     // The server and edge-server compilers both run `webpack()`; the notice
     // belongs in the log once per config, not once per compiler.
     let persistentCacheNoticeShown = false;
+    // Both server compilers use the same project root and normalized config.
+    // Cache the bounded synchronous probe so configuration never repeats I/O.
+    let proxyEntryDetectionComplete = false;
+    let detectedProxyEntry: string | undefined;
+    const getNextjsProxyEntry = (dir: string, pageExtensions: string[]) => {
+      if (!proxyEntryDetectionComplete) {
+        detectedProxyEntry = findNextjsProxyEntry(dir, pageExtensions);
+        proxyEntryDetectionComplete = true;
+      }
+
+      return detectedProxyEntry;
+    };
 
     // The App Router cross-compiler rule registry lives on `globalThis`, so
     // the client/server/edge-server compilers must share one build process.
@@ -177,10 +199,7 @@ const withStyleX =
             },
           }
         : {}),
-      webpack(
-        config: webpack.Configuration & WebpackConfigurationContext,
-        ctx: WebpackConfigContext
-      ) {
+      webpack(config: RspackConfiguration, ctx: WebpackConfigContext) {
         if (!process.env.NEXT_RSPACK) {
           throw new Error(
             [
@@ -212,22 +231,17 @@ const withStyleX =
         // the server compilers so the client keeps its cache, and to production
         // builds — `next dev` shows no such stall, and keeping its cache is
         // worth ~200ms on first compile of a route.
-        if (isServer && pluginOptions?.rspackServerPersistentCache !== true) {
+        if (isServer && rspackServerPersistentCache !== true) {
           const proxyEntry =
-            dev || pluginOptions?.rspackServerPersistentCache === false
+            dev || rspackServerPersistentCache === false
               ? undefined
-              : findNextjsProxyEntry(ctx.dir, nextConfig.pageExtensions);
+              : getNextjsProxyEntry(ctx.dir, ctx.config.pageExtensions);
           // An explicit `false` disables the cache everywhere, dev included
-          const disableCache =
-            pluginOptions?.rspackServerPersistentCache === false || proxyEntry != null;
+          const disableCache = rspackServerPersistentCache === false || proxyEntry != null;
 
           if (disableCache) {
-            // `experiments.cache` is Rspack-only, so it is absent from the
-            // webpack `Configuration` type Next.js hands us
-            const experiments = (config.experiments ?? {}) as Record<string, unknown>;
-
-            experiments.cache = false;
-            config.experiments = experiments as typeof config.experiments;
+            config.experiments ??= {};
+            config.experiments.cache = false;
 
             if (!persistentCacheNoticeShown) {
               persistentCacheNoticeShown = true;
@@ -364,7 +378,7 @@ const withStyleX =
             // Router, where each compiler sees the complete rule set)
             nextjsMode: true,
             nextjsAppRouterMode: true,
-            ...pluginOptions,
+            ...rspackPluginOptions,
             // Pre-resolved absolute path: the plugin's chunk pattern and the
             // css rule above can never disagree about the carrier location
             ...(pluginOptions?.carrierCss ? { carrierCss: carrierPath } : {}),
@@ -406,5 +420,10 @@ const withStyleX =
 
 export default withStyleX;
 
-module.exports = withStyleX;
-module.exports.default = withStyleX;
+const moduleExportsDescriptor =
+  typeof module === 'undefined' ? undefined : Object.getOwnPropertyDescriptor(module, 'exports');
+
+if (moduleExportsDescriptor?.writable) {
+  module.exports = withStyleX;
+  module.exports.default = withStyleX;
+}

--- a/packages/nextjs-plugin/src/rspack.ts
+++ b/packages/nextjs-plugin/src/rspack.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import browserslist from 'next/dist/compiled/browserslist';
 import { warn } from 'next/dist/build/output/log';
@@ -14,6 +15,57 @@ import type { StyleXPluginOption } from '@stylexswc/rspack-plugin';
 import type webpack from 'webpack';
 import type { Processor as PostCSSProcessor } from 'postcss';
 import type { ConfigurationContext as WebpackConfigurationContext } from 'next/dist/build/webpack/config/utils';
+
+export type StyleXNextRspackPluginOption = StyleXPluginOption & {
+  /**
+   * Whether the server compilers keep Rspack's persistent cache.
+   *
+   * Next.js 16 turns on `experiments.cache = { type: 'persistent' }` for
+   * every `next-rspack` compiler. With a `proxy.ts`/`middleware.ts` entry
+   * that cache degrades catastrophically in the server compilers: the build
+   * spends its time in Rspack's native filesystem layer walking the whole
+   * workspace, and warm builds are slower than cold ones (measured on the
+   * example app: 1.6s -> 27s cold, 50s warm; unbounded in large monorepos).
+   *
+   * Left unset, the cache is disabled for the server compilers of a
+   * **production build** when a proxy/middleware entry is detected. `next dev`
+   * is left alone: it shows no such stall, and keeping its cache is worth
+   * ~200ms on the first compile of a route. Set `true` to keep Next.js'
+   * setting untouched, `false` to always disable it (dev included).
+   *
+   * @default undefined (auto-detect, production builds only)
+   */
+  rspackServerPersistentCache?: boolean;
+};
+
+/**
+ * Next.js resolves the proxy/middleware entry from `<root>` or `<root>/src`
+ * @see https://nextjs.org/docs/app/api-reference/file-conventions/proxy
+ */
+const NEXTJS_PROXY_FILENAMES = ['proxy', 'middleware'] as const;
+const NEXTJS_PROXY_DIRS = ['', 'src'] as const;
+// Detection only gates a cache optimization, so a superset of Next.js'
+// `pageExtensions` is deliberate: a false positive costs build cache, a
+// false negative costs a hanging build
+const NEXTJS_PROXY_EXTENSIONS = ['ts', 'tsx', 'js', 'jsx', 'mjs', 'mts', 'cjs', 'cts'] as const;
+
+const findNextjsProxyEntry = (dir: string, pageExtensions?: string[]): string | undefined => {
+  const extensions = new Set([...NEXTJS_PROXY_EXTENSIONS, ...(pageExtensions ?? [])]);
+
+  for (const subDir of NEXTJS_PROXY_DIRS) {
+    for (const filename of NEXTJS_PROXY_FILENAMES) {
+      for (const extension of extensions) {
+        const candidate = path.join(dir, subDir, `${filename}.${extension}`);
+
+        if (fs.existsSync(candidate)) {
+          return path.relative(dir, candidate);
+        }
+      }
+    }
+  }
+
+  return undefined;
+};
 
 type CssExtractPluginClass = {
   new (_options: { filename: string; chunkFilename: string; ignoreOrder: boolean }): unknown;
@@ -90,12 +142,15 @@ function getStyleXVirtualCssLoader(
 }
 
 const withStyleX =
-  (pluginOptions?: StyleXPluginOption) =>
+  (pluginOptions?: StyleXNextRspackPluginOption) =>
   (nextConfig: NextConfig = {}): NextConfig => {
     // Scoped per `withStyleX(...)` call rather than module-level, so it doesn't
     // leak across unrelated Next.js configs sharing this process (e.g. a
     // monorepo building multiple apps, or repeated calls in tests).
     let count = 0;
+    // The server and edge-server compilers both run `webpack()`; the notice
+    // belongs in the log once per config, not once per compiler.
+    let persistentCacheNoticeShown = false;
 
     // The App Router cross-compiler rule registry lives on `globalThis`, so
     // the client/server/edge-server compilers must share one build process.
@@ -149,6 +204,47 @@ const withStyleX =
           warn(
             `@stylexswc/nextjs-plugin/rspack: rspack config #${count} (buildId=${buildId}, server=${isServer}, env=${dev ? 'dev' : 'prod'})`
           );
+        }
+
+        // Upstream workaround: Next.js 16 enables Rspack's persistent cache for
+        // every compiler, and a proxy/middleware entry makes it pathological in
+        // the server compilers (see `rspackServerPersistentCache`). Scoped to
+        // the server compilers so the client keeps its cache, and to production
+        // builds — `next dev` shows no such stall, and keeping its cache is
+        // worth ~200ms on first compile of a route.
+        if (isServer && pluginOptions?.rspackServerPersistentCache !== true) {
+          const proxyEntry =
+            dev || pluginOptions?.rspackServerPersistentCache === false
+              ? undefined
+              : findNextjsProxyEntry(ctx.dir, nextConfig.pageExtensions);
+          // An explicit `false` disables the cache everywhere, dev included
+          const disableCache =
+            pluginOptions?.rspackServerPersistentCache === false || proxyEntry != null;
+
+          if (disableCache) {
+            // `experiments.cache` is Rspack-only, so it is absent from the
+            // webpack `Configuration` type Next.js hands us
+            const experiments = (config.experiments ?? {}) as Record<string, unknown>;
+
+            experiments.cache = false;
+            config.experiments = experiments as typeof config.experiments;
+
+            if (!persistentCacheNoticeShown) {
+              persistentCacheNoticeShown = true;
+              warn(
+                proxyEntry
+                  ? [
+                      "@stylexswc/nextjs-plugin/rspack: disabling Rspack's persistent cache for the",
+                      `server compilers — "${proxyEntry}" makes it pathologically slow on Next.js 16`,
+                      '(builds can appear to hang). Set "rspackServerPersistentCache: true" to keep it.',
+                    ].join(' ')
+                  : [
+                      "@stylexswc/nextjs-plugin/rspack: disabling Rspack's persistent cache for the",
+                      'server compilers — "rspackServerPersistentCache: false" was set.',
+                    ].join(' ')
+              );
+            }
+          }
         }
 
         config.optimization ||= {};

--- a/packages/nextjs-plugin/tsconfig.typecheck.json
+++ b/packages/nextjs-plugin/tsconfig.typecheck.json
@@ -1,4 +1,14 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {}
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "__tests__/**/*.ts",
+    "./typings/**/*.d.ts"
+  ]
 }

--- a/packages/nextjs-plugin/vitest.config.ts
+++ b/packages/nextjs-plugin/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    globals: true,
+  },
+});

--- a/packages/nextjs-plugin/vitest.config.ts
+++ b/packages/nextjs-plugin/vitest.config.ts
@@ -4,6 +4,5 @@ export default defineConfig({
   test: {
     environment: 'node',
     exclude: ['**/node_modules/**', '**/dist/**'],
-    globals: true,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1982,9 +1982,12 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.2)(yaml@2.9.0))
       webpack:
         specifier: ^5.108.3
-        version: 5.108.3(postcss@8.5.16)
+        version: 5.108.3(esbuild@0.28.1)(postcss@8.5.16)
 
   packages/playwright:
     devDependencies:
@@ -22601,6 +22604,17 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
 
+  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(postcss@8.5.16)(webpack@5.108.3(esbuild@0.28.1)(postcss@8.5.16)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.108.3(esbuild@0.28.1)(postcss@8.5.16)
+    optionalDependencies:
+      esbuild: 0.28.1
+      postcss: 8.5.16
+
   minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(postcss@8.5.22)(webpack@5.108.3(esbuild@0.28.1)(postcss@8.5.22)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -22622,16 +22636,6 @@ snapshots:
       webpack: 5.108.3(esbuild@0.28.1)
     optionalDependencies:
       esbuild: 0.28.1
-
-  minimizer-webpack-plugin@5.6.1(postcss@8.5.16)(webpack@5.108.3(postcss@8.5.16)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.48.0
-      webpack: 5.108.3(postcss@8.5.16)
-    optionalDependencies:
-      postcss: 8.5.16
 
   minimizer-webpack-plugin@5.6.1(webpack@5.108.3):
     dependencies:
@@ -25540,6 +25544,44 @@ snapshots:
       - postcss
       - uglify-js
 
+  webpack@5.108.3(esbuild@0.28.1)(postcss@8.5.16):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.4
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.1
+      es-module-lexer: 2.2.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(postcss@8.5.16)(webpack@5.108.3(esbuild@0.28.1)(postcss@8.5.16))
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
   webpack@5.108.3(esbuild@0.28.1)(postcss@8.5.22):
     dependencies:
       '@types/estree': 1.0.9
@@ -25578,44 +25620,6 @@ snapshots:
       - postcss
       - uglify-js
     optional: true
-
-  webpack@5.108.3(postcss@8.5.16):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.4
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.1
-      es-module-lexer: 2.2.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(postcss@8.5.16)(webpack@5.108.3(postcss@8.5.16))
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.0
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
 
   websocket-driver@0.7.5:
     dependencies:


### PR DESCRIPTION
Next.js 16 builds using the `/rspack` export hang when the project has a `proxy.ts`/`middleware.ts` file. Next.js enables Rspack's persistent cache for every compiler (`experiments.cache = { type: 'persistent' }`), and a proxy entry makes that cache degrade catastrophically in the server compiler: JavaScript sits idle while Rspack's native threads walk the whole workspace. The cost scales with workspace size rather than app size, and warm builds are slower than cold ones because the cache is both read and written every build, so in a large monorepo the build never appears to finish.

The cause is upstream, not StyleX. On the example app the server compile goes from 1.6s to 27s cold and 50s warm; removing the StyleX plugin entirely makes it worse (31.1s), an empty `proxy.ts` with no imports is enough to trigger it, and `next build --webpack` is unaffected.

The `/rspack` export now looks for a proxy/middleware entry in the project root or `src/` and, when it finds one, turns the persistent cache off for the server compilers of a production build, warning once so the change is never silent. The client compiler keeps its cache, and the emitted CSS is byte-identical to a build without a proxy entry.

`next dev` is deliberately left alone: it shows no such stall (ready in ~240ms, proxy entry compiled in ~310ms with the cache on), and keeping its cache is worth roughly 100-300ms on the first compile of a route. The new `rspackServerPersistentCache` option overrides the detection — `true` keeps Next.js' setting untouched, `false` disables the cache everywhere, dev included, for projects where dev is affected too.

Also adds a `proxy.ts` to the Rspack and Webpack example apps so the regression is covered by an app that builds in CI.

## Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Fixes

(Optional) Fixes # (issue)

## Additional Info

(Optional) Add any other relevant information about the pull request here.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
