### PR TITLE
feat(stylex): add support for direct member access in stylex.create

### DIFF
--- a/crates/stylex-transform/src/shared/utils/validators.rs
+++ b/crates/stylex-transform/src/shared/utils/validators.rs
@@ -3,7 +3,9 @@ use stylex_macros::stylex_panic;
 use stylex_structures::top_level_expression::TopLevelExpression;
 use swc_core::{
   atoms::Atom,
-  ecma::ast::{ArrowExpr, CallExpr, Expr, KeyValueProp, Lit, Pat, PropOrSpread, VarDeclarator},
+  ecma::ast::{
+    ArrowExpr, CallExpr, Expr, KeyValueProp, Lit, OptChainBase, Pat, PropOrSpread, VarDeclarator,
+  },
 };
 
 use crate::shared::{
@@ -35,7 +37,7 @@ use stylex_constants::constants::{
 };
 
 use super::ast::convertors::{convert_key_value_to_str, convert_lit_to_string};
-use stylex_ast::ast::convertors::get_key_values_from_object;
+use stylex_ast::ast::convertors::{get_key_values_from_object, normalize_expr};
 
 fn validate_arg_count_for_expr(
   wrapped_expr: &Expr,
@@ -133,10 +135,32 @@ macro_rules! stylex_var_decl_call_predicate {
 /// comparison would let a genuinely unbound call borrow an unrelated twin's
 /// binding and silently skip validation.
 fn contains_call(expr: &Expr, call: &CallExpr) -> bool {
-  match expr {
+  match strip_transparent_wrappers(expr) {
     Expr::Call(candidate) => candidate.span == call.span,
     Expr::Member(member) => contains_call(&member.obj, call),
+    Expr::OptChain(opt_chain) => match opt_chain.base.as_ref() {
+      OptChainBase::Member(member) => contains_call(&member.obj, call),
+      OptChainBase::Call(_) => false,
+    },
     _ => false,
+  }
+}
+
+/// Strips wrappers that neither change the value being accessed nor require
+/// parentheses to be member-accessed: `(stylex.create({...})).root` and
+/// `stylex.create({...})!.root` reach the very same object as
+/// `stylex.create({...}).root`, so binding analysis must see through them.
+///
+/// Type assertions (`as`, `satisfies`, `<T>`, `as const`) are deliberately *not*
+/// stripped. They can only be member-accessed through parentheses, and the
+/// emitter drops that grouping — `(x as any).root` is printed as
+/// `x as any.root`, which re-parses as `x as (any.root)`. Accepting that shape
+/// here would turn a clear "must be bound to a bare variable" diagnostic into
+/// silently invalid output.
+fn strip_transparent_wrappers(expr: &Expr) -> &Expr {
+  match normalize_expr(expr) {
+    Expr::TsNonNull(inner) => strip_transparent_wrappers(&inner.expr),
+    other => other,
   }
 }
 
@@ -155,9 +179,13 @@ fn contains_call(expr: &Expr, call: &CallExpr) -> bool {
 /// Containment is O(1) and still rejects a call that merely coexists with an
 /// unrelated array, which a bare `matches!(_, Expr::Array(_))` would accept.
 fn is_bound_create_expr(expr: &Expr, call: &CallExpr) -> bool {
-  match expr {
+  match strip_transparent_wrappers(expr) {
     Expr::Array(array) => array.span.contains(call.span),
     Expr::Member(member) => contains_call(&member.obj, call),
+    Expr::OptChain(opt_chain) => match opt_chain.base.as_ref() {
+      OptChainBase::Member(member) => contains_call(&member.obj, call),
+      OptChainBase::Call(_) => false,
+    },
     _ => false,
   }
 }

--- a/crates/stylex-transform/src/shared/utils/validators.rs
+++ b/crates/stylex-transform/src/shared/utils/validators.rs
@@ -3,8 +3,7 @@ use stylex_macros::stylex_panic;
 use stylex_structures::top_level_expression::TopLevelExpression;
 use swc_core::{
   atoms::Atom,
-  common::EqIgnoreSpan,
-  ecma::ast::{ArrowExpr, CallExpr, Expr, KeyValueProp, Lit, Pat, VarDeclarator},
+  ecma::ast::{ArrowExpr, CallExpr, Expr, KeyValueProp, Lit, Pat, PropOrSpread, VarDeclarator},
 };
 
 use crate::shared::{
@@ -126,50 +125,96 @@ macro_rules! stylex_var_decl_call_predicate {
   };
 }
 
+/// Returns `true` when `expr` *is* `call`, or is a member chain rooted at it
+/// (`stylex.create({...}).root`, `stylex.create({...})["root"]`).
+///
+/// Identity is the span, not the structure: two distinct `stylex.create()` call
+/// sites with identical arguments are `eq_ignore_span`-equal, so a structural
+/// comparison would let a genuinely unbound call borrow an unrelated twin's
+/// binding and silently skip validation.
+fn contains_call(expr: &Expr, call: &CallExpr) -> bool {
+  match expr {
+    Expr::Call(candidate) => candidate.span == call.span,
+    Expr::Member(member) => contains_call(&member.obj, call),
+    _ => false,
+  }
+}
+
+/// Returns `true` when the top-level expression `expr` binds `call`.
+///
+/// Two shapes count as bound beyond a plain variable declarator (which
+/// [`StateManager::find_call_declaration`] handles):
+/// - an array literal holding the call — `[stylex.create({...}), ...]`;
+/// - a direct member access on the call — `stylex.create({...}).root`.
+///
+/// The array case is decided by span containment, **not** by walking `elems`.
+/// A single top-level array holding every style in a module is an idiomatic
+/// StyleX shape (`export const lotsOfStyles = [stylex.create({...}), ...]`), and
+/// this predicate runs once per `stylex.create()` call — scanning the elements
+/// would make validation quadratic in the number of styles in that array.
+/// Containment is O(1) and still rejects a call that merely coexists with an
+/// unrelated array, which a bare `matches!(_, Expr::Array(_))` would accept.
+fn is_bound_create_expr(expr: &Expr, call: &CallExpr) -> bool {
+  match expr {
+    Expr::Array(array) => array.span.contains(call.span),
+    Expr::Member(member) => contains_call(&member.obj, call),
+    _ => false,
+  }
+}
+
 pub(crate) fn validate_stylex_create(call: &CallExpr, state: &mut StateManager) {
   if !is_create_call(call, state) {
     return;
   }
 
-  let call_expr = Expr::Call(call.clone());
-
+  // `Expr::Call(call.clone())` deep-clones the whole style object, so it is
+  // built lazily — only on the paths that are about to panic anyway.
   if state.find_call_declaration(call).is_none()
     && state
       .find_top_level_expr(
         call,
-        |tpe: &TopLevelExpression| {
-          matches!(&tpe.1, Expr::Array(_))
-            || matches!(
-              &tpe.1,
-              Expr::Member(member)
-                if matches!(
-                  member.obj.as_ref(),
-                  Expr::Call(member_call) if member_call.eq_ignore_span(call)
-                )
-            )
-        },
+        |tpe: &TopLevelExpression| is_bound_create_expr(&tpe.1, call),
         None,
       )
       .is_none()
   {
-    build_code_frame_error_and_panic_at(&call_expr, &unbound_call_value(STYLEX_CREATE), state);
+    build_code_frame_error_and_panic_at(
+      &Expr::Call(call.clone()),
+      &unbound_call_value(STYLEX_CREATE),
+      state,
+    );
   }
 
-  validate_arg_count_for_expr(&call_expr, call, 1, STYLEX_CREATE, state);
-  assert_first_arg_is_object(&call_expr, call, STYLEX_CREATE, state);
+  if call.args.len() != 1 {
+    build_code_frame_error_and_panic_at(
+      &Expr::Call(call.clone()),
+      &illegal_argument_length(STYLEX_CREATE, 1),
+      state,
+    );
+  }
 
   let first_arg = &call.args[0];
-  let has_spread = if let Expr::Object(obj) = first_arg.expr.as_ref() {
-    obj
-      .props
-      .iter()
-      .any(|prop| matches!(prop, swc_core::ecma::ast::PropOrSpread::Spread(_)))
-  } else {
-    false
+
+  let Expr::Object(obj) = first_arg.expr.as_ref() else {
+    build_code_frame_error_and_panic(
+      &Expr::Call(call.clone()),
+      &first_arg.expr,
+      &non_style_object(STYLEX_CREATE),
+      state,
+    );
   };
 
-  if has_spread {
-    build_code_frame_error_and_panic(&call_expr, &first_arg.expr, NO_OBJECT_SPREADS, state);
+  if obj
+    .props
+    .iter()
+    .any(|prop| matches!(prop, PropOrSpread::Spread(_)))
+  {
+    build_code_frame_error_and_panic(
+      &Expr::Call(call.clone()),
+      &first_arg.expr,
+      NO_OBJECT_SPREADS,
+      state,
+    );
   }
 }
 

--- a/crates/stylex-transform/src/shared/utils/validators.rs
+++ b/crates/stylex-transform/src/shared/utils/validators.rs
@@ -3,6 +3,7 @@ use stylex_macros::stylex_panic;
 use stylex_structures::top_level_expression::TopLevelExpression;
 use swc_core::{
   atoms::Atom,
+  common::EqIgnoreSpan,
   ecma::ast::{ArrowExpr, CallExpr, Expr, KeyValueProp, Lit, Pat, VarDeclarator},
 };
 
@@ -136,7 +137,17 @@ pub(crate) fn validate_stylex_create(call: &CallExpr, state: &mut StateManager) 
     && state
       .find_top_level_expr(
         call,
-        |tpe: &TopLevelExpression| matches!(tpe.1, Expr::Array(_)),
+        |tpe: &TopLevelExpression| {
+          matches!(&tpe.1, Expr::Array(_))
+            || matches!(
+              &tpe.1,
+              Expr::Member(member)
+                if matches!(
+                  member.obj.as_ref(),
+                  Expr::Call(member_call) if member_call.eq_ignore_span(call)
+                )
+            )
+        },
         None,
       )
       .is_none()

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_computed_member_access_stylex_create.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_computed_member_access_stylex_create.js
@@ -1,0 +1,8 @@
+import * as stylex from "@stylexjs/stylex";
+const _styles = {
+    root: {
+        k1xSpc: "x78zum5",
+        $$css: true
+    }
+};
+export const root = _styles["root"];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_member_access_stylex_create.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_member_access_stylex_create.js
@@ -1,0 +1,8 @@
+import * as stylex from "@stylexjs/stylex";
+const _styles = {
+    root: {
+        k1xSpc: "x78zum5",
+        $$css: true
+    }
+};
+export const root = _styles.root;

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_member_access_stylex_create_non_null_assertion.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_member_access_stylex_create_non_null_assertion.js
@@ -1,0 +1,8 @@
+import * as stylex from "@stylexjs/stylex";
+const _styles = {
+    root: {
+        k1xSpc: "x78zum5",
+        $$css: true
+    }
+};
+export const root = _styles!.root;

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_member_access_stylex_create_optional_chain.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_member_access_stylex_create_optional_chain.js
@@ -1,0 +1,8 @@
+import * as stylex from "@stylexjs/stylex";
+const _styles = {
+    root: {
+        k1xSpc: "x78zum5",
+        $$css: true
+    }
+};
+export const root = _styles?.root;

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_member_access_stylex_create_parenthesized.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/direct_member_access_stylex_create_parenthesized.js
@@ -1,0 +1,8 @@
+import * as stylex from "@stylexjs/stylex";
+const _styles = {
+    root: {
+        k1xSpc: "x78zum5",
+        $$css: true
+    }
+};
+export const root = _styles.root;

--- a/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
@@ -22,6 +22,18 @@ stylex_test!(
 );
 
 stylex_test!(
+  direct_member_access_stylex_create,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from "@stylexjs/stylex";
+
+    export const root = stylex.create({
+      root: { display: "flex" },
+    }).root;
+  "#
+);
+
+stylex_test!(
   style_object,
   |tr| stylex_transform(tr.comments.clone(), |b| b),
   r#"

--- a/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
@@ -34,6 +34,18 @@ stylex_test!(
 );
 
 stylex_test!(
+  direct_computed_member_access_stylex_create,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from "@stylexjs/stylex";
+
+    export const root = stylex.create({
+      root: { display: "flex" },
+    })["root"];
+  "#
+);
+
+stylex_test!(
   style_object,
   |tr| stylex_transform(tr.comments.clone(), |b| b),
   r#"

--- a/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
@@ -943,3 +943,39 @@ stylex_test!(
     });
   "#
 );
+
+stylex_test!(
+  direct_member_access_stylex_create_parenthesized,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from "@stylexjs/stylex";
+
+    export const root = (stylex.create({
+      root: { display: "flex" },
+    })).root;
+  "#
+);
+
+stylex_test!(
+  direct_member_access_stylex_create_non_null_assertion,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from "@stylexjs/stylex";
+
+    export const root = stylex.create({
+      root: { display: "flex" },
+    })!.root;
+  "#
+);
+
+stylex_test!(
+  direct_member_access_stylex_create_optional_chain,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from "@stylexjs/stylex";
+
+    export const root = stylex.create({
+      root: { display: "flex" },
+    })?.root;
+  "#
+);

--- a/crates/stylex-transform/tests/validation_stylex_create_test/stylex_validation_create.rs
+++ b/crates/stylex-transform/tests/validation_stylex_create_test/stylex_validation_create.rs
@@ -22,6 +22,33 @@ stylex_test_panic!(
   "#
 );
 
+// An unrelated top-level array must not vouch for an unbound call.
+stylex_test_panic!(
+  invalid_use_not_bound_with_unrelated_top_level_array,
+  "create() calls must be bound to a bare variable.",
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const nums = [1, 2];
+    stylex.create({ root: { display: 'flex' } });
+  "#
+);
+
+// A bound `stylex.create({...}).root` must not vouch for a structurally
+// identical but genuinely unbound call elsewhere in the same file.
+stylex_test_panic!(
+  invalid_use_not_bound_with_identical_member_access_twin,
+  "create() calls must be bound to a bare variable.",
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const root = stylex.create({ root: { display: 'flex' } }).root;
+    function f() {
+      stylex.create({ root: { display: 'flex' } });
+    }
+  "#
+);
+
 stylex_test_panic!(
   invalid_argument_none,
   "create() should have 1 argument.",

--- a/crates/stylex-transform/tests/validation_stylex_create_test/stylex_validation_create.rs
+++ b/crates/stylex-transform/tests/validation_stylex_create_test/stylex_validation_create.rs
@@ -87,3 +87,16 @@ stylex_test!(
     export const styles = stylex.create({});
   "#
 );
+
+// Type assertions can only be member-accessed through parentheses, and the
+// emitter drops that grouping (`(x as any).root` prints as `x as any.root`).
+// The call must stay rejected rather than compile to invalid output.
+stylex_test_panic!(
+  invalid_use_not_bound_through_type_assertion,
+  "create() calls must be bound to a bare variable.",
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const root = (stylex.create({ root: { display: 'flex' } }) as any).root;
+  "#
+);


### PR DESCRIPTION
## Description

This pull request updates the validation logic for `stylex.create` calls to support direct member access patterns, and adds corresponding tests to ensure this behavior. The main changes include enhancing the validator to recognize member expressions, updating test cases, and adding a new snapshot for the direct member access scenario.

### Validation logic improvements

* Updated the `validate_stylex_create` function in `validators.rs` to recognize member expressions where a property is accessed directly from the result of a `stylex.create` call (e.g., `stylex.create(...).root`). This is done by matching `Expr::Member` and checking if the underlying call matches the original `stylex.create` call using `EqIgnoreSpan`.
* Added the `EqIgnoreSpan` import to support the comparison logic in the validator.

### Testing updates

* Added a new test case, `direct_member_access_stylex_create`, to `static_styles.rs` to verify that direct member access is handled correctly by the transformer.
* Added a corresponding snapshot file, `direct_member_access_stylex_create.js`, to capture the expected output for the new test case.

## Fixes

(Optional) Fixes #1131

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
