### PR TITLE
feat(transform): enhance binding safety checks for constant violations and mutations

### DIFF
--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -409,13 +409,17 @@ pub struct StateManager {
 
   pub(crate) declarations_state: DeclarationState,
   pub(crate) declarations: Vec<VarDeclarator>,
-  /// Bindings written through assignment, update, destructuring, or loop
-  /// targets. The evaluator must not follow their declaration initializer.
-  pub(crate) constant_violations: FxHashSet<Id>,
-  /// Bindings whose referenced object or array is mutated without rebinding.
-  /// Kept separate from `constant_violations` to preserve the evaluator's two
-  /// binding-safety checks.
-  pub(crate) mutated_bindings: FxHashSet<Id>,
+  /// Bindings whose value can differ from their declaration initializer:
+  /// either rebound (assignment, update, destructuring or loop target — a
+  /// constant violation) or mutated in place (`obj.x = 1`, `arr.push(…)`,
+  /// `delete obj.x`, `Object.assign(obj, …)`). Both cases make the
+  /// initializer an unsound stand-in for the value at the use site, so the
+  /// evaluator deopts identically for them; they share one set to keep the
+  /// lookup on the evaluation hot path to a single hash probe. Keyed by full
+  /// `Id` (`(Atom, SyntaxContext)`), so a write to a shadowing binding never
+  /// deopts the outer one. Populated by the `Discover` pre-scan
+  /// ([`ModuleBindingsCollector`]).
+  pub(crate) binding_writes: FxHashSet<Id>,
   pub(crate) top_level_expressions: Vec<TopLevelExpression>,
   pub(crate) call_expressions: CallExpressionState,
   pub(crate) seen: FxHashMap<u64, Rc<SeenValue>>,
@@ -530,8 +534,7 @@ impl StateManager {
 
       declarations: vec![],
       declarations_state: DeclarationState::default(),
-      constant_violations: FxHashSet::default(),
-      mutated_bindings: FxHashSet::default(),
+      binding_writes: FxHashSet::default(),
       top_level_expressions: vec![],
       call_expressions: CallExpressionState::default(),
       jsx_spread_attr_exprs_map: FxHashMap::default(),
@@ -612,12 +615,11 @@ impl StateManager {
     })
   }
 
-  pub(crate) fn has_constant_violation(&self, ident: &Ident) -> bool {
-    self.constant_violations.contains(&ident.to_id())
-  }
-
-  pub(crate) fn is_mutated(&self, ident: &Ident) -> bool {
-    self.mutated_bindings.contains(&ident.to_id())
+  /// Whether `ident`'s binding is rebound or mutated anywhere in the module,
+  /// which makes its declaration initializer unsafe to inline. See
+  /// [`StateManager::binding_writes`].
+  pub(crate) fn has_binding_write(&self, ident: &Ident) -> bool {
+    self.binding_writes.contains(&ident.to_id())
   }
 
   /// Seeds an empty replacement entry for a JSX spread expression seen during

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -409,6 +409,13 @@ pub struct StateManager {
 
   pub(crate) declarations_state: DeclarationState,
   pub(crate) declarations: Vec<VarDeclarator>,
+  /// Bindings written through assignment, update, destructuring, or loop
+  /// targets. The evaluator must not follow their declaration initializer.
+  pub(crate) constant_violations: FxHashSet<Id>,
+  /// Bindings whose referenced object or array is mutated without rebinding.
+  /// Kept separate from `constant_violations` to preserve the evaluator's two
+  /// binding-safety checks.
+  pub(crate) mutated_bindings: FxHashSet<Id>,
   pub(crate) top_level_expressions: Vec<TopLevelExpression>,
   pub(crate) call_expressions: CallExpressionState,
   pub(crate) seen: FxHashMap<u64, Rc<SeenValue>>,
@@ -523,6 +530,8 @@ impl StateManager {
 
       declarations: vec![],
       declarations_state: DeclarationState::default(),
+      constant_violations: FxHashSet::default(),
+      mutated_bindings: FxHashSet::default(),
       top_level_expressions: vec![],
       call_expressions: CallExpressionState::default(),
       jsx_spread_attr_exprs_map: FxHashMap::default(),
@@ -601,6 +610,14 @@ impl StateManager {
         .iter()
         .any(|scope| scope.lo <= site.lo && scope.hi >= site.hi)
     })
+  }
+
+  pub(crate) fn has_constant_violation(&self, ident: &Ident) -> bool {
+    self.constant_violations.contains(&ident.to_id())
+  }
+
+  pub(crate) fn is_mutated(&self, ident: &Ident) -> bool {
+    self.mutated_bindings.contains(&ident.to_id())
   }
 
   /// Seeds an empty replacement entry for a JSX spread expression seen during

--- a/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
+++ b/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
@@ -371,6 +371,14 @@ fn _evaluate(
 
     let binding = get_var_decl_by_ident(ident, traversal_state, &state.functions);
 
+    if binding.is_some() && traversal_state.has_constant_violation(ident) {
+      return deopt(path, state, NON_CONSTANT);
+    }
+
+    if binding.is_some() && traversal_state.is_mutated(ident) {
+      return deopt(path, state, NON_CONSTANT);
+    }
+
     if let Some(init) = binding.and_then(|mut var_decl| var_decl.init.take()) {
       return evaluate_cached(&init, state, traversal_state, fns);
     }

--- a/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
+++ b/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
@@ -371,11 +371,12 @@ fn _evaluate(
 
     let binding = get_var_decl_by_ident(ident, traversal_state, &state.functions);
 
-    if binding.is_some() && traversal_state.has_constant_violation(ident) {
-      return deopt(path, state, NON_CONSTANT);
-    }
-
-    if binding.is_some() && traversal_state.is_mutated(ident) {
+    // A binding that is rebound or mutated somewhere in the module no longer
+    // matches its declaration initializer at this use site, so inlining the
+    // initializer would bake in a stale value. Bail out to the runtime path
+    // instead; idents with no declaration (imports, globals, injected
+    // functions) are resolved below and unaffected.
+    if binding.is_some() && traversal_state.has_binding_write(ident) {
       return deopt(path, state, NON_CONSTANT);
     }
 

--- a/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
+++ b/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
@@ -369,16 +369,25 @@ fn _evaluate(
       )
     };
 
-    let binding = get_var_decl_by_ident(ident, traversal_state, &state.functions);
-
     // A binding that is rebound or mutated somewhere in the module no longer
     // matches its declaration initializer at this use site, so inlining the
     // initializer would bake in a stale value. Bail out to the runtime path
     // instead; idents with no declaration (imports, globals, injected
     // functions) are resolved below and unaffected.
-    if binding.is_some() && traversal_state.has_binding_write(ident) {
+    //
+    // `has_binding_write` is a single hash probe and is tested first on
+    // purpose: the declaration lookup below deep-clones the `VarDeclarator` it
+    // finds, and on the deopt path that clone is thrown away. Existence is
+    // confirmed with the borrowing `get_var_decl_from`, which — unlike
+    // `get_var_decl_by_ident` — does not also match injected function mappers;
+    // those are regenerated per evaluation and can never hold a stale value.
+    if traversal_state.has_binding_write(ident)
+      && get_var_decl_from(traversal_state, ident).is_some()
+    {
       return deopt(path, state, NON_CONSTANT);
     }
+
+    let binding = get_var_decl_by_ident(ident, traversal_state, &state.functions);
 
     if let Some(init) = binding.and_then(|mut var_decl| var_decl.init.take()) {
       return evaluate_cached(&init, state, traversal_state, fns);

--- a/crates/stylex-transform/src/transform/visit_mut/tests/module_bindings_collector_tests.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/tests/module_bindings_collector_tests.rs
@@ -59,7 +59,7 @@ fn written_names(code: &str) -> FxHashSet<String> {
 fn written_ids(code: &str) -> FxHashSet<Id> {
   GLOBALS.set(&Globals::default(), || {
     let module = resolved_module(code);
-    let mut collector = ModuleBindingsCollector::new(false);
+    let mut collector = ModuleBindingsCollector::writes_only();
     module.visit_with(&mut collector);
 
     collector.binding_writes
@@ -138,6 +138,47 @@ fn records_mutating_object_methods_on_their_target() {
   assert_written("const o = {}; Object.keys(o);", &[]);
 }
 
+/// Parenthesised and nested-wrapper targets reach the same binding as their
+/// bare form, so every write shape must look through them. Each case here
+/// silently escaped detection while the expression-target match was shallow.
+#[test]
+fn looks_through_parenthesised_targets() {
+  assert_written("let a = 1; (a)++;", &["a"]);
+  assert_written("let a = 1; ((a)) = 2;", &["a"]);
+  assert_written("const o = { n: 1 }; (o.n)++;", &["o"]);
+  assert_written("const o = { n: 1 }; ((o).n) = 2;", &["o"]);
+  assert_written("const o = {}; Object.assign((o), { a: 1 });", &["o"]);
+  assert_written("const o = { a: {} }; delete ((o).a);", &["o"]);
+}
+
+/// `arr?.push(1)` parses as an optional call rather than a `CallExpr`, but
+/// mutates the receiver just the same whenever it is non-nullish.
+#[test]
+fn records_mutating_methods_reached_through_optional_calls() {
+  assert_written("const items = []; items?.push(1);", &["items"]);
+  assert_written(
+    "const state = { items: [] }; state.items?.push(1);",
+    &["state"],
+  );
+  assert_written(
+    "const state = { items: [] }; state?.items?.push(1);",
+    &["state"],
+  );
+  // Non-mutating optional calls leave the receiver alone.
+  assert_written("const items = []; items?.at(0);", &[]);
+}
+
+/// A string-literal computed property names its method as unambiguously as
+/// dot access does.
+#[test]
+fn records_mutating_methods_named_by_a_string_literal() {
+  assert_written("const items = []; items['push'](1);", &["items"]);
+  assert_written("const o = {}; Object['assign'](o, { a: 1 });", &["o"]);
+  // A genuinely dynamic property name is unknowable, so nothing is recorded
+  // rather than deopting every computed call in the module.
+  assert_written("const items = []; const m = 'push'; items[m](1);", &[]);
+}
+
 #[test]
 fn keeps_shadowed_bindings_distinct() {
   GLOBALS.set(&Globals::default(), || {
@@ -155,7 +196,7 @@ fn keeps_shadowed_bindings_distinct() {
 
     let outer_id = first_top_level_binding(&module);
 
-    let mut collector = ModuleBindingsCollector::new(false);
+    let mut collector = ModuleBindingsCollector::writes_only();
     module.visit_with(&mut collector);
 
     let written: Vec<&Id> = collector

--- a/crates/stylex-transform/src/transform/visit_mut/tests/module_bindings_collector_tests.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/tests/module_bindings_collector_tests.rs
@@ -1,0 +1,195 @@
+use std::sync::Arc;
+
+use rustc_hash::FxHashSet;
+use swc_core::{
+  common::{FileName, GLOBALS, Globals, Mark, SourceMap, input::StringInput},
+  ecma::{
+    ast::{Decl, Id, Module, ModuleItem, Pass, Program, Stmt},
+    parser::{EsSyntax, Parser, Syntax, lexer::Lexer},
+    transforms::base::resolver,
+    visit::VisitWith,
+  },
+};
+
+use super::ModuleBindingsCollector;
+
+/// Parses `code` and runs SWC's resolver over it, the same way the compiler
+/// does before the StyleX pass, so `Id`s carry real syntax contexts and
+/// shadowed bindings stay distinguishable.
+fn resolved_module(code: &str) -> Module {
+  let source_map = SourceMap::default();
+  let source_file = source_map.new_source_file(
+    Arc::new(FileName::Custom("module_bindings_fixture.tsx".to_string())),
+    code.to_string(),
+  );
+
+  let lexer = Lexer::new(
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    Default::default(),
+    StringInput::from(&*source_file),
+    None,
+  );
+
+  let module = match Parser::new_from(lexer).parse_module() {
+    Ok(module) => module,
+    Err(error) => panic!("failed to parse fixture: {:?}", error),
+  };
+
+  let mut program = Program::Module(module);
+  resolver(Mark::new(), Mark::new(), true).process(&mut program);
+
+  match program {
+    Program::Module(module) => module,
+    Program::Script(_) => unreachable!("a parsed module never becomes a script"),
+  }
+}
+
+/// Names of the bindings the collector recorded as written, ignoring syntax
+/// contexts (asserted separately where shadowing is what's under test).
+fn written_names(code: &str) -> FxHashSet<String> {
+  written_ids(code)
+    .iter()
+    .map(|(sym, _)| sym.to_string())
+    .collect()
+}
+
+fn written_ids(code: &str) -> FxHashSet<Id> {
+  GLOBALS.set(&Globals::default(), || {
+    let module = resolved_module(code);
+    let mut collector = ModuleBindingsCollector::new(false);
+    module.visit_with(&mut collector);
+
+    collector.binding_writes
+  })
+}
+
+fn assert_written(code: &str, expected: &[&str]) {
+  let written = written_names(code);
+  let expected: FxHashSet<String> = expected.iter().map(|name| name.to_string()).collect();
+
+  assert_eq!(written, expected, "for source: {}", code);
+}
+
+#[test]
+fn records_plain_and_compound_assignments() {
+  assert_written("let a = 1; a = 2;", &["a"]);
+  assert_written("let a = 1; a += 2;", &["a"]);
+  assert_written("let a = 1; (a) = 2;", &["a"]);
+}
+
+#[test]
+fn records_update_expressions() {
+  assert_written("let a = 1; a++;", &["a"]);
+  assert_written("let a = 1; --a;", &["a"]);
+  assert_written("const o = { n: 1 }; o.n++;", &["o"]);
+}
+
+#[test]
+fn records_destructuring_assignment_targets() {
+  assert_written("let a, b; [a, b] = [1, 2];", &["a", "b"]);
+  assert_written("let a, rest; ({ a, ...rest } = {});", &["a", "rest"]);
+  assert_written("let a; ({ a = 1 } = {});", &["a"]);
+  // A member target inside a destructuring assignment mutates the object it
+  // is reached through, it does not rebind a name of its own.
+  assert_written("const o = {}; ({ x: o.x } = { x: 1 });", &["o"]);
+}
+
+#[test]
+fn records_loop_head_rebindings() {
+  assert_written("let key; const o = {}; for (key in o) {}", &["key"]);
+  assert_written("let item; for (item of []) {}", &["item"]);
+  // A `for` head that declares its own binding is not a write.
+  assert_written("for (const item of []) { item; }", &[]);
+}
+
+#[test]
+fn records_member_writes_through_the_chain_root() {
+  assert_written("const o = { a: { b: 1 } }; o.a.b = 2;", &["o"]);
+  assert_written("const o = { a: {} }; delete o.a.b;", &["o"]);
+  assert_written("const o = { a: [] }; o.a[0] = 1;", &["o"]);
+  // Nothing to invalidate when the chain root owns no binding.
+  assert_written("getConfig().a.b = 1;", &[]);
+}
+
+#[test]
+fn records_mutating_array_methods_on_nested_receivers() {
+  assert_written("const items = []; items.push(1);", &["items"]);
+  assert_written(
+    "const state = { items: [] }; state.items.push(1);",
+    &["state"],
+  );
+  assert_written("const items = []; items.at(0);", &[]);
+}
+
+#[test]
+fn records_mutating_object_methods_on_their_target() {
+  assert_written("const o = {}; Object.assign(o, { a: 1 });", &["o"]);
+  assert_written("const o = { a: {} }; Object.assign(o.a, {});", &["o"]);
+  assert_written(
+    "const o = {}; Object.defineProperty(o, 'a', { value: 1 });",
+    &["o"],
+  );
+  // A spread first argument names no single binding to invalidate.
+  assert_written("const o = {}; Object.assign(...[o], {});", &[]);
+  // Non-mutating `Object` statics leave their argument alone.
+  assert_written("const o = {}; Object.keys(o);", &[]);
+}
+
+#[test]
+fn keeps_shadowed_bindings_distinct() {
+  GLOBALS.set(&Globals::default(), || {
+    let module = resolved_module(
+      r#"
+        const tokens = { color: "red" };
+
+        export function Component() {
+          let tokens = { color: "blue" };
+          tokens = { color: "green" };
+          return tokens;
+        }
+      "#,
+    );
+
+    let outer_id = first_top_level_binding(&module);
+
+    let mut collector = ModuleBindingsCollector::new(false);
+    module.visit_with(&mut collector);
+
+    let written: Vec<&Id> = collector
+      .binding_writes
+      .iter()
+      .filter(|(sym, _)| sym == "tokens")
+      .collect();
+
+    assert_eq!(
+      written.len(),
+      1,
+      "only the inner `tokens` is written: {:?}",
+      collector.binding_writes
+    );
+    assert_ne!(
+      *written[0], outer_id,
+      "the write to the shadowing `tokens` must not invalidate the outer one"
+    );
+  });
+}
+
+/// `Id` of the first module-level `var`/`let`/`const` binding, used to assert
+/// that a write to a shadowing binding is recorded under a different `Id`.
+fn first_top_level_binding(module: &Module) -> Id {
+  module
+    .body
+    .iter()
+    .find_map(|item| match item {
+      ModuleItem::Stmt(Stmt::Decl(Decl::Var(var_decl))) => var_decl
+        .decls
+        .first()
+        .and_then(|declarator| declarator.name.as_ident())
+        .map(|binding_ident| binding_ident.id.to_id()),
+      _ => None,
+    })
+    .expect("fixture declares a top-level binding")
+}

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -3,10 +3,10 @@ use swc_core::{
   ecma::{
     ast::{
       ArrayPat, ArrowExpr, AssignExpr, AssignTarget, AssignTargetPat, BindingIdent, BlockStmt,
-      CallExpr, Callee, CatchClause, ClassDecl, ClassExpr, Expr, FnDecl, FnExpr, ForHead,
-      ForInStmt, ForOfStmt, Function, Id, Ident, ImportDecl, MemberExpr, MemberProp, Module,
-      ModuleItem, ObjectPat, ObjectPatProp, OptChainBase, Pat, Program, Script, SimpleAssignTarget,
-      UnaryExpr, UnaryOp, UpdateExpr, VarDecl, VarDeclKind,
+      CallExpr, Callee, CatchClause, ClassDecl, ClassExpr, Expr, ExprOrSpread, FnDecl, FnExpr,
+      ForHead, ForInStmt, ForOfStmt, Function, Id, Ident, ImportDecl, Lit, MemberExpr, MemberProp,
+      Module, ModuleItem, ObjectPat, ObjectPatProp, OptChainBase, OptChainExpr, Pat, Program,
+      Script, SimpleAssignTarget, UnaryExpr, UnaryOp, UpdateExpr, VarDecl, VarDeclKind,
     },
     visit::{Visit, VisitMutWith, VisitWith},
   },
@@ -82,6 +82,18 @@ struct ModuleBindingsCollector {
 }
 
 impl ModuleBindingsCollector {
+  /// Collects everything: the `sx` runtime-binding inputs (import sources,
+  /// bound names, rebinding scopes) *and* binding writes, in one pass.
+  fn for_sx() -> Self {
+    Self::new(true)
+  }
+
+  /// Collects binding writes only — used when the `sx` prop is disabled and
+  /// nothing consumes the import-source or scope information.
+  fn writes_only() -> Self {
+    Self::new(false)
+  }
+
   fn new(collect_sx_bindings: bool) -> Self {
     Self {
       collect_sx_bindings,
@@ -147,36 +159,63 @@ impl ModuleBindingsCollector {
   /// Record a write to `ident`'s binding — a rebinding or an in-place
   /// mutation of the value it references. Both make the declaration
   /// initializer unsafe to inline at a use site.
+  ///
+  /// Note the deliberate limit on what counts as a write: only mutations
+  /// spelled out syntactically in this module are recorded. A binding that
+  /// *escapes* into a call (`const a = []; mutate(a);`) is not, because
+  /// deopting on every identifier passed as an argument would disable
+  /// evaluation for nearly every StyleX module. This matches Babel StyleX,
+  /// which tracks `constantViolations` only; the escape case stays a known
+  /// unsoundness in both implementations.
   fn add_binding_write(&mut self, ident: &Ident) {
     self.binding_writes.insert(ident.to_id());
   }
 
-  /// Record a write reached through a member expression (`obj.x = 1`,
-  /// `obj.a.b.push(…)`, `delete obj.x`). Only the *root* object of the chain
-  /// is a binding, so walk past intermediate members, parens and optional
-  /// links to reach it — stopping at anything that is not a plain identifier
-  /// (a call result or literal owns no binding to invalidate).
-  fn add_member_root_write(&mut self, member_expression: &MemberExpr) {
-    let mut object = member_expression.obj.as_ref();
+  /// Record the write performed by an expression used as a write target: a
+  /// bare identifier rebinds itself, a member expression mutates the object at
+  /// the *root* of its chain (`obj.a.b = 1` and `obj.a.b.push(…)` both
+  /// invalidate `obj`). Walks past intermediate members and the parenthesised,
+  /// optional-chain and TypeScript wrappers that can sit anywhere along the
+  /// chain, stopping at anything that owns no binding to invalidate — a call
+  /// result, `this`, `super`, or a literal.
+  ///
+  /// This is the single entry point for every write shape the collector
+  /// recognises (assignment targets, update and `delete` operands, mutating
+  /// method receivers, `Object.assign` targets). Keeping one walk means a
+  /// wrapper handled for one shape is handled for all of them; the earlier
+  /// split between a member-only walk and a shallow expression match silently
+  /// missed `(n)++`, `((a)) = 2` and `Object.assign((o), …)`.
+  fn add_target_root_write(&mut self, expression: &Expr) {
+    let mut current = expression;
 
     loop {
-      match object {
+      match current {
         Expr::Ident(ident) => {
           self.add_binding_write(ident);
           return;
         },
-        Expr::Member(inner) => object = inner.obj.as_ref(),
-        Expr::Paren(paren) => object = paren.expr.as_ref(),
+        Expr::Member(inner) => current = inner.obj.as_ref(),
+        Expr::Paren(paren) => current = paren.expr.as_ref(),
         Expr::OptChain(opt_chain) => match opt_chain.base.as_ref() {
-          OptChainBase::Member(inner) => object = inner.obj.as_ref(),
+          OptChainBase::Member(inner) => current = inner.obj.as_ref(),
+          // `f()?.x = 1` writes into a call result, which owns no binding.
           OptChainBase::Call(_) => return,
         },
-        Expr::TsNonNull(non_null) => object = non_null.expr.as_ref(),
-        Expr::TsAs(ts_as) => object = ts_as.expr.as_ref(),
-        Expr::TsSatisfies(satisfies) => object = satisfies.expr.as_ref(),
+        Expr::TsNonNull(non_null) => current = non_null.expr.as_ref(),
+        Expr::TsAs(ts_as) => current = ts_as.expr.as_ref(),
+        Expr::TsSatisfies(satisfies) => current = satisfies.expr.as_ref(),
+        Expr::TsTypeAssertion(assertion) => current = assertion.expr.as_ref(),
+        Expr::TsInstantiation(instantiation) => current = instantiation.expr.as_ref(),
         _ => return,
       }
     }
+  }
+
+  /// Record a write reached through a member expression (`obj.x = 1`,
+  /// `obj.a.b.push(…)`, `delete obj.x`) by invalidating the binding at the
+  /// root of the chain.
+  fn add_member_root_write(&mut self, member_expression: &MemberExpr) {
+    self.add_target_root_write(member_expression.obj.as_ref());
   }
 
   /// Record every binding written by an assignment or `for-in`/`for-of`
@@ -218,46 +257,113 @@ impl ModuleBindingsCollector {
     }
   }
 
-  /// Record the write performed by an assignment target, unwrapping the
-  /// parenthesised and TypeScript wrappers that can sit between the target
-  /// and the identifier or member it resolves to.
+  /// Record the write performed by an assignment target. Every arm that
+  /// carries an expression defers to [`Self::add_target_root_write`], which
+  /// unwraps the parenthesised and TypeScript wrappers that can nest between
+  /// the target and the identifier or member it resolves to.
   fn add_simple_target_write(&mut self, target: &SimpleAssignTarget) {
     match target {
       SimpleAssignTarget::Ident(ident) => self.add_binding_write(&ident.id),
       SimpleAssignTarget::Member(member_expression) => {
         self.add_member_root_write(member_expression)
       },
-      SimpleAssignTarget::Paren(paren) => self.add_expr_target_write(&paren.expr),
+      SimpleAssignTarget::Paren(paren) => self.add_target_root_write(&paren.expr),
       SimpleAssignTarget::OptChain(opt_chain) => {
         if let OptChainBase::Member(member_expression) = opt_chain.base.as_ref() {
           self.add_member_root_write(member_expression);
         }
       },
-      SimpleAssignTarget::TsAs(ts_as) => self.add_expr_target_write(&ts_as.expr),
-      SimpleAssignTarget::TsSatisfies(satisfies) => self.add_expr_target_write(&satisfies.expr),
-      SimpleAssignTarget::TsNonNull(non_null) => self.add_expr_target_write(&non_null.expr),
-      SimpleAssignTarget::TsTypeAssertion(assertion) => self.add_expr_target_write(&assertion.expr),
+      SimpleAssignTarget::TsAs(ts_as) => self.add_target_root_write(&ts_as.expr),
+      SimpleAssignTarget::TsSatisfies(satisfies) => self.add_target_root_write(&satisfies.expr),
+      SimpleAssignTarget::TsNonNull(non_null) => self.add_target_root_write(&non_null.expr),
+      SimpleAssignTarget::TsTypeAssertion(assertion) => self.add_target_root_write(&assertion.expr),
       SimpleAssignTarget::TsInstantiation(instantiation) => {
-        self.add_expr_target_write(&instantiation.expr)
+        self.add_target_root_write(&instantiation.expr)
       },
       // `super.x = 1` and invalid targets bind no module-level name.
       SimpleAssignTarget::SuperProp(_) | SimpleAssignTarget::Invalid(_) => {},
     }
   }
 
-  /// Record the write performed by an expression used as an assignment target
-  /// (the payload of the TypeScript assignment-target wrappers).
-  fn add_expr_target_write(&mut self, expression: &Expr) {
-    match expression {
-      Expr::Ident(ident) => self.add_binding_write(ident),
-      Expr::Member(member_expression) => self.add_member_root_write(member_expression),
-      _ => {},
+  /// Record the mutations performed by a method call, shared by plain calls
+  /// (`arr.push(1)`) and optional calls (`arr?.push(1)`) — both reach the same
+  /// receiver, so both must invalidate it.
+  fn add_call_mutation_writes(&mut self, callee: &Expr, args: &[ExprOrSpread]) {
+    let Some(member_expression) = member_target(callee) else {
+      return;
+    };
+
+    let Some(property) = member_property_name(&member_expression.prop) else {
+      // A dynamic property (`arr[method](…)`) names no known method. Nothing
+      // is recorded: guessing would deopt every computed call in the module.
+      return;
+    };
+
+    // `arr.push(…)`, `arr.sort()`, … mutate the receiver in place. The
+    // receiver may itself be a member chain (`state.items.push(…)`), in
+    // which case the binding to invalidate is the chain's root object.
+    if MUTATING_ARRAY_METHODS.contains(property) {
+      self.add_member_root_write(member_expression);
     }
+
+    // `Object.assign(target, …)` and friends mutate their first argument.
+    // Matching on the `Object` name is a deliberate over-approximation: a
+    // shadowed `Object` only costs a deopt, never a wrong inline.
+    if MUTATING_OBJECT_METHODS.contains(property)
+      && member_expression
+        .obj
+        .as_ident()
+        .is_some_and(|object| object.sym == "Object")
+      && let Some(first_argument) = args.first()
+      && first_argument.spread.is_none()
+    {
+      self.add_target_root_write(first_argument.expr.as_ref());
+    }
+  }
+}
+
+/// The `MemberExpr` an expression resolves to, looking through parentheses,
+/// TypeScript wrappers and the optional-chain link of `obj?.x`. `None` when
+/// the expression is not a member access — used where only a member access can
+/// signal a mutation (a mutating method's callee, a `delete` operand), so that
+/// `arr.push`, `(arr).push` and `arr?.push` are all recognised alike.
+fn member_target(expression: &Expr) -> Option<&MemberExpr> {
+  match expression {
+    Expr::Member(member_expression) => Some(member_expression),
+    Expr::Paren(paren) => member_target(paren.expr.as_ref()),
+    Expr::TsNonNull(non_null) => member_target(non_null.expr.as_ref()),
+    Expr::TsAs(ts_as) => member_target(ts_as.expr.as_ref()),
+    Expr::TsSatisfies(satisfies) => member_target(satisfies.expr.as_ref()),
+    Expr::TsTypeAssertion(assertion) => member_target(assertion.expr.as_ref()),
+    Expr::TsInstantiation(instantiation) => member_target(instantiation.expr.as_ref()),
+    Expr::OptChain(opt_chain) => match opt_chain.base.as_ref() {
+      OptChainBase::Member(member_expression) => Some(member_expression),
+      OptChainBase::Call(_) => None,
+    },
+    _ => None,
+  }
+}
+
+/// The statically known name of a member property: `obj.push` and
+/// `obj["push"]` both yield `push`. `None` for a genuinely dynamic property,
+/// whose name is unknowable at build time.
+fn member_property_name(property: &MemberProp) -> Option<&str> {
+  match property {
+    MemberProp::Ident(ident) => Some(ident.sym.as_ref()),
+    MemberProp::Computed(computed) => match computed.expr.as_ref() {
+      // A lone-surrogate property name cannot be one of the method names being
+      // matched, so treat it as unknown rather than panicking on the decode.
+      Expr::Lit(Lit::Str(string)) => string.value.as_atom().map(|atom| &**atom),
+      _ => None,
+    },
+    MemberProp::PrivateName(_) => None,
   }
 }
 
 impl Visit for ModuleBindingsCollector {
   fn visit_import_decl(&mut self, import_decl: &ImportDecl) {
+    // An import declaration contains no write targets, so in writes-only mode
+    // there is nothing to collect and nothing to descend into.
     if !self.collect_sx_bindings {
       return;
     }
@@ -383,14 +489,16 @@ impl Visit for ModuleBindingsCollector {
   }
 
   fn visit_update_expr(&mut self, update_expression: &UpdateExpr) {
-    self.add_expr_target_write(update_expression.arg.as_ref());
+    self.add_target_root_write(update_expression.arg.as_ref());
 
     update_expression.visit_children_with(self);
   }
 
   fn visit_unary_expr(&mut self, unary_expression: &UnaryExpr) {
+    // `delete obj.x` mutates `obj`. Only a member operand is a mutation:
+    // `delete someBinding` is a no-op on a declared binding's value.
     if unary_expression.op == UnaryOp::Delete
-      && let Expr::Member(member_expression) = unary_expression.arg.as_ref()
+      && let Some(member_expression) = member_target(unary_expression.arg.as_ref())
     {
       self.add_member_root_write(member_expression);
     }
@@ -399,33 +507,22 @@ impl Visit for ModuleBindingsCollector {
   }
 
   fn visit_call_expr(&mut self, call_expression: &CallExpr) {
-    if let Callee::Expr(callee) = &call_expression.callee
-      && let Expr::Member(member_expression) = callee.as_ref()
-      && let MemberProp::Ident(property) = &member_expression.prop
-    {
-      // `arr.push(…)`, `arr.sort()`, … mutate the receiver in place. The
-      // receiver may itself be a member chain (`state.items.push(…)`), in
-      // which case the binding to invalidate is the chain's root object.
-      if MUTATING_ARRAY_METHODS.contains(property.sym.as_ref()) {
-        self.add_member_root_write(member_expression);
-      }
-
-      // `Object.assign(target, …)` and friends mutate their first argument.
-      // Matching on the `Object` name is a deliberate over-approximation: a
-      // shadowed `Object` only costs a deopt, never a wrong inline.
-      if MUTATING_OBJECT_METHODS.contains(property.sym.as_ref())
-        && member_expression
-          .obj
-          .as_ident()
-          .is_some_and(|object| object.sym == "Object")
-        && let Some(first_argument) = call_expression.args.first()
-        && first_argument.spread.is_none()
-      {
-        self.add_expr_target_write(first_argument.expr.as_ref());
-      }
+    if let Callee::Expr(callee) = &call_expression.callee {
+      self.add_call_mutation_writes(callee.as_ref(), &call_expression.args);
     }
 
     call_expression.visit_children_with(self);
+  }
+
+  fn visit_opt_chain_expr(&mut self, opt_chain: &OptChainExpr) {
+    // `arr?.push(1)` parses as an optional *call*, not a `CallExpr`, so it
+    // needs its own hook — it mutates the receiver exactly as `arr.push(1)`
+    // does whenever the receiver is non-nullish.
+    if let OptChainBase::Call(call) = opt_chain.base.as_ref() {
+      self.add_call_mutation_writes(call.callee.as_ref(), &call.args);
+    }
+
+    opt_chain.visit_children_with(self);
   }
 
   fn visit_for_in_stmt(&mut self, for_in_statement: &ForInStmt) {
@@ -533,7 +630,7 @@ where
     // scan is deferred to `collect_binding_writes`, which only runs for
     // modules that actually reach evaluation.
     if self.state.options.sx_prop_name.is_some() {
-      let mut collector = ModuleBindingsCollector::new(true);
+      let mut collector = ModuleBindingsCollector::for_sx();
       module.visit_with(&mut collector);
 
       self.state.binding_writes = collector.binding_writes;
@@ -557,7 +654,7 @@ where
       return;
     }
 
-    let mut collector = ModuleBindingsCollector::new(false);
+    let mut collector = ModuleBindingsCollector::writes_only();
     module.visit_with(&mut collector);
 
     self.state.binding_writes = collector.binding_writes;

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -2,9 +2,12 @@ use swc_core::{
   common::{BytePos, Span, comments::Comments},
   ecma::{
     ast::{
-      ArrowExpr, BindingIdent, BlockStmt, CatchClause, ClassDecl, ClassExpr, FnDecl, FnExpr,
-      Function, ImportDecl, Module, ModuleItem, Program, Script, VarDecl, VarDeclKind,
+      ArrowExpr, AssignExpr, AssignTarget, BindingIdent, BlockStmt, CallExpr, Callee, CatchClause,
+      ClassDecl, ClassExpr, Expr, FnDecl, FnExpr, ForHead, ForInStmt, ForOfStmt, Function, Id,
+      Ident, ImportDecl, MemberExpr, MemberProp, Module, ModuleItem, Program, Script,
+      SimpleAssignTarget, UnaryExpr, UnaryOp, UpdateExpr, VarDecl, VarDeclKind,
     },
+    utils::find_pat_ids,
     visit::{Visit, VisitMutWith, VisitWith},
   },
 };
@@ -19,6 +22,7 @@ use crate::{
   },
 };
 use rustc_hash::{FxHashMap, FxHashSet};
+use stylex_constants::constants::common::{MUTATING_ARRAY_METHODS, MUTATING_OBJECT_METHODS};
 use stylex_enums::core::TransformationCycle;
 
 /// Span covering the whole source, used for the module-level scope frame so
@@ -54,17 +58,20 @@ struct ScopeFrame {
 /// `Discover` cycle. Captures the sources of every import declaration
 /// (including type-only ones) in body order, the names of every bound
 /// identifier in the module, and — for non-import bindings — the source span
-/// of the scope each one occupies. SWC visitors have no parent pointers or
-/// scope chain, so this pre-scan supplies the import-source and binding
-/// information `get_stylex_runtime_binding` needs; the recorded scope spans
-/// let `is_locally_rebound_at` perform its position-aware shadow check.
+/// of the scope each one occupies. It also records writes to bindings and
+/// mutations of their referenced values for static evaluation. SWC visitors
+/// have no parent pointers or scope chain, so this pre-scan supplies the
+/// binding information used by both runtime-binding resolution and evaluation.
 struct ModuleBindingsCollector {
+  collect_sx_bindings: bool,
   import_sources: Vec<String>,
   bound_names: FxHashSet<String>,
   /// For each name bound by a non-import declaration, the spans of the scopes
   /// in which it is bound. A name shadows an `sx` site iff one of its scope
   /// spans encloses that site (see [`StateManager::is_locally_rebound_at`]).
   local_rebinding_scopes: FxHashMap<String, Vec<Span>>,
+  constant_violations: FxHashSet<Id>,
+  mutated_bindings: FxHashSet<Id>,
   /// Stack of enclosing lexical scopes, outermost (module) first.
   scope_stack: Vec<ScopeFrame>,
   /// `VarDeclKind` of the `VarDecl` currently being visited, if any — needed
@@ -74,11 +81,14 @@ struct ModuleBindingsCollector {
 }
 
 impl ModuleBindingsCollector {
-  fn new() -> Self {
+  fn new(collect_sx_bindings: bool) -> Self {
     Self {
+      collect_sx_bindings,
       import_sources: Vec::new(),
       bound_names: FxHashSet::default(),
       local_rebinding_scopes: FxHashMap::default(),
+      constant_violations: FxHashSet::default(),
+      mutated_bindings: FxHashSet::default(),
       // Seed a module-level function scope spanning the whole source so
       // top-level bindings enclose every `sx` site.
       scope_stack: vec![ScopeFrame {
@@ -115,7 +125,12 @@ impl ModuleBindingsCollector {
   /// `bound_names` (every binding) and `local_rebinding_scopes` (non-import
   /// only), scoping it to the function scope when `hoisted` (`var`
   /// declarations) or the innermost scope otherwise.
-  fn add_local_binding(&mut self, name: String, hoisted: bool) {
+  fn add_local_binding(&mut self, name: &str, hoisted: bool) {
+    if !self.collect_sx_bindings {
+      return;
+    }
+
+    let name = name.to_string();
     let scope = if hoisted {
       self.nearest_function_scope()
     } else {
@@ -128,10 +143,35 @@ impl ModuleBindingsCollector {
       .or_default()
       .push(scope);
   }
+
+  fn add_constant_violations<T>(&mut self, pattern: &T)
+  where
+    T: VisitWith<swc_core::ecma::utils::DestructuringFinder<Id>>,
+  {
+    self.constant_violations.extend(find_pat_ids(pattern));
+  }
+
+  fn add_constant_violation(&mut self, ident: &Ident) {
+    self.constant_violations.insert(ident.to_id());
+  }
+
+  fn add_mutated_binding(&mut self, ident: &Ident) {
+    self.mutated_bindings.insert(ident.to_id());
+  }
+
+  fn add_mutated_member(&mut self, member_expression: &MemberExpr) {
+    if let Some(object) = member_expression.obj.as_ident() {
+      self.add_mutated_binding(object);
+    }
+  }
 }
 
 impl Visit for ModuleBindingsCollector {
   fn visit_import_decl(&mut self, import_decl: &ImportDecl) {
+    if !self.collect_sx_bindings {
+      return;
+    }
+
     self
       .import_sources
       .push(convert_atom_to_string(&import_decl.src.value));
@@ -174,7 +214,7 @@ impl Visit for ModuleBindingsCollector {
     if let Some(ident) = &fn_expr.ident {
       // A named function expression's name is bound only inside the function
       // body, where it can shadow an imported `stylex` namespace.
-      self.add_local_binding(ident.sym.to_string(), false);
+      self.add_local_binding(ident.sym.as_ref(), false);
     }
 
     fn_expr.function.visit_children_with(self);
@@ -189,7 +229,7 @@ impl Visit for ModuleBindingsCollector {
 
     if let Some(ident) = &class_expr.ident {
       // A named class expression's name is visible inside the class body.
-      self.add_local_binding(ident.sym.to_string(), false);
+      self.add_local_binding(ident.sym.as_ref(), false);
     }
 
     class_expr.class.visit_children_with(self);
@@ -222,21 +262,101 @@ impl Visit for ModuleBindingsCollector {
 
   fn visit_binding_ident(&mut self, binding_ident: &BindingIdent) {
     let hoisted = self.current_var_kind == Some(VarDeclKind::Var);
-    self.add_local_binding(binding_ident.id.sym.to_string(), hoisted);
+    self.add_local_binding(binding_ident.id.sym.as_ref(), hoisted);
     binding_ident.visit_children_with(self);
   }
 
   fn visit_fn_decl(&mut self, fn_decl: &FnDecl) {
     // Function declarations in modules are block-scoped; top-level ones still
     // land in the module scope because it is the innermost frame there.
-    self.add_local_binding(fn_decl.ident.sym.to_string(), false);
+    self.add_local_binding(fn_decl.ident.sym.as_ref(), false);
     fn_decl.visit_children_with(self);
   }
 
   fn visit_class_decl(&mut self, class_decl: &ClassDecl) {
     // Class declarations are block-scoped, not hoisted.
-    self.add_local_binding(class_decl.ident.sym.to_string(), false);
+    self.add_local_binding(class_decl.ident.sym.as_ref(), false);
     class_decl.visit_children_with(self);
+  }
+
+  fn visit_assign_expr(&mut self, assign_expression: &AssignExpr) {
+    match &assign_expression.left {
+      AssignTarget::Simple(SimpleAssignTarget::Ident(ident)) => {
+        self.add_constant_violation(&ident.id);
+      },
+      AssignTarget::Simple(SimpleAssignTarget::Member(member_expression)) => {
+        self.add_mutated_member(member_expression);
+      },
+      AssignTarget::Pat(pattern) => {
+        self.add_constant_violations(pattern);
+      },
+      _ => {},
+    }
+
+    assign_expression.visit_children_with(self);
+  }
+
+  fn visit_update_expr(&mut self, update_expression: &UpdateExpr) {
+    match update_expression.arg.as_ref() {
+      Expr::Ident(ident) => {
+        self.add_constant_violation(ident);
+      },
+      Expr::Member(member_expression) => {
+        self.add_mutated_member(member_expression);
+      },
+      _ => {},
+    }
+
+    update_expression.visit_children_with(self);
+  }
+
+  fn visit_unary_expr(&mut self, unary_expression: &UnaryExpr) {
+    if unary_expression.op == UnaryOp::Delete
+      && let Expr::Member(member_expression) = unary_expression.arg.as_ref()
+    {
+      self.add_mutated_member(member_expression);
+    }
+
+    unary_expression.visit_children_with(self);
+  }
+
+  fn visit_call_expr(&mut self, call_expression: &CallExpr) {
+    if let Callee::Expr(callee) = &call_expression.callee
+      && let Expr::Member(member_expression) = callee.as_ref()
+      && let Some(object) = member_expression.obj.as_ident()
+      && let MemberProp::Ident(property) = &member_expression.prop
+    {
+      if MUTATING_ARRAY_METHODS.contains(property.sym.as_ref()) {
+        self.add_mutated_binding(object);
+      }
+
+      if object.sym == "Object"
+        && MUTATING_OBJECT_METHODS.contains(property.sym.as_ref())
+        && let Some(first_argument) = call_expression.args.first()
+        && first_argument.spread.is_none()
+        && let Some(ident) = first_argument.expr.as_ident()
+      {
+        self.add_mutated_binding(ident);
+      }
+    }
+
+    call_expression.visit_children_with(self);
+  }
+
+  fn visit_for_in_stmt(&mut self, for_in_statement: &ForInStmt) {
+    if let ForHead::Pat(pattern) = &for_in_statement.left {
+      self.add_constant_violations(pattern.as_ref());
+    }
+
+    for_in_statement.visit_children_with(self);
+  }
+
+  fn visit_for_of_stmt(&mut self, for_of_statement: &ForOfStmt) {
+    if let ForHead::Pat(pattern) = &for_of_statement.left {
+      self.add_constant_violations(pattern.as_ref());
+    }
+
+    for_of_statement.visit_children_with(self);
   }
 }
 
@@ -316,15 +436,17 @@ where
   pub(crate) fn discover_module(&mut self, module: &mut Module) {
     self.state.cycle = TransformationCycle::Discover;
 
-    // Pre-scan the whole module once so the `sx` runtime-binding injection
-    // (which runs mid-walk, in this same cycle) can consult existing import
-    // sources and bound names without parent-pointer / scope APIs. The scan's
-    // output is consumed solely by `get_stylex_runtime_binding` on the `sx`
-    // path, so skip the extra full-module traversal entirely when the `sx`
-    // feature is disabled.
-    if self.state.options.sx_prop_name.is_some() {
-      let mut collector = ModuleBindingsCollector::new();
-      module.visit_with(&mut collector);
+    // Pre-scan the whole module once so evaluator binding-safety checks and the
+    // `sx` runtime-binding injection can consult scope-aware binding data
+    // without parent-pointer / scope APIs.
+    let collect_sx_bindings = self.state.options.sx_prop_name.is_some();
+    let mut collector = ModuleBindingsCollector::new(collect_sx_bindings);
+    module.visit_with(&mut collector);
+
+    self.state.constant_violations = collector.constant_violations;
+    self.state.mutated_bindings = collector.mutated_bindings;
+
+    if collect_sx_bindings {
       self.state.existing_import_sources = collector.import_sources;
       self.state.bound_names = collector.bound_names;
       self.state.local_rebinding_scopes = collector.local_rebinding_scopes;

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_module.rs
@@ -2,12 +2,12 @@ use swc_core::{
   common::{BytePos, Span, comments::Comments},
   ecma::{
     ast::{
-      ArrowExpr, AssignExpr, AssignTarget, BindingIdent, BlockStmt, CallExpr, Callee, CatchClause,
-      ClassDecl, ClassExpr, Expr, FnDecl, FnExpr, ForHead, ForInStmt, ForOfStmt, Function, Id,
-      Ident, ImportDecl, MemberExpr, MemberProp, Module, ModuleItem, Program, Script,
-      SimpleAssignTarget, UnaryExpr, UnaryOp, UpdateExpr, VarDecl, VarDeclKind,
+      ArrayPat, ArrowExpr, AssignExpr, AssignTarget, AssignTargetPat, BindingIdent, BlockStmt,
+      CallExpr, Callee, CatchClause, ClassDecl, ClassExpr, Expr, FnDecl, FnExpr, ForHead,
+      ForInStmt, ForOfStmt, Function, Id, Ident, ImportDecl, MemberExpr, MemberProp, Module,
+      ModuleItem, ObjectPat, ObjectPatProp, OptChainBase, Pat, Program, Script, SimpleAssignTarget,
+      UnaryExpr, UnaryOp, UpdateExpr, VarDecl, VarDeclKind,
     },
-    utils::find_pat_ids,
     visit::{Visit, VisitMutWith, VisitWith},
   },
 };
@@ -70,8 +70,9 @@ struct ModuleBindingsCollector {
   /// in which it is bound. A name shadows an `sx` site iff one of its scope
   /// spans encloses that site (see [`StateManager::is_locally_rebound_at`]).
   local_rebinding_scopes: FxHashMap<String, Vec<Span>>,
-  constant_violations: FxHashSet<Id>,
-  mutated_bindings: FxHashSet<Id>,
+  /// Bindings rebound or mutated anywhere in the module. See
+  /// [`StateManager::binding_writes`].
+  binding_writes: FxHashSet<Id>,
   /// Stack of enclosing lexical scopes, outermost (module) first.
   scope_stack: Vec<ScopeFrame>,
   /// `VarDeclKind` of the `VarDecl` currently being visited, if any — needed
@@ -87,8 +88,7 @@ impl ModuleBindingsCollector {
       import_sources: Vec::new(),
       bound_names: FxHashSet::default(),
       local_rebinding_scopes: FxHashMap::default(),
-      constant_violations: FxHashSet::default(),
-      mutated_bindings: FxHashSet::default(),
+      binding_writes: FxHashSet::default(),
       // Seed a module-level function scope spanning the whole source so
       // top-level bindings enclose every `sx` site.
       scope_stack: vec![ScopeFrame {
@@ -144,24 +144,114 @@ impl ModuleBindingsCollector {
       .push(scope);
   }
 
-  fn add_constant_violations<T>(&mut self, pattern: &T)
-  where
-    T: VisitWith<swc_core::ecma::utils::DestructuringFinder<Id>>,
-  {
-    self.constant_violations.extend(find_pat_ids(pattern));
+  /// Record a write to `ident`'s binding — a rebinding or an in-place
+  /// mutation of the value it references. Both make the declaration
+  /// initializer unsafe to inline at a use site.
+  fn add_binding_write(&mut self, ident: &Ident) {
+    self.binding_writes.insert(ident.to_id());
   }
 
-  fn add_constant_violation(&mut self, ident: &Ident) {
-    self.constant_violations.insert(ident.to_id());
+  /// Record a write reached through a member expression (`obj.x = 1`,
+  /// `obj.a.b.push(…)`, `delete obj.x`). Only the *root* object of the chain
+  /// is a binding, so walk past intermediate members, parens and optional
+  /// links to reach it — stopping at anything that is not a plain identifier
+  /// (a call result or literal owns no binding to invalidate).
+  fn add_member_root_write(&mut self, member_expression: &MemberExpr) {
+    let mut object = member_expression.obj.as_ref();
+
+    loop {
+      match object {
+        Expr::Ident(ident) => {
+          self.add_binding_write(ident);
+          return;
+        },
+        Expr::Member(inner) => object = inner.obj.as_ref(),
+        Expr::Paren(paren) => object = paren.expr.as_ref(),
+        Expr::OptChain(opt_chain) => match opt_chain.base.as_ref() {
+          OptChainBase::Member(inner) => object = inner.obj.as_ref(),
+          OptChainBase::Call(_) => return,
+        },
+        Expr::TsNonNull(non_null) => object = non_null.expr.as_ref(),
+        Expr::TsAs(ts_as) => object = ts_as.expr.as_ref(),
+        Expr::TsSatisfies(satisfies) => object = satisfies.expr.as_ref(),
+        _ => return,
+      }
+    }
   }
 
-  fn add_mutated_binding(&mut self, ident: &Ident) {
-    self.mutated_bindings.insert(ident.to_id());
+  /// Record every binding written by an assignment or `for-in`/`for-of`
+  /// pattern. Identifier targets rebind (`[a, b] = …`); `Pat::Expr` targets
+  /// are member writes (`({ x: obj.x } = …)`) and invalidate the member's
+  /// root object instead.
+  fn add_pattern_writes(&mut self, pattern: &Pat) {
+    match pattern {
+      Pat::Ident(binding_ident) => self.add_binding_write(&binding_ident.id),
+      Pat::Array(array_pattern) => self.add_array_pattern_writes(array_pattern),
+      Pat::Object(object_pattern) => self.add_object_pattern_writes(object_pattern),
+      Pat::Rest(rest_pattern) => self.add_pattern_writes(&rest_pattern.arg),
+      Pat::Assign(assign_pattern) => self.add_pattern_writes(&assign_pattern.left),
+      Pat::Expr(expression) => {
+        if let Expr::Member(member_expression) = expression.as_ref() {
+          self.add_member_root_write(member_expression);
+        }
+      },
+      Pat::Invalid(_) => {},
+    }
   }
 
-  fn add_mutated_member(&mut self, member_expression: &MemberExpr) {
-    if let Some(object) = member_expression.obj.as_ident() {
-      self.add_mutated_binding(object);
+  /// `[a, obj.x, ...rest] = …`, shared by `Pat` and `AssignTargetPat`.
+  fn add_array_pattern_writes(&mut self, array_pattern: &ArrayPat) {
+    for element in array_pattern.elems.iter().flatten() {
+      self.add_pattern_writes(element);
+    }
+  }
+
+  /// `{ a, b: obj.x, c = 1, ...rest } = …`, shared by `Pat` and
+  /// `AssignTargetPat`.
+  fn add_object_pattern_writes(&mut self, object_pattern: &ObjectPat) {
+    for property in &object_pattern.props {
+      match property {
+        ObjectPatProp::KeyValue(key_value) => self.add_pattern_writes(&key_value.value),
+        ObjectPatProp::Assign(assign) => self.add_binding_write(&assign.key.id),
+        ObjectPatProp::Rest(rest) => self.add_pattern_writes(&rest.arg),
+      }
+    }
+  }
+
+  /// Record the write performed by an assignment target, unwrapping the
+  /// parenthesised and TypeScript wrappers that can sit between the target
+  /// and the identifier or member it resolves to.
+  fn add_simple_target_write(&mut self, target: &SimpleAssignTarget) {
+    match target {
+      SimpleAssignTarget::Ident(ident) => self.add_binding_write(&ident.id),
+      SimpleAssignTarget::Member(member_expression) => {
+        self.add_member_root_write(member_expression)
+      },
+      SimpleAssignTarget::Paren(paren) => self.add_expr_target_write(&paren.expr),
+      SimpleAssignTarget::OptChain(opt_chain) => {
+        if let OptChainBase::Member(member_expression) = opt_chain.base.as_ref() {
+          self.add_member_root_write(member_expression);
+        }
+      },
+      SimpleAssignTarget::TsAs(ts_as) => self.add_expr_target_write(&ts_as.expr),
+      SimpleAssignTarget::TsSatisfies(satisfies) => self.add_expr_target_write(&satisfies.expr),
+      SimpleAssignTarget::TsNonNull(non_null) => self.add_expr_target_write(&non_null.expr),
+      SimpleAssignTarget::TsTypeAssertion(assertion) => self.add_expr_target_write(&assertion.expr),
+      SimpleAssignTarget::TsInstantiation(instantiation) => {
+        self.add_expr_target_write(&instantiation.expr)
+      },
+      // `super.x = 1` and invalid targets bind no module-level name.
+      SimpleAssignTarget::SuperProp(_) | SimpleAssignTarget::Invalid(_) => {},
+    }
+  }
+
+  /// Record the write performed by an expression used as an assignment target
+  /// (the payload of the TypeScript assignment-target wrappers).
+  fn add_expr_target_write(&mut self, expression: &Expr) {
+    match expression {
+      Expr::Ident(ident) => self.add_binding_write(ident),
+      Expr::Member(member_expression) => self.add_member_root_write(member_expression),
+      _ => {},
     }
   }
 }
@@ -281,31 +371,19 @@ impl Visit for ModuleBindingsCollector {
 
   fn visit_assign_expr(&mut self, assign_expression: &AssignExpr) {
     match &assign_expression.left {
-      AssignTarget::Simple(SimpleAssignTarget::Ident(ident)) => {
-        self.add_constant_violation(&ident.id);
+      AssignTarget::Simple(target) => self.add_simple_target_write(target),
+      AssignTarget::Pat(pattern) => match pattern {
+        AssignTargetPat::Array(array_pattern) => self.add_array_pattern_writes(array_pattern),
+        AssignTargetPat::Object(object_pattern) => self.add_object_pattern_writes(object_pattern),
+        AssignTargetPat::Invalid(_) => {},
       },
-      AssignTarget::Simple(SimpleAssignTarget::Member(member_expression)) => {
-        self.add_mutated_member(member_expression);
-      },
-      AssignTarget::Pat(pattern) => {
-        self.add_constant_violations(pattern);
-      },
-      _ => {},
     }
 
     assign_expression.visit_children_with(self);
   }
 
   fn visit_update_expr(&mut self, update_expression: &UpdateExpr) {
-    match update_expression.arg.as_ref() {
-      Expr::Ident(ident) => {
-        self.add_constant_violation(ident);
-      },
-      Expr::Member(member_expression) => {
-        self.add_mutated_member(member_expression);
-      },
-      _ => {},
-    }
+    self.add_expr_target_write(update_expression.arg.as_ref());
 
     update_expression.visit_children_with(self);
   }
@@ -314,7 +392,7 @@ impl Visit for ModuleBindingsCollector {
     if unary_expression.op == UnaryOp::Delete
       && let Expr::Member(member_expression) = unary_expression.arg.as_ref()
     {
-      self.add_mutated_member(member_expression);
+      self.add_member_root_write(member_expression);
     }
 
     unary_expression.visit_children_with(self);
@@ -323,20 +401,27 @@ impl Visit for ModuleBindingsCollector {
   fn visit_call_expr(&mut self, call_expression: &CallExpr) {
     if let Callee::Expr(callee) = &call_expression.callee
       && let Expr::Member(member_expression) = callee.as_ref()
-      && let Some(object) = member_expression.obj.as_ident()
       && let MemberProp::Ident(property) = &member_expression.prop
     {
+      // `arr.push(…)`, `arr.sort()`, … mutate the receiver in place. The
+      // receiver may itself be a member chain (`state.items.push(…)`), in
+      // which case the binding to invalidate is the chain's root object.
       if MUTATING_ARRAY_METHODS.contains(property.sym.as_ref()) {
-        self.add_mutated_binding(object);
+        self.add_member_root_write(member_expression);
       }
 
-      if object.sym == "Object"
-        && MUTATING_OBJECT_METHODS.contains(property.sym.as_ref())
+      // `Object.assign(target, …)` and friends mutate their first argument.
+      // Matching on the `Object` name is a deliberate over-approximation: a
+      // shadowed `Object` only costs a deopt, never a wrong inline.
+      if MUTATING_OBJECT_METHODS.contains(property.sym.as_ref())
+        && member_expression
+          .obj
+          .as_ident()
+          .is_some_and(|object| object.sym == "Object")
         && let Some(first_argument) = call_expression.args.first()
         && first_argument.spread.is_none()
-        && let Some(ident) = first_argument.expr.as_ident()
       {
-        self.add_mutated_binding(ident);
+        self.add_expr_target_write(first_argument.expr.as_ref());
       }
     }
 
@@ -345,7 +430,7 @@ impl Visit for ModuleBindingsCollector {
 
   fn visit_for_in_stmt(&mut self, for_in_statement: &ForInStmt) {
     if let ForHead::Pat(pattern) = &for_in_statement.left {
-      self.add_constant_violations(pattern.as_ref());
+      self.add_pattern_writes(pattern);
     }
 
     for_in_statement.visit_children_with(self);
@@ -353,7 +438,7 @@ impl Visit for ModuleBindingsCollector {
 
   fn visit_for_of_stmt(&mut self, for_of_statement: &ForOfStmt) {
     if let ForHead::Pat(pattern) = &for_of_statement.left {
-      self.add_constant_violations(pattern.as_ref());
+      self.add_pattern_writes(pattern);
     }
 
     for_of_statement.visit_children_with(self);
@@ -419,6 +504,12 @@ where
       return;
     }
 
+    // Binding writes are only read by the evaluator, which runs from here on,
+    // so modules that never reach this point pay no pre-scan. When the `sx`
+    // feature is on, `discover_module` already scanned (its output is needed
+    // mid-walk) and this is a no-op.
+    self.collect_binding_writes(module);
+
     self.transform_producers(module);
     self.transform_atoms(module);
     self.transform_consumers(module);
@@ -436,17 +527,16 @@ where
   pub(crate) fn discover_module(&mut self, module: &mut Module) {
     self.state.cycle = TransformationCycle::Discover;
 
-    // Pre-scan the whole module once so evaluator binding-safety checks and the
-    // `sx` runtime-binding injection can consult scope-aware binding data
-    // without parent-pointer / scope APIs.
-    let collect_sx_bindings = self.state.options.sx_prop_name.is_some();
-    let mut collector = ModuleBindingsCollector::new(collect_sx_bindings);
-    module.visit_with(&mut collector);
+    // The `sx` runtime-binding injection runs mid-walk in this same cycle and
+    // consults the pre-scan, so with `sx` enabled the scan has to happen up
+    // front. It collects binding writes in the same pass; without `sx` the
+    // scan is deferred to `collect_binding_writes`, which only runs for
+    // modules that actually reach evaluation.
+    if self.state.options.sx_prop_name.is_some() {
+      let mut collector = ModuleBindingsCollector::new(true);
+      module.visit_with(&mut collector);
 
-    self.state.constant_violations = collector.constant_violations;
-    self.state.mutated_bindings = collector.mutated_bindings;
-
-    if collect_sx_bindings {
+      self.state.binding_writes = collector.binding_writes;
       self.state.existing_import_sources = collector.import_sources;
       self.state.bound_names = collector.bound_names;
       self.state.local_rebinding_scopes = collector.local_rebinding_scopes;
@@ -457,6 +547,20 @@ where
     if self.state.has_import_paths() {
       fill_top_level_expressions(module, &mut self.state);
     }
+  }
+
+  /// Record every binding the module rebinds or mutates, so the evaluator
+  /// never inlines a declaration initializer that no longer holds at the use
+  /// site. No-op when `discover_module` already collected them for `sx`.
+  pub(crate) fn collect_binding_writes(&mut self, module: &Module) {
+    if self.state.options.sx_prop_name.is_some() {
+      return;
+    }
+
+    let mut collector = ModuleBindingsCollector::new(false);
+    module.visit_with(&mut collector);
+
+    self.state.binding_writes = collector.binding_writes;
   }
 
   /// Run the producer transformation pass.
@@ -522,3 +626,7 @@ where
     module.visit_mut_children_with(self);
   }
 }
+
+#[cfg(test)]
+#[path = "tests/module_bindings_collector_tests.rs"]
+mod tests;

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/mutations_of_shadowed_bindings_do_not_deopt_outer_binding.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/mutations_of_shadowed_bindings_do_not_deopt_outer_binding.js
@@ -1,0 +1,18 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as stylex from "@stylexjs/stylex";
+_inject2({
+    ltr: ".x1e2nbdu{color:red}",
+    priority: 3000
+});
+export function Component({ flag }) {
+    if (flag) {
+        let tokens = {
+            color: "blue"
+        };
+        tokens = {
+            color: "green"
+        };
+    }
+    return <div className="x1e2nbdu"/>;
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/sx_conditions_derived_from_mutated_arrays_deopt_static_evaluation.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/sx_conditions_derived_from_mutated_arrays_deopt_static_evaluation.js
@@ -1,0 +1,24 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as stylex from "@stylexjs/stylex";
+_inject2({
+    ltr: ".x78zum5{display:flex}",
+    priority: 3000
+});
+_inject2({
+    ltr: ".x1jnr06f{gap:4px}",
+    priority: 2000
+});
+export function Component({ flag }) {
+    const items = [];
+    if (flag) items.push(1);
+    const hasItems = items.length > 0;
+    return <div {...{
+        0: {
+            className: "x78zum5"
+        },
+        1: {
+            className: "x78zum5 x1jnr06f"
+        }
+    }[!!hasItems << 0]}/>;
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/sx_conditions_derived_from_reassigned_variables_fail_static_evaluation.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/react.rs/sx_conditions_derived_from_reassigned_variables_fail_static_evaluation.js
@@ -1,0 +1,26 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as stylex from "@stylexjs/stylex";
+_inject2({
+    ltr: ".x78zum5{display:flex}",
+    priority: 3000
+});
+_inject2({
+    ltr: ".x1jnr06f{gap:4px}",
+    priority: 2000
+});
+export function Component({
+    flag
+}) {
+    let items = [];
+    if (flag) items = [1];
+    const hasItems = items.length > 0;
+    return <div {...{
+        0: {
+            className: "x78zum5"
+        },
+        1: {
+            className: "x78zum5 x1jnr06f"
+        }
+    }[!!hasItems << 0]} />;
+}

--- a/crates/stylex-transform/tests/transform_misc_test/react.rs
+++ b/crates/stylex-transform/tests/transform_misc_test/react.rs
@@ -291,3 +291,68 @@ stylex_test!(
     });
   "#
 );
+
+stylex_test!(
+  sx_conditions_derived_from_reassigned_variables_fail_static_evaluation,
+  |tr| { build_test_transform(tr.comments.clone(), move |b| { b.with_runtime_injection() }) },
+  r#"
+    import * as stylex from "@stylexjs/stylex";
+
+    const styles = stylex.create({
+      root: { display: "flex" },
+      populated: { gap: 4 },
+    });
+
+    export function Component({ flag }) {
+      let items = [];
+      if (flag) items = [1];
+
+      const hasItems = items.length > 0;
+      return <div sx={[styles.root, hasItems && styles.populated]} />;
+    }
+  "#
+);
+
+stylex_test!(
+  sx_conditions_derived_from_mutated_arrays_deopt_static_evaluation,
+  |tr| { build_test_transform(tr.comments.clone(), move |b| { b.with_runtime_injection() }) },
+  r#"
+    import * as stylex from "@stylexjs/stylex";
+
+    const styles = stylex.create({
+      root: { display: "flex" },
+      populated: { gap: 4 },
+    });
+
+    export function Component({ flag }) {
+      const items = [];
+      if (flag) items.push(1);
+
+      const hasItems = items.length > 0;
+      return <div sx={[styles.root, hasItems && styles.populated]} />;
+    }
+  "#
+);
+
+stylex_test!(
+  mutations_of_shadowed_bindings_do_not_deopt_outer_binding,
+  |tr| { build_test_transform(tr.comments.clone(), move |b| { b.with_runtime_injection() }) },
+  r#"
+    import * as stylex from "@stylexjs/stylex";
+
+    const tokens = { color: "red" };
+
+    const styles = stylex.create({
+      root: { color: tokens.color },
+    });
+
+    export function Component({ flag }) {
+      if (flag) {
+        let tokens = { color: "blue" };
+        tokens = { color: "green" };
+      }
+
+      return <div sx={styles.root} />;
+    }
+  "#
+);

--- a/crates/stylex-transform/tests/validation_stylex_create_test/invalid_values.rs
+++ b/crates/stylex-transform/tests/validation_stylex_create_test/invalid_values.rs
@@ -297,6 +297,61 @@ stylex_test_panic!(
   "#
 );
 
+// Parenthesised and optional-call write targets reach the same binding as
+// their bare forms. Each of these silently produced stale CSS before the
+// write-target walk was unified.
+stylex_test_panic!(
+  parenthesised_update_target_is_not_a_constant_value,
+  "Referenced value is not a constant",
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    let gap = 4;
+    (gap)++;
+
+    const styles = stylex.create({ x: { gap } });
+  "#
+);
+
+stylex_test_panic!(
+  parenthesised_object_assign_target_is_not_a_constant_value,
+  "Referenced value is not a constant",
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    const tokens = { color: 'red' };
+    Object.assign((tokens), { color: 'blue' });
+
+    const styles = stylex.create({ x: { color: tokens.color } });
+  "#
+);
+
+stylex_test_panic!(
+  optionally_called_mutating_method_is_not_a_constant_value,
+  "Referenced value is not a constant",
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    const spacing = [4, 8];
+    spacing?.push(16);
+
+    const styles = stylex.create({ x: { gap: spacing[0] } });
+  "#
+);
+
+stylex_test_panic!(
+  mutating_method_named_by_a_string_literal_is_not_a_constant_value,
+  "Referenced value is not a constant",
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    const spacing = [4, 8];
+    spacing['push'](16);
+
+    const styles = stylex.create({ x: { gap: spacing[0] } });
+  "#
+);
+
 // With the `sx` prop disabled the module pre-scan is deferred until the
 // module is known to import stylex; the binding-write guard must still hold.
 stylex_test_panic!(

--- a/crates/stylex-transform/tests/validation_stylex_create_test/invalid_values.rs
+++ b/crates/stylex-transform/tests/validation_stylex_create_test/invalid_values.rs
@@ -240,3 +240,80 @@ stylex_test_panic!(
     const styles = stylex.create({ x: { transitionProperty: "width" } });
   "#
 );
+
+// A binding that is rebound or mutated anywhere in the module no longer holds
+// its declaration initializer at the `stylex.create` site. Inlining the
+// initializer would bake a stale value into the generated CSS, so evaluation
+// must bail out and report a non-constant reference instead.
+stylex_test_panic!(
+  reassigned_binding_is_not_a_constant_value,
+  "Referenced value is not a constant",
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    let color = 'red';
+    color = 'blue';
+
+    const styles = stylex.create({ x: { color } });
+  "#
+);
+
+stylex_test_panic!(
+  mutated_array_binding_is_not_a_constant_value,
+  "Referenced value is not a constant",
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    const spacing = [4, 8];
+    spacing.push(16);
+
+    const styles = stylex.create({ x: { gap: spacing[0] } });
+  "#
+);
+
+stylex_test_panic!(
+  object_assigned_binding_is_not_a_constant_value,
+  "Referenced value is not a constant",
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    const tokens = { color: 'red' };
+    Object.assign(tokens, { color: 'blue' });
+
+    const styles = stylex.create({ x: { color: tokens.color } });
+  "#
+);
+
+stylex_test_panic!(
+  binding_mutated_through_a_nested_member_is_not_a_constant_value,
+  "Referenced value is not a constant",
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    const theme = { colors: { primary: 'red' } };
+    theme.colors.primary = 'blue';
+
+    const styles = stylex.create({ x: { color: theme.colors.primary } });
+  "#
+);
+
+// With the `sx` prop disabled the module pre-scan is deferred until the
+// module is known to import stylex; the binding-write guard must still hold.
+stylex_test_panic!(
+  reassigned_binding_is_not_a_constant_value_with_sx_disabled,
+  "Referenced value is not a constant",
+  |tr| {
+    build_test_transform(tr.comments.clone(), |b| {
+      b.with_sx_prop_name(SxPropNameParam::Disabled)
+        .with_runtime_injection()
+    })
+  },
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    let color = 'red';
+    color = 'blue';
+
+    const styles = stylex.create({ x: { color } });
+  "#
+);


### PR DESCRIPTION
## Description

This pull request enhances the static evaluation logic in the StyleX transform by tracking assignments and mutations to bindings within modules. This allows the evaluator to correctly deoptimize when variables are reassigned or mutated, improving the accuracy of static evaluation and preventing incorrect optimizations. The changes also ensure that mutations to shadowed bindings do not affect outer bindings. Additional tests are included to verify these behaviors.

**Static Evaluation Improvements**

* Added tracking of bindings that are reassigned (constant violations) and bindings whose referenced objects/arrays are mutated, via new `constant_violations` and `mutated_bindings` fields in `StateManager` and `ModuleBindingsCollector`. This enables the evaluator to detect when a variable is no longer safe for static evaluation. [[1]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805R412-R418) [[2]](diffhunk://#diff-f49c196b273043e82c4b89ee799e471eab1c7fbfe1e6fdd845056dbe431f8d76L57-R74) [[3]](diffhunk://#diff-f49c196b273043e82c4b89ee799e471eab1c7fbfe1e6fdd845056dbe431f8d76L77-R91) [[4]](diffhunk://#diff-f49c196b273043e82c4b89ee799e471eab1c7fbfe1e6fdd845056dbe431f8d76R146-R174) [[5]](diffhunk://#diff-f49c196b273043e82c4b89ee799e471eab1c7fbfe1e6fdd845056dbe431f8d76L319-R449)
* Updated the evaluator logic in `mod.rs` to check for these violations and deoptimize static evaluation when necessary. [[1]](diffhunk://#diff-584b001b50775da92ad0cdddf8f9f9b0d60b4813fa3477ccacad1aa97080d239R374-R381) [[2]](diffhunk://#diff-6062ef539d29a92fc75d1c3579faea348fe403b48deacd729da16836455ad805R615-R622)

**Module Traversal and Binding Collection**

* Enhanced the `ModuleBindingsCollector` to record assignments, mutations, and destructuring patterns that affect binding safety, including handling of assignment, update, unary, and call expressions, as well as loop targets.
* Modified the module discovery phase to always collect mutation/assignment information, even if StyleX is not enabled, ensuring evaluator correctness.

**Testing**

* Added new tests to verify that static evaluation is correctly deoptimized for mutated arrays, reassigned variables, and that mutations of shadowed bindings do not affect outer bindings. [[1]](diffhunk://#diff-c7edd725daa12f006e83e3f11d048b1c935eaa1c0013c08af6c1067fc1b51c28R294-R358) [[2]](diffhunk://#diff-b5b6c5339a2eb1260738b9493f0a8a711e3fddaf7c06009e92e67d8f39197273R1-R26) [[3]](diffhunk://#diff-a936018cf7ada5cdc116cc95d672ecf78f85dc1f82e488c20011556db79b4e9fR1-R24) [[4]](diffhunk://#diff-843e08386fa95eb3e2c9c1bab6ac799f8755093cd5ef92cd941211bc66dbcd1bR1-R18)

These changes significantly improve the reliability of static evaluation in the transform, especially in the presence of dynamic mutations or reassignments.

## Fixes

Fixes #1130

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
