### PR TITLE
fix(unplugin): enhance StyleX transformation logic

### DIFF
--- a/packages/unplugin/__tests__/vite.test.ts
+++ b/packages/unplugin/__tests__/vite.test.ts
@@ -1,0 +1,229 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { createServer } from 'vite';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import type { UnpluginStylexRSOptions } from '../src/types';
+import stylexSwc from '../src/vite';
+
+const roots: string[] = [];
+const placeholder = '/* @stylex-placeholder */';
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
+});
+
+async function transformFixture(
+  files: Record<string, string>,
+  transformCss: (css: string) => string,
+  options: UnpluginStylexRSOptions = {}
+): Promise<void> {
+  const root = await mkdtemp(path.join(process.cwd(), '.stylex-define-consts-'));
+  roots.push(root);
+
+  await Promise.all([
+    writeFile(path.join(root, 'package.json'), JSON.stringify({ type: 'module' })),
+    writeFile(path.join(root, 'stylex.css'), `${placeholder}\n`),
+    ...Object.entries(files).map(async ([file, source]) => {
+      const filePath = path.join(root, file);
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, source);
+    }),
+  ]);
+
+  const server = await createServer({
+    root,
+    logLevel: 'silent',
+    optimizeDeps: { noDiscovery: true },
+    plugins: [
+      {
+        name: 'stylex-runtime-stub',
+        resolveId(id) {
+          return id === '@stylexjs/stylex' ? '\0stylex-runtime-stub' : null;
+        },
+        load(id) {
+          return id === '\0stylex-runtime-stub' ? 'export const create = value => value;' : null;
+        },
+      },
+      stylexSwc({
+        ...options,
+        useCssPlaceholder: placeholder,
+        rsOptions: {
+          dev: true,
+          unstable_moduleResolution: { type: 'commonJS' },
+          ...options.rsOptions,
+        },
+        transformCss,
+      }),
+    ],
+    server: { middlewareMode: true, preTransformRequests: false },
+  });
+
+  try {
+    await server.transformRequest('/styles.ts');
+    await server.transformRequest('/stylex.css');
+  } finally {
+    await server.close();
+  }
+}
+
+const containerConsts = `import * as stylex from '@stylexjs/stylex';
+
+export const Container = stylex.defineConsts({
+  query: '@container example (max-width: 600px)',
+});
+`;
+
+const containerStyles = `import * as stylex from '@stylexjs/stylex';
+import { Container } from './tokens.stylex';
+
+export const styles = stylex.create({
+  root: {
+    display: {
+      default: 'flex',
+      [Container.query]: 'none',
+    },
+  },
+});
+`;
+
+function rejectUnresolvedAtRules(css: string): string {
+  if (/var\(--[^)]+\)\s*\{/.test(css)) throw new Error('Invalid unresolved at-rule');
+  return css;
+}
+
+describe('Vite', () => {
+  test('resolves imported defineConsts at-rules before transforming placeholder CSS', async () => {
+    const transformCss = vi.fn<(css: string) => string>(rejectUnresolvedAtRules);
+
+    await transformFixture(
+      { 'styles.ts': containerStyles, 'tokens.stylex.ts': containerConsts },
+      transformCss
+    );
+
+    expect(transformCss).toHaveBeenCalledTimes(1);
+    expect(transformCss.mock.calls[0]?.[0]).toContain('@container example (max-width: 600px)');
+  });
+
+  test('resolves defineConsts from independent dependency branches', async () => {
+    const transformCss = vi.fn<(css: string) => string>(rejectUnresolvedAtRules);
+
+    await transformFixture(
+      {
+        'styles.ts': `import * as stylex from '@stylexjs/stylex';
+import { Container } from './container.stylex';
+import { Media } from './media.stylex';
+
+export const styles = stylex.create({
+  root: {
+    color: {
+      default: 'red',
+      [Container.query]: 'blue',
+      [Media.query]: 'green',
+    },
+  },
+});
+`,
+        'container.stylex.ts': containerConsts,
+        'media.stylex.ts': `import * as stylex from '@stylexjs/stylex';
+
+export const Media = stylex.defineConsts({
+  query: '@media (min-width: 800px)',
+});
+`,
+      },
+      transformCss
+    );
+
+    expect(transformCss).toHaveBeenCalledTimes(1);
+    expect(transformCss.mock.calls[0]?.[0]).toContain('@container example (max-width: 600px)');
+    expect(transformCss.mock.calls[0]?.[0]).toContain('@media (min-width: 800px)');
+  });
+
+  test('handles cycles while transforming pending dependencies', async () => {
+    const transformCss = vi.fn<(css: string) => string>(rejectUnresolvedAtRules);
+
+    await transformFixture(
+      {
+        'styles.ts': containerStyles,
+        'tokens.stylex.ts': `import './cycle';
+${containerConsts}`,
+        'cycle.ts': `import './tokens.stylex';
+export const cycle = true;
+`,
+      },
+      transformCss
+    );
+
+    expect(transformCss).toHaveBeenCalledTimes(1);
+    expect(transformCss.mock.calls[0]?.[0]).toContain('@container example (max-width: 600px)');
+  });
+
+  test('resolves imported defineConsts inside CSS layers', async () => {
+    const transformCss = vi.fn<(css: string) => string>(rejectUnresolvedAtRules);
+
+    await transformFixture(
+      { 'styles.ts': containerStyles, 'tokens.stylex.ts': containerConsts },
+      transformCss,
+      { useCSSLayers: true }
+    );
+
+    expect(transformCss).toHaveBeenCalledTimes(1);
+    expect(transformCss.mock.calls[0]?.[0]).toContain('@layer');
+    expect(transformCss.mock.calls[0]?.[0]).toContain('@container example (max-width: 600px)');
+  });
+
+  test('does not treat CSS variable declarations as unresolved at-rules', async () => {
+    const transformCss = vi.fn<(css: string) => string>(rejectUnresolvedAtRules);
+
+    await transformFixture(
+      {
+        'styles.ts': `import * as stylex from '@stylexjs/stylex';
+
+export const styles = stylex.create({
+  root: {
+    color: 'var(--brand-color)',
+  },
+});
+`,
+      },
+      transformCss
+    );
+
+    expect(transformCss).toHaveBeenCalledTimes(1);
+    expect(transformCss.mock.calls[0]?.[0]).toContain('color:var(--brand-color)');
+  });
+
+  test('does not treat CSS strings as unresolved at-rules', async () => {
+    const transformCss = vi.fn<(css: string) => string>(css => css);
+
+    await transformFixture(
+      {
+        'styles.ts': `import * as stylex from '@stylexjs/stylex';
+
+export const styles = stylex.create({
+  root: {
+    content: '"} var(--brand-color) {"',
+  },
+});
+`,
+      },
+      transformCss
+    );
+
+    expect(transformCss).toHaveBeenCalledTimes(1);
+  });
+
+  test('defers CSS transformation when defineConsts metadata remains unavailable', async () => {
+    const transformCss = vi.fn<(css: string) => string>(rejectUnresolvedAtRules);
+
+    await transformFixture(
+      { 'styles.ts': containerStyles, 'tokens.stylex.ts': containerConsts },
+      transformCss,
+      { rsOptions: { exclude: [/tokens\.stylex\.ts$/] } }
+    );
+
+    expect(transformCss).not.toHaveBeenCalled();
+  });
+});

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -35,6 +35,17 @@ function hasValidExtension(filePath: string, pageExtensions: string[]): boolean 
 import type { NormalizedOptions as NormalizedOptionsType } from './utils/normalizeOptions';
 type NormalizedOptions = NormalizedOptionsType;
 
+function shouldTransformStyleXFile(id: string, normalizedOptions: NormalizedOptions): boolean {
+  return (
+    hasValidExtension(id, normalizedOptions.pageExtensions) &&
+    shouldTransformFile(
+      id,
+      normalizedOptions.rsOptions.include,
+      normalizedOptions.rsOptions.exclude
+    )
+  );
+}
+
 const { writeFile, mkdir } = promises;
 
 const PLUGIN_NAME = 'unplugin-stylex-rs';
@@ -118,6 +129,96 @@ async function invalidateAndCollectCssModules(
   );
 
   return cssModules;
+}
+
+function hasUnresolvedDefineConstAtRule(css: string): boolean {
+  let atRuleStart = true;
+
+  for (let index = 0; index < css.length; index += 1) {
+    const character = css[index];
+    const nextCharacter = css[index + 1];
+
+    if (character === '/' && nextCharacter === '*') {
+      const commentEnd = css.indexOf('*/', index + 2);
+      if (commentEnd === -1) return false;
+      index = commentEnd + 1;
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      const quote = character;
+      index += 1;
+
+      for (; index < css.length; index += 1) {
+        if (css[index] === '\\') {
+          index += 1;
+        } else if (css[index] === quote) {
+          break;
+        }
+      }
+
+      atRuleStart = false;
+      continue;
+    }
+
+    if (character === '{' || character === '}') {
+      atRuleStart = true;
+      continue;
+    }
+
+    if (/\s/.test(character ?? '')) continue;
+
+    if (atRuleStart && css.startsWith('var(--', index)) {
+      const closingParenthesis = css.indexOf(')', index + 6);
+      if (closingParenthesis === -1) return false;
+
+      if (closingParenthesis > index + 6) {
+        let nextToken = closingParenthesis + 1;
+        while (/\s/.test(css[nextToken] ?? '')) nextToken += 1;
+        if (css[nextToken] === '{') return true;
+      }
+
+      index = closingParenthesis;
+    }
+
+    atRuleStart = false;
+  }
+
+  return false;
+}
+
+async function transformStyleXDependencies(
+  server: ViteDevServer,
+  stylexRules: StyleXRules,
+  normalizedOptions: NormalizedOptions
+): Promise<void> {
+  const visited = new Set<string>();
+
+  const transformDependencies = async (module: ModuleNode): Promise<void> => {
+    await Promise.all(
+      Array.from(module.importedModules, async importedModule => {
+        const moduleId = importedModule.id ?? importedModule.url;
+
+        if (visited.has(moduleId)) return;
+        visited.add(moduleId);
+
+        if (!shouldTransformStyleXFile(moduleId, normalizedOptions)) return;
+
+        await server.transformRequest(importedModule.url);
+        await transformDependencies(importedModule);
+      })
+    );
+  };
+
+  await Promise.all(
+    Object.keys(stylexRules).map(async id => {
+      const module = server.moduleGraph.getModuleById(id);
+
+      if (!module) return;
+      visited.add(id);
+      await transformDependencies(module);
+    })
+  );
 }
 
 /**
@@ -223,16 +324,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
     },
 
     transformInclude(id) {
-      if (!hasValidExtension(id, normalizedOptions.pageExtensions)) {
-        return false;
-      }
-
-      // Add path filtering using Rust function
-      return shouldTransformFile(
-        id,
-        normalizedOptions.rsOptions?.include,
-        normalizedOptions.rsOptions?.exclude
-      );
+      return shouldTransformStyleXFile(id, normalizedOptions);
     },
 
     async transform(inputCode, id) {
@@ -435,7 +527,14 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         if (!cssContent.includes(normalizedOptions.useCssPlaceholder)) return null;
 
         // Get collected StyleX CSS
-        const collectedCSS = getStyleXRules(stylexRules, transformedOptions);
+        let collectedCSS = getStyleXRules(stylexRules, transformedOptions);
+
+        if (collectedCSS && viteDevServer && hasUnresolvedDefineConstAtRule(collectedCSS)) {
+          // Static imports can be registered but not transformed when Vite's request
+          // pre-transform is disabled, leaving defineConsts metadata unavailable.
+          await transformStyleXDependencies(viteDevServer, stylexRules, normalizedOptions);
+          collectedCSS = getStyleXRules(stylexRules, transformedOptions);
+        }
         // Check if dev server is running (more reliable than watchMode)
         const isDevMode = !!viteDevServer;
 
@@ -446,8 +545,10 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           replacementCSS = isDevMode
             ? '/* StyleX styles will load after transformation */'
             : '/* No StyleX styles */';
-        } else {
+        } else if (!hasUnresolvedDefineConstAtRule(collectedCSS)) {
           replacementCSS = await transformStyleXCSS(collectedCSS, id, normalizedOptions);
+        } else {
+          replacementCSS = '/* StyleX styles will load after transformation */';
         }
 
         return cssContent.replace(normalizedOptions.useCssPlaceholder, () => replacementCSS);


### PR DESCRIPTION
- Introduced a new test suite for Vite integration in `vite.test.ts` to validate the resolution of imported defineConsts at-rules.
- Added helper functions to determine if StyleX files should be transformed and to check for unresolved define const at-rules in CSS.
- Enhanced the transformation logic to handle StyleX dependencies more effectively during the Vite server's request transformation process.

## Description

This pull request introduces comprehensive improvements to how StyleX dependencies and `defineConsts` at-rules are resolved and transformed in Vite environments. The changes ensure that imported constants are correctly processed before CSS transformation, handle dependency cycles, and defer transformation when necessary metadata is unavailable. Additionally, the code is refactored for better modularity and maintainability.

### Dependency resolution and transformation improvements

* Added `transformStyleXDependencies` to recursively transform all StyleX dependencies before processing CSS, ensuring that imported `defineConsts` are resolved even in cases of complex or cyclic dependencies.
* Introduced `hasUnresolvedDefineConstAtRule` to detect unresolved at-rules in CSS, allowing the plugin to defer CSS transformation until all necessary metadata is available. [[1]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dR134-R171) [[2]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL438-R485) [[3]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL449-R499)

### Refactoring and code quality

* Refactored file filtering logic by introducing `shouldTransformStyleXFile`, consolidating extension and include/exclude checks for better clarity and maintainability. [[1]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dR38-R48) [[2]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL226-R275)

### Test coverage

* Added extensive tests in `vite.test.ts` to verify correct resolution of imported `defineConsts`, handling of dependency cycles, CSS layer integration, and correct deferral of transformation when metadata is missing.

## Fixes

Fixes #1199 

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
