### PR TITLE
fix(rs-compiler): emit sourcesContent and preserve comments in output

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "oxc.configPath": ".oxlintrc.jsonc",
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
-  "javascript.validate.enable": false,
+  "js/ts.validate.enable": true,
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer"
   },
@@ -47,7 +47,7 @@
     "CLAUDE.md": true
   },
   "git.ignoreLimitWarning": true,
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "[javascript]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,5 +47,8 @@
     "CLAUDE.md": true
   },
   "git.ignoreLimitWarning": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[javascript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,10 @@ Rust reimplementation of Facebook's `StyleX` CSS-in-JS compiler, built on
 - `pnpm run --filter=@stylexswc/<package-name> test` -- run tests for a package
 - `pnpm lint:check` -- lint every Node file (one root Oxlint process; there are
   no per-package lint scripts)
-- `pnpm lint:type-aware` -- type-aware lint rules; needs a prior build
+- `pnpm lint:type-aware` -- type-aware lint rules; builds first, then runs
+  `lint:node:type-aware` once at the root. Its findings are errors and are not
+  reported by `lint:check`, so run it before calling TypeScript work done.
+- `pnpm lint:all` -- `lint:check` plus `lint:type-aware`
 - `pnpm format:check` -- check formatting (one root Oxfmt process, plus rustfmt
   and Taplo for Rust and TOML)
 - `pnpm run --filter=@stylexswc/<package-name> typecheck` -- type check a
@@ -56,5 +59,10 @@ Run npm scripts after the main action has been performed:
 
 - Type checking: `pnpm typecheck`
 - Formatting: `pnpm format:check`
-- Linting: `pnpm lint:check`
+- Linting: `pnpm lint:check`, and `pnpm lint:type-aware` when TypeScript changed
 - Testing: `pnpm test`
+
+Tests that exercise the native binding (anything importing
+`@stylexswc/rs-compiler`) run against `dist/*.node`, not the Rust sources. Edit
+a crate and you must rebuild before the JS suite means anything -- see
+[Testing](./guidelines/coding/TESTING.md).

--- a/crates/stylex-rs-compiler/README.md
+++ b/crates/stylex-rs-compiler/README.md
@@ -127,6 +127,16 @@ Transforming the example above with source maps enabled
 The `metadata.stylex` rules are what bundler plugins collect to build the final
 CSS file.
 
+The `map` above is abridged; by default it also carries `sourcesContent` and
+column-accurate `mappings` — see [`inlineSourcesContent`](#inlinesourcescontent)
+and [`emitSourceMapColumns`](#emitsourcemapcolumns).
+
+> [!NOTE]
+> Comments are preserved in `code`. That matters beyond readability: bundlers
+> and minifiers read some of them — `/* webpackChunkName: "…" */` on dynamic
+> imports names the emitted chunk, and `/* #__PURE__ */` is what lets a
+> minifier drop an unused call.
+
 ## Path Filtering
 
 > [!NOTE]
@@ -366,6 +376,44 @@ namespace instead of re-reading and re-parsing the source.
 An invalid map is ignored with a warning, and the compiler falls back to
 locating positions in the source text as described under
 [`useRealFileForSource`](#userealfileforsource).
+
+### `inlineSourcesContent`
+
+**Type:** `boolean` **Default:** `true`
+
+Embeds the original source text in the emitted map's `sourcesContent`, so
+tooling that reads the map can render the authored file without fetching
+`sources[0]` separately. Chrome DevTools needs this under Next.js dev
+(`eval-source-map`): without it the fetch goes out over `webpack-internal://`
+and fails with `net::ERR_UNKNOWN_URL_SCHEME`.
+
+```ts
+const { map } = transform(filename, inputCode, {
+  // Smaller production maps, or where the source shouldn't ship with the map
+  inlineSourcesContent: false,
+});
+```
+
+Set to `false` and the `sourcesContent` key is omitted from the map entirely.
+
+When [`inputSourceMap`](#inputsourcemap) is provided, the emitted map is the
+chained input map — so the authored text is seeded into that map instead.
+Sources that already carry their own text keep it, which means a chain that
+resolves back to an earlier authored file is left untouched.
+
+### `emitSourceMapColumns`
+
+**Type:** `boolean` **Default:** `true`
+
+Emits column positions in the map's `mappings`, so devtools resolve individual
+expressions rather than whole lines. Set to `false` for smaller,
+line-granularity maps — the same trade-off webpack's `cheap-*` devtools make.
+
+```ts
+const { map } = transform(filename, inputCode, {
+  emitSourceMapColumns: false,
+});
+```
 
 ### `useRealFileForSource`
 

--- a/crates/stylex-rs-compiler/README.md
+++ b/crates/stylex-rs-compiler/README.md
@@ -396,11 +396,18 @@ const { map } = transform(filename, inputCode, {
 
 Set to `false` and the `sourcesContent` key is omitted from the map entirely.
 
+> [!NOTE]
+> This is the default for the compiler's own API. The bundler plugins narrow it
+> to development builds — where the map is read by DevTools — so a production
+> `.map` doesn't publish your source unless you ask for it. Set the option
+> explicitly to override either way.
+
 When [`inputSourceMap`](#inputsourcemap) is provided, the emitted map preserves
-source text supplied by that map. Missing upstream text is not synthesized:
-the compiler only has the current loader input, which may differ from the
-earlier authored files named by the chained map. Set this option to `false` to
-remove inherited source text as well.
+source text supplied by that map, and a missing entry for _this_ file is filled
+in from the current input. Entries naming other files are left alone — the
+compiler only has its own loader input, so text attached to an earlier authored
+file would be plausible but wrong. If two entries resolve to this file, neither
+is filled. Set this option to `false` to drop inherited source text as well.
 
 ### `emitSourceMapColumns`
 
@@ -415,6 +422,14 @@ const { map } = transform(filename, inputCode, {
   emitSourceMapColumns: false,
 });
 ```
+
+> [!NOTE]
+> Ignored when [`inputSourceMap`](#inputsourcemap) is provided. Chaining keeps
+> the input map's own tokens and only shifts them, so the emitted granularity
+> is the upstream map's, not this option's — and a line-granularity shift would
+> apply one correction to every token on the line, misplacing all but the
+> first. To get line-granularity output from a chain, emit the _input_ map
+> without columns.
 
 ### `useRealFileForSource`
 

--- a/crates/stylex-rs-compiler/README.md
+++ b/crates/stylex-rs-compiler/README.md
@@ -396,10 +396,11 @@ const { map } = transform(filename, inputCode, {
 
 Set to `false` and the `sourcesContent` key is omitted from the map entirely.
 
-When [`inputSourceMap`](#inputsourcemap) is provided, the emitted map is the
-chained input map — so the authored text is seeded into that map instead.
-Sources that already carry their own text keep it, which means a chain that
-resolves back to an earlier authored file is left untouched.
+When [`inputSourceMap`](#inputsourcemap) is provided, the emitted map preserves
+source text supplied by that map. Missing upstream text is not synthesized:
+the compiler only has the current loader input, which may differ from the
+earlier authored files named by the chained map. Set this option to `false` to
+remove inherited source text as well.
 
 ### `emitSourceMapColumns`
 

--- a/crates/stylex-rs-compiler/__test__/comments.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/comments.spec.ts
@@ -1,0 +1,87 @@
+// Comments must survive the transform. They are not cosmetic: bundlers and
+// minifiers read some of them, and dropping those silently changes chunk names
+// and defeats tree shaking.
+import { expect, test } from 'vitest';
+
+import { transform } from '../dist/index.js';
+import type { StyleXOptions } from '../dist/index.js';
+
+const FILENAME = '/abs/path/page.tsx';
+
+function compile(code: string): string {
+  return transform(FILENAME, code, {
+    unstable_moduleResolution: { type: 'commonJS' },
+  } as StyleXOptions).code;
+}
+
+test('webpack magic comments survive on dynamic imports', () => {
+  // Losing this silently renames the emitted chunk.
+  const code = compile('export const lazy = () => import(/* webpackChunkName: "lazy" */ "./m");');
+
+  expect(code).toContain('/* webpackChunkName: "lazy" */');
+});
+
+test('#__PURE__ annotations survive', () => {
+  // Losing this defeats minifier tree shaking for the annotated call.
+  const code = compile('export const value = /* #__PURE__ */ compute();');
+
+  expect(code).toContain('/* #__PURE__ */');
+});
+
+test('license banners survive', () => {
+  const code = compile('/*! @license MIT */\nexport const x = 1;');
+
+  expect(code).toContain('/*! @license MIT */');
+});
+
+test('line, block and jsdoc comments all survive', () => {
+  const code = compile(
+    ['// line', '/** jsdoc */', 'export const a = 1;', 'export const b = 2; // trailing'].join('\n')
+  );
+
+  expect(code).toContain('// line');
+  expect(code).toContain('/** jsdoc */');
+  expect(code).toContain('// trailing');
+});
+
+test('comments around a stylex.create call survive its transformation', () => {
+  const code = compile(
+    [
+      'import stylex from "@stylexjs/stylex";',
+      '',
+      '// styles below',
+      'export const styles = stylex.create({',
+      '  default: { color: "red" },',
+      '});',
+      '',
+      '// after',
+      'export const done = true;',
+    ].join('\n')
+  );
+
+  expect(code).toContain('// styles below');
+  expect(code).toContain('// after');
+  // The call itself is still compiled away.
+  expect(code).not.toContain('stylex.create');
+});
+
+test('a comment attached to a removed node does not resurrect the node', () => {
+  const code = compile(
+    [
+      'import stylex from "@stylexjs/stylex";',
+      'export const styles = stylex.create({',
+      '  // per-namespace note',
+      '  default: { color: "red" },',
+      '});',
+    ].join('\n')
+  );
+
+  expect(code).not.toContain('stylex.create');
+  expect(code).toContain('$$css');
+});
+
+test('a file that is only a comment compiles to just that comment', () => {
+  const code = compile('// nothing else here\n');
+
+  expect(code.trim()).toBe('// nothing else here');
+});

--- a/crates/stylex-rs-compiler/__test__/comments.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/comments.spec.ts
@@ -4,14 +4,13 @@
 import { expect, test } from 'vitest';
 
 import { transform } from '../dist/index.js';
-import type { StyleXOptions } from '../dist/index.js';
 
 const FILENAME = '/abs/path/page.tsx';
 
 function compile(code: string): string {
   return transform(FILENAME, code, {
     unstable_moduleResolution: { type: 'commonJS' },
-  } as StyleXOptions).code;
+  }).code;
 }
 
 test('webpack magic comments survive on dynamic imports', () => {

--- a/crates/stylex-rs-compiler/__test__/index.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/index.spec.ts
@@ -80,7 +80,16 @@ export const styles = {
         ],
       ],
     },
-    map: '{"version":3,"sources":["page.tsx"],"names":[],"mappings":"AACI;AAEA;;;;;;;;EAOG"}',
+    // Key order matches the serializer's. `sourcesContent` holds the authored
+    // text and `mappings` carries columns — both on by default, see
+    // `sourceMaps.spec.ts`.
+    map: JSON.stringify({
+      version: 3,
+      sources: ['page.tsx'],
+      sourcesContent: [fixture],
+      names: [],
+      mappings: 'AACI,OAAO,YAAY,mBAAmB;AAEtC,OAAO,MAAM;;;;;;;;EAOV',
+    }),
   };
 
   expect(result).toStrictEqual(expected);

--- a/crates/stylex-rs-compiler/__test__/normalizeRsOptions.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/normalizeRsOptions.spec.ts
@@ -27,6 +27,8 @@ const defaultResult: StyleXOptions = {
   enableLTRRTLComments: false,
   legacyDisableLayers: false,
   useRealFileForSource: true,
+  inlineSourcesContent: true,
+  emitSourceMapColumns: true,
   enableMediaQueryOrder: true,
   enableDebugClassNames: false,
   propertyValidationMode: 'silent',
@@ -417,6 +419,19 @@ test('normalizeRsOptions: legacyDisableLayers default and override', () => {
 test('normalizeRsOptions: useRealFileForSource default and override', () => {
   expect(normalizeRsOptions({}).useRealFileForSource).toBe(true);
   expect(normalizeRsOptions({ useRealFileForSource: false }).useRealFileForSource).toBe(false);
+});
+
+test('normalizeRsOptions: inlineSourcesContent default and override', () => {
+  expect(normalizeRsOptions({}).inlineSourcesContent).toBe(true);
+  expect(normalizeRsOptions({ inlineSourcesContent: false }).inlineSourcesContent).toBe(false);
+  // An explicit `undefined` must not clobber the default — see `definedEntries`.
+  expect(normalizeRsOptions({ inlineSourcesContent: undefined }).inlineSourcesContent).toBe(true);
+});
+
+test('normalizeRsOptions: emitSourceMapColumns default and override', () => {
+  expect(normalizeRsOptions({}).emitSourceMapColumns).toBe(true);
+  expect(normalizeRsOptions({ emitSourceMapColumns: false }).emitSourceMapColumns).toBe(false);
+  expect(normalizeRsOptions({ emitSourceMapColumns: undefined }).emitSourceMapColumns).toBe(true);
 });
 
 test('normalizeRsOptions: enableDebugClassNames default and override', () => {

--- a/crates/stylex-rs-compiler/__test__/sourceMaps.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/sourceMaps.spec.ts
@@ -32,7 +32,7 @@ function compile(options: Partial<StyleXOptions> = {}, code = FIXTURE): Map {
   const result = transform(FILENAME, code, {
     unstable_moduleResolution: { type: 'commonJS' },
     ...options,
-  } as StyleXOptions);
+  });
 
   if (result.map == null) {
     throw new Error('expected the compiler to emit a source map');
@@ -108,7 +108,7 @@ test('sourceMap: false emits no map at all', () => {
   const result = transform(FILENAME, FIXTURE, {
     sourceMap: SourceMaps.False,
     unstable_moduleResolution: { type: 'commonJS' },
-  } as StyleXOptions);
+  });
 
   expect(result.map).toBeUndefined();
 });
@@ -117,7 +117,7 @@ test('inline source maps carry sourcesContent in the data URI', () => {
   const result = transform(FILENAME, FIXTURE, {
     sourceMap: SourceMaps.Inline,
     unstable_moduleResolution: { type: 'commonJS' },
-  } as StyleXOptions);
+  });
 
   const encoded = result.code.match(
     /sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/
@@ -125,7 +125,7 @@ test('inline source maps carry sourcesContent in the data URI', () => {
 
   expect(encoded).toBeDefined();
 
-  const map = JSON.parse(Buffer.from(encoded as string, 'base64').toString('utf8')) as Map;
+  const map = JSON.parse(Buffer.from(encoded!, 'base64').toString('utf8')) as Map;
 
   expect(map.sourcesContent).toStrictEqual([FIXTURE]);
 });
@@ -138,15 +138,49 @@ test('columns are emitted by default and collapse when turned off', () => {
 });
 
 // ── chaining onto an input source map ───────────────────────────────
-// `SourceMap::build_source_map_with_config` returns the *input* map with
-// adjusted mappings, including any source text supplied by earlier tooling.
+// `SourceMap::build_source_map_with_config` returns the *input* map with its
+// mappings adjusted, discarding whatever the printer would have inlined. So
+// `inlineSourcesContent` is applied to the input map itself before printing:
+// the hole for *this* file is seeded, everything else is left as upstream
+// tooling left it.
 
-test('a chained map does not synthesize missing upstream source text', () => {
+test('a chained map is seeded with this file’s text when upstream left it null', () => {
   const map = compile({ inputSourceMap: upstreamMap() });
 
-  // The compiler only has the generated loader input. Attaching it to an
+  // Without this the emitted map reaches DevTools with `sourcesContent: null`
+  // and it goes back out over `webpack-internal://` to fetch the source.
+  expect(map.sourcesContent).toStrictEqual([FIXTURE]);
+});
+
+test('a chained map naming a different file is never backfilled', () => {
+  const map = compile({
+    inputSourceMap: upstreamMap({ sources: ['/abs/path/other.tsx'] }),
+  });
+
+  // The compiler only has the current loader input. Attaching it to an
   // earlier authored source would produce a plausible but incorrect map.
   expect('sourcesContent' in map).toBe(false);
+});
+
+test('an ambiguous chained map is left alone rather than guessed at', () => {
+  // Both entries resolve to the compiled file; neither can be filled with
+  // confidence, so neither is.
+  const map = compile({
+    inputSourceMap: upstreamMap({
+      sources: ['page.tsx', 'path/page.tsx'],
+      sourcesContent: [null, null],
+    }),
+  });
+
+  expect('sourcesContent' in map).toBe(false);
+});
+
+test('a chained map spelling the file relatively is still recognised', () => {
+  const map = compile({
+    inputSourceMap: upstreamMap({ sources: ['./page.tsx'] }),
+  });
+
+  expect(map.sourcesContent).toStrictEqual([FIXTURE]);
 });
 
 test('a chained map keeps the upstream text when it already has some', () => {
@@ -164,6 +198,28 @@ test('inlineSourcesContent: false is honoured on the chained path too', () => {
   });
 
   expect('sourcesContent' in map).toBe(false);
+});
+
+test('emitSourceMapColumns: false is ignored while chaining', () => {
+  // `adjust_mappings` keeps the input map's own tokens and only shifts them by
+  // one delta per covering range in the map built here. Dropping columns from
+  // that map leaves one range per generated line, so every token on the line
+  // gets the delta computed for the first — wrong columns, and no smaller,
+  // since the size is the input map's token count either way.
+  const inputSourceMap = upstreamMap({ mappings: 'AAAA,CAAC,CAAC;AACF,CAAC' });
+
+  const lineOnly = compile({ inputSourceMap, emitSourceMapColumns: false });
+  const withColumns = compile({ inputSourceMap, emitSourceMapColumns: true });
+
+  expect(lineOnly.mappings).toBe(withColumns.mappings);
+});
+
+test('emitSourceMapColumns: false still collapses when nothing is chained', () => {
+  // The option keeps its meaning on the path where it can actually be honoured.
+  const lineOnly = compile({ emitSourceMapColumns: false });
+  const withColumns = compile({ emitSourceMapColumns: true });
+
+  expect(segmentCount(lineOnly.mappings)).toBeLessThan(segmentCount(withColumns.mappings));
 });
 
 test('an unparseable inputSourceMap is ignored and the map still has content', () => {

--- a/crates/stylex-rs-compiler/__test__/sourceMaps.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/sourceMaps.spec.ts
@@ -1,5 +1,5 @@
 // End-to-end coverage for the source-map shape the compiler emits. The Rust
-// unit tests cover flag resolution and the `sourcesContent` backfill in
+// unit tests cover flag resolution and `sourcesContent` removal in
 // isolation; these assert the values actually survive the napi boundary and
 // reach the serialized map.
 import { expect, test } from 'vitest';
@@ -139,13 +139,14 @@ test('columns are emitted by default and collapse when turned off', () => {
 
 // ── chaining onto an input source map ───────────────────────────────
 // `SourceMap::build_source_map_with_config` returns the *input* map with
-// adjusted mappings and skips inlining entirely when chaining, so the authored
-// text has to be seeded into the input map before printing.
+// adjusted mappings, including any source text supplied by earlier tooling.
 
-test('a chained map without sourcesContent gets the authored text backfilled', () => {
+test('a chained map does not synthesize missing upstream source text', () => {
   const map = compile({ inputSourceMap: upstreamMap() });
 
-  expect(map.sourcesContent).toStrictEqual([FIXTURE]);
+  // The compiler only has the generated loader input. Attaching it to an
+  // earlier authored source would produce a plausible but incorrect map.
+  expect('sourcesContent' in map).toBe(false);
 });
 
 test('a chained map keeps the upstream text when it already has some', () => {
@@ -158,44 +159,10 @@ test('a chained map keeps the upstream text when it already has some', () => {
 
 test('inlineSourcesContent: false is honoured on the chained path too', () => {
   const map = compile({
-    inputSourceMap: upstreamMap(),
+    inputSourceMap: upstreamMap({ sourcesContent: ['// private source\n'] }),
     inlineSourcesContent: false,
   });
 
-  expect(map.sourcesContent ?? []).not.toContain(FIXTURE);
-});
-
-test('a chained map whose sources spell the path differently is still filled', () => {
-  // Single-source maps are unambiguously ours regardless of path spelling.
-  const map = compile({
-    inputSourceMap: upstreamMap({ sources: ['webpack://app/./page.tsx'] }),
-  });
-
-  expect(map.sourcesContent).toStrictEqual([FIXTURE]);
-});
-
-test('a multi-source chained map only gets its matching entry filled', () => {
-  const map = compile({
-    inputSourceMap: upstreamMap({
-      sources: ['/abs/path/other.tsx', FILENAME],
-      sourcesContent: [null, null],
-    }),
-  });
-
-  expect(map.sourcesContent).toStrictEqual([null, FIXTURE]);
-});
-
-test('a multi-source chained map with no matching entry is left alone', () => {
-  const map = compile({
-    inputSourceMap: upstreamMap({
-      sources: ['/abs/path/a.tsx', '/abs/path/b.tsx'],
-      sourcesContent: [null, null],
-    }),
-  });
-
-  // With several sources and no path match there is no way to tell which entry
-  // the authored text belongs to, so nothing is filled — and an all-null
-  // `sourcesContent` is dropped on serialization.
   expect('sourcesContent' in map).toBe(false);
 });
 

--- a/crates/stylex-rs-compiler/__test__/sourceMaps.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/sourceMaps.spec.ts
@@ -1,0 +1,206 @@
+// End-to-end coverage for the source-map shape the compiler emits. The Rust
+// unit tests cover flag resolution and the `sourcesContent` backfill in
+// isolation; these assert the values actually survive the napi boundary and
+// reach the serialized map.
+import { expect, test } from 'vitest';
+
+import { transform } from '../dist/index.js';
+import type { StyleXOptions } from '../dist/index.js';
+import { SourceMaps } from '../dist/transform.js';
+
+const FILENAME = '/abs/path/page.tsx';
+
+const FIXTURE = `import stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  default: {
+    backgroundColor: "red",
+    color: "blue",
+  },
+});
+`;
+
+type Map = {
+  version: number;
+  sources: string[];
+  sourcesContent?: (string | null)[];
+  names: string[];
+  mappings: string;
+};
+
+function compile(options: Partial<StyleXOptions> = {}, code = FIXTURE): Map {
+  const result = transform(FILENAME, code, {
+    unstable_moduleResolution: { type: 'commonJS' },
+    ...options,
+  } as StyleXOptions);
+
+  if (result.map == null) {
+    throw new Error('expected the compiler to emit a source map');
+  }
+
+  return JSON.parse(result.map) as Map;
+}
+
+/** A map produced by earlier tooling for the same file. */
+function upstreamMap(overrides: Partial<Map> = {}): string {
+  return JSON.stringify({
+    version: 3,
+    sources: [FILENAME],
+    sourcesContent: [null],
+    names: [],
+    mappings: 'AAAA',
+    ...overrides,
+  });
+}
+
+/** Number of mapping segments — line-only maps produce one per line. */
+function segmentCount(mappings: string): number {
+  return mappings.split(/[;,]/).filter(Boolean).length;
+}
+
+test('sourcesContent is embedded by default', () => {
+  const map = compile();
+
+  expect(map.sourcesContent).toStrictEqual([FIXTURE]);
+});
+
+test('inlineSourcesContent: false omits the key entirely', () => {
+  const map = compile({ inlineSourcesContent: false });
+
+  // Omitted, not `[null]` — an explicit null would tell consumers the source
+  // is known to be unavailable rather than simply not inlined.
+  expect('sourcesContent' in map).toBe(false);
+  expect(map.sources).toStrictEqual([FILENAME]);
+});
+
+test('sourcesContent is the authored text, not the transformed output', () => {
+  const map = compile();
+
+  expect(map.sourcesContent?.[0]).toContain('stylex.create');
+});
+
+test('an empty file yields an empty map rather than a null content entry', () => {
+  const map = compile({}, '');
+
+  // Nothing was emitted, so no source is ever registered with the builder and
+  // there is nothing to inline. The map must still be valid JSON, not a
+  // `sources: [] / sourcesContent: [null]` mismatch.
+  expect(map.sources).toStrictEqual([]);
+  expect('sourcesContent' in map).toBe(false);
+  expect(map.mappings).toBe('');
+});
+
+test('non-ASCII source text survives the napi boundary intact', () => {
+  const code = `${FIXTURE}\nexport const label = "日本語 — émoji 🎨";\n`;
+  const map = compile({}, code);
+
+  expect(map.sourcesContent).toStrictEqual([code]);
+});
+
+test('a file with no stylex usage still gets its content inlined', () => {
+  const code = 'export const answer = 42;\n';
+  const map = compile({}, code);
+
+  expect(map.sourcesContent).toStrictEqual([code]);
+});
+
+test('sourceMap: false emits no map at all', () => {
+  const result = transform(FILENAME, FIXTURE, {
+    sourceMap: SourceMaps.False,
+    unstable_moduleResolution: { type: 'commonJS' },
+  } as StyleXOptions);
+
+  expect(result.map).toBeUndefined();
+});
+
+test('inline source maps carry sourcesContent in the data URI', () => {
+  const result = transform(FILENAME, FIXTURE, {
+    sourceMap: SourceMaps.Inline,
+    unstable_moduleResolution: { type: 'commonJS' },
+  } as StyleXOptions);
+
+  const encoded = result.code.match(
+    /sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/
+  )?.[1];
+
+  expect(encoded).toBeDefined();
+
+  const map = JSON.parse(Buffer.from(encoded as string, 'base64').toString('utf8')) as Map;
+
+  expect(map.sourcesContent).toStrictEqual([FIXTURE]);
+});
+
+test('columns are emitted by default and collapse when turned off', () => {
+  const withColumns = compile();
+  const lineOnly = compile({ emitSourceMapColumns: false });
+
+  expect(segmentCount(withColumns.mappings)).toBeGreaterThan(segmentCount(lineOnly.mappings));
+});
+
+// ── chaining onto an input source map ───────────────────────────────
+// `SourceMap::build_source_map_with_config` returns the *input* map with
+// adjusted mappings and skips inlining entirely when chaining, so the authored
+// text has to be seeded into the input map before printing.
+
+test('a chained map without sourcesContent gets the authored text backfilled', () => {
+  const map = compile({ inputSourceMap: upstreamMap() });
+
+  expect(map.sourcesContent).toStrictEqual([FIXTURE]);
+});
+
+test('a chained map keeps the upstream text when it already has some', () => {
+  const map = compile({
+    inputSourceMap: upstreamMap({ sourcesContent: ['// authored elsewhere\n'] }),
+  });
+
+  expect(map.sourcesContent).toStrictEqual(['// authored elsewhere\n']);
+});
+
+test('inlineSourcesContent: false is honoured on the chained path too', () => {
+  const map = compile({
+    inputSourceMap: upstreamMap(),
+    inlineSourcesContent: false,
+  });
+
+  expect(map.sourcesContent ?? []).not.toContain(FIXTURE);
+});
+
+test('a chained map whose sources spell the path differently is still filled', () => {
+  // Single-source maps are unambiguously ours regardless of path spelling.
+  const map = compile({
+    inputSourceMap: upstreamMap({ sources: ['webpack://app/./page.tsx'] }),
+  });
+
+  expect(map.sourcesContent).toStrictEqual([FIXTURE]);
+});
+
+test('a multi-source chained map only gets its matching entry filled', () => {
+  const map = compile({
+    inputSourceMap: upstreamMap({
+      sources: ['/abs/path/other.tsx', FILENAME],
+      sourcesContent: [null, null],
+    }),
+  });
+
+  expect(map.sourcesContent).toStrictEqual([null, FIXTURE]);
+});
+
+test('a multi-source chained map with no matching entry is left alone', () => {
+  const map = compile({
+    inputSourceMap: upstreamMap({
+      sources: ['/abs/path/a.tsx', '/abs/path/b.tsx'],
+      sourcesContent: [null, null],
+    }),
+  });
+
+  // With several sources and no path match there is no way to tell which entry
+  // the authored text belongs to, so nothing is filled — and an all-null
+  // `sourcesContent` is dropped on serialization.
+  expect('sourcesContent' in map).toBe(false);
+});
+
+test('an unparseable inputSourceMap is ignored and the map still has content', () => {
+  const map = compile({ inputSourceMap: 'not json' });
+
+  expect(map.sourcesContent).toStrictEqual([FIXTURE]);
+});

--- a/crates/stylex-rs-compiler/src/index.ts
+++ b/crates/stylex-rs-compiler/src/index.ts
@@ -14,17 +14,24 @@ export type {
 } from '../dist/transform';
 
 import type {
+  SourceMaps as NativeSourceMaps,
   StyleXOptions as NativeStyleXOptions,
   StyleXTransformResult,
 } from '../dist/transform';
 
 // const enums are erased by TypeScript — provide runtime values
-// so ESM consumers can import them.
+// so ESM consumers can import them. Typed as the native enum rather than as
+// string literals: without that, `{ sourceMap: SourceMaps.False }` fails to
+// typecheck, which defeats the point of exporting the values at all.
 export const SourceMaps = Object.freeze({
   True: 'True',
   False: 'False',
   Inline: 'Inline',
-} as const);
+}) as Readonly<{
+  True: NativeSourceMaps;
+  False: NativeSourceMaps;
+  Inline: NativeSourceMaps;
+}>;
 
 export const PropertyValidationMode = Object.freeze({
   Throw: 'throw',
@@ -74,6 +81,8 @@ const defaultOptions: Partial<StyleXOptions> = {
   enableLTRRTLComments: false,
   legacyDisableLayers: false,
   useRealFileForSource: true,
+  inlineSourcesContent: true,
+  emitSourceMapColumns: true,
   enableMediaQueryOrder: true,
   enableDebugClassNames: false,
   propertyValidationMode: 'silent',
@@ -190,9 +199,13 @@ export function transform(
     // plugins' own edits, so the positions handed to the native transform
     // keep describing the code it actually receives. The native transform
     // owns emission of the final map per `options.sourceMap` (incl. inline).
+    // The intermediate map becomes the native transform's `orig`, and a
+    // chained map keeps whatever `sourcesContent` it arrives with — so it has
+    // to carry the authored text from here.
     const result = swc.transformSync(transformedCode, {
       filename,
       sourceMaps: true,
+      inlineSourcesContent: options.inlineSourcesContent ?? true,
       inputSourceMap,
       jsc: {
         parser: { syntax: 'typescript', tsx: true },

--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -16,7 +16,7 @@ use stylex_transform::StyleXTransform;
 use swc_ecma_parser::{Parser, StringInput, Syntax, TsSyntax, lexer::Lexer};
 
 use swc_core::{
-  common::{FileName, GLOBALS, Globals, Mark, SourceMap},
+  common::{FileName, GLOBALS, Globals, Mark, SourceMap, comments::SingleThreadedComments},
   ecma::{
     ast::EsVersion,
     transforms::{
@@ -39,6 +39,58 @@ fn source_maps_config(source_map: Option<&SourceMaps>) -> SourceMapsConfig {
     Some(SourceMaps::False) => SourceMapsConfig::Bool(false),
     Some(SourceMaps::Inline) => SourceMapsConfig::Str("inline".into()),
     None => SourceMapsConfig::Bool(true),
+  }
+}
+
+/// Whether to embed the original source text in the emitted map's
+/// `sourcesContent`. Defaults to `true`: `@babel/generator` always embeds it,
+/// and `next-swc-loader` turns it on whenever it asks for a map, so leaving it
+/// off makes DevTools fall back to fetching `sources[0]` over
+/// `webpack-internal://` — which 404s.
+fn resolve_inline_sources_content(inline_sources_content: Option<bool>) -> bool {
+  inline_sources_content.unwrap_or(true)
+}
+
+/// Whether to emit column positions in `mappings`. Defaults to `true`, matching
+/// `@babel/generator` and webpack's own `SourceMapDevToolPlugin` (which only
+/// drops columns for the `cheap-*` devtools). Without it every mapping starts
+/// at column 0 and DevTools can only highlight whole lines.
+fn resolve_emit_source_map_columns(emit_source_map_columns: Option<bool>) -> bool {
+  emit_source_map_columns.unwrap_or(true)
+}
+
+/// Ensure the input map carries the authored source text for `filename`.
+///
+/// When an input map is chained, `SourceMap::build_source_map_with_config`
+/// returns the *input* map with adjusted mappings and drops anything it would
+/// otherwise have inlined, so `sourcesContent` is whatever earlier tooling put
+/// there. Filling the gap here — on the already-parsed map, before it is handed
+/// to `print` — costs no extra parse or serialization.
+///
+/// Only entries with no content are touched, so a map that already resolves
+/// back to an earlier authored file keeps its own text. A single-source map is
+/// unambiguously ours even when its `sources` entry spells the path
+/// differently (relative, `webpack://`-prefixed, …).
+fn backfill_source_contents(
+  input_source_map: &mut swc_sourcemap::SourceMap,
+  filename: &str,
+  src: &str,
+) {
+  let source_count = input_source_map.get_source_count();
+
+  for idx in 0..source_count {
+    if input_source_map.get_source_contents(idx).is_some() {
+      continue;
+    }
+
+    let is_ours = source_count == 1
+      || input_source_map
+        .get_source(idx)
+        .is_some_and(|source| source.as_str() == filename);
+
+    if is_ours {
+      input_source_map.set_source_contents(idx, Some(src.to_owned().into()));
+    }
   }
 }
 
@@ -94,12 +146,23 @@ pub fn transform(
     let source_map = source_maps_config(options.source_map.as_ref());
     let should_chain_input_source_map =
       !matches!(options.source_map.as_ref(), Some(SourceMaps::False));
+    let inline_sources_content = resolve_inline_sources_content(options.inline_sources_content);
+    let emit_source_map_columns = resolve_emit_source_map_columns(options.emit_source_map_columns);
 
     // Parse the incoming source map (if any) once: it feeds both the debug
     // source-map annotations and the chaining of the emitted map.
     let input_source_map = options.input_source_map.take().and_then(|json| {
       match swc_sourcemap::SourceMap::from_slice(json.as_bytes()) {
-        Ok(map) => Some(Arc::new(map)),
+        Ok(mut map) => {
+          // A chained map is returned as-is by `build_source_map_with_config`,
+          // which skips inlining entirely when `orig` is set. Seed the authored
+          // text here so `sourcesContent` survives the chaining.
+          if inline_sources_content {
+            backfill_source_contents(&mut map, &fm.name.to_string(), &fm.src);
+          }
+
+          Some(Arc::new(map))
+        },
         Err(err) => {
           warn!(
             "[StyleX] Failed to parse inputSourceMap, ignoring it: {}",
@@ -116,6 +179,12 @@ pub fn transform(
     config.env = parsed_env;
     config.debug_file_path = parsed_debug_file_path;
 
+    // Collect comments while lexing and hand the same store to the printer.
+    // Without it the emitted code loses every comment — including the ones
+    // bundlers act on: `/* webpackChunkName: "…" */` on dynamic imports and
+    // `/* #__PURE__ */` annotations that minifiers need to drop dead calls.
+    let comments = SingleThreadedComments::default();
+
     let mut parser = Parser::new_from(Lexer::new(
       Syntax::Typescript(TsSyntax {
         tsx: true,
@@ -123,7 +192,7 @@ pub fn transform(
       }),
       EsVersion::latest(),
       StringInput::from(&*fm),
-      None,
+      Some(&comments),
     ));
 
     let program = match parser.parse_program() {
@@ -166,6 +235,9 @@ pub fn transform(
           &program,
           PrintArgs {
             source_map,
+            inline_sources_content,
+            emit_source_map_columns,
+            comments: Some(&comments),
             // Chain the emitted map onto the input map so it resolves all the
             // way back to the original authored file. Skip the clone when
             // source maps are disabled; debug annotations already use the

--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -59,38 +59,10 @@ fn resolve_emit_source_map_columns(emit_source_map_columns: Option<bool>) -> boo
   emit_source_map_columns.unwrap_or(true)
 }
 
-/// Ensure the input map carries the authored source text for `filename`.
-///
-/// When an input map is chained, `SourceMap::build_source_map_with_config`
-/// returns the *input* map with adjusted mappings and drops anything it would
-/// otherwise have inlined, so `sourcesContent` is whatever earlier tooling put
-/// there. Filling the gap here — on the already-parsed map, before it is handed
-/// to `print` — costs no extra parse or serialization.
-///
-/// Only entries with no content are touched, so a map that already resolves
-/// back to an earlier authored file keeps its own text. A single-source map is
-/// unambiguously ours even when its `sources` entry spells the path
-/// differently (relative, `webpack://`-prefixed, …).
-fn backfill_source_contents(
-  input_source_map: &mut swc_sourcemap::SourceMap,
-  filename: &str,
-  src: &str,
-) {
-  let source_count = input_source_map.get_source_count();
-
-  for idx in 0..source_count {
-    if input_source_map.get_source_contents(idx).is_some() {
-      continue;
-    }
-
-    let is_ours = source_count == 1
-      || input_source_map
-        .get_source(idx)
-        .is_some_and(|source| source.as_str() == filename);
-
-    if is_ours {
-      input_source_map.set_source_contents(idx, Some(src.to_owned().into()));
-    }
+/// Remove source text inherited from an input map when inlining is disabled.
+fn clear_source_contents(input_source_map: &mut swc_sourcemap::SourceMap) {
+  for idx in 0..input_source_map.get_source_count() {
+    input_source_map.set_source_contents(idx, None);
   }
 }
 
@@ -154,11 +126,11 @@ pub fn transform(
     let input_source_map = options.input_source_map.take().and_then(|json| {
       match swc_sourcemap::SourceMap::from_slice(json.as_bytes()) {
         Ok(mut map) => {
-          // A chained map is returned as-is by `build_source_map_with_config`,
-          // which skips inlining entirely when `orig` is set. Seed the authored
-          // text here so `sourcesContent` survives the chaining.
-          if inline_sources_content {
-            backfill_source_contents(&mut map, &fm.name.to_string(), &fm.src);
+          // Chaining preserves the input map's source contents. Remove them
+          // explicitly when the caller disables inlining so the option remains
+          // a reliable size and source-disclosure control.
+          if should_chain_input_source_map && !inline_sources_content {
+            clear_source_contents(&mut map);
           }
 
           Some(Arc::new(map))
@@ -229,6 +201,19 @@ pub fn transform(
           .apply(&mut fixer(None));
 
         let stylex_metadata = extract_stylex_metadata(env, &stylex)?;
+        drop(stylex);
+
+        // StateManager shared this map during transformation. It has been
+        // dropped now, so transfer the remaining Arc into the printer instead
+        // of cloning every token and source-content string in a large map.
+        let original_source_map = if should_chain_input_source_map {
+          input_source_map.map(|map| match Arc::try_unwrap(map) {
+            Ok(map) => map,
+            Err(map) => (*map).clone(),
+          })
+        } else {
+          None
+        };
 
         let transformed_code = print(
           cm,
@@ -239,14 +224,8 @@ pub fn transform(
             emit_source_map_columns,
             comments: Some(&comments),
             // Chain the emitted map onto the input map so it resolves all the
-            // way back to the original authored file. Skip the clone when
-            // source maps are disabled; debug annotations already use the
-            // shared Arc stored in StateManager.
-            orig: if should_chain_input_source_map {
-              input_source_map.as_ref().map(|map| (**map).clone())
-            } else {
-              None
-            },
+            // way back to the original authored file.
+            orig: original_source_map,
             ..Default::default()
           },
         );

--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -5,7 +5,11 @@ mod structs;
 mod utils;
 use log::{info, warn};
 use napi::{Env, Result};
-use std::{env, panic, sync::Arc};
+use std::{
+  env, panic,
+  path::{Component, Path, PathBuf},
+  sync::Arc,
+};
 use structs::{StyleXMetadata, StyleXOptions, StyleXTransformResult};
 use stylex_logs::initializer::initialize as initialize_logger;
 use stylex_macros::stylex_error::{SuppressPanicStderr, format_panic_message};
@@ -25,7 +29,6 @@ use swc_core::{
     },
     visit::visit_mut_pass,
   },
-  plugin::proxies::PluginCommentsProxy,
 };
 
 use napi_derive::napi;
@@ -63,6 +66,88 @@ fn resolve_emit_source_map_columns(emit_source_map_columns: Option<bool>) -> boo
 fn clear_source_contents(input_source_map: &mut swc_sourcemap::SourceMap) {
   for idx in 0..input_source_map.get_source_count() {
     input_source_map.set_source_contents(idx, None);
+  }
+}
+
+/// Whether a source map's `sources` entry refers to `path`.
+///
+/// The same file is spelled several ways by upstream tooling — `page.tsx`,
+/// `./app/page.tsx`, the absolute path, `file:///abs/path/page.tsx` — so the
+/// comparison is on trailing path *components* after dropping any URL scheme,
+/// never on the raw string. Component-wise matching is what keeps
+/// `other/page.tsx` from matching `app/page.tsx`; a plain suffix compare would
+/// also accept `my-page.tsx`.
+///
+/// An entry that still doesn't line up (a `webpack://<namespace>/…` URL, say)
+/// simply doesn't match, and the caller leaves it untouched.
+fn source_names_file(source: &str, path: &Path) -> bool {
+  let source = source.split_once("://").map_or(source, |(_, rest)| rest);
+
+  let mut path_components = path.components().rev();
+  let mut matched = false;
+
+  for source_component in Path::new(source).components().rev() {
+    // `Components` keeps a leading `.`; it carries no meaning here.
+    if matches!(source_component, Component::CurDir) {
+      continue;
+    }
+
+    match path_components.next() {
+      Some(path_component) if path_component == source_component => matched = true,
+      _ => return false,
+    }
+  }
+
+  matched
+}
+
+/// Seed the authored text into a chained input map, for the one entry that
+/// unambiguously names the file being compiled.
+///
+/// `SourceMap::build_source_map_with_config` returns `orig` verbatim once its
+/// mappings have been adjusted, discarding everything the builder would
+/// otherwise have inlined. So on the chained path `inline_sources_content` has
+/// no effect and `sourcesContent` is whatever earlier tooling left behind —
+/// frequently `null`, which is what sends Chrome DevTools off to re-fetch
+/// `sources[0]` over `webpack-internal://`. Filling the gap here, on the
+/// already-parsed map and before it reaches `print`, costs no extra parse or
+/// serialization.
+///
+/// Deliberately narrow. `src` is this loader's *input*, not the original
+/// authored file, so it is only correct for the entry describing this file.
+/// An entry is filled only when it carries no text already and is the sole
+/// entry resolving to `path`; two claimants means neither can be filled with
+/// confidence and nothing is written. Attaching this text to an earlier
+/// authored file named by the chain would yield a plausible but wrong map,
+/// which is worse to debug against than no text at all.
+fn backfill_source_contents(
+  input_source_map: &mut swc_sourcemap::SourceMap,
+  path: &Path,
+  src: &str,
+) {
+  let mut candidate = None;
+
+  for idx in 0..input_source_map.get_source_count() {
+    let names_this_file = input_source_map
+      .get_source(idx)
+      .is_some_and(|source| source_names_file(source, path));
+
+    if !names_this_file {
+      continue;
+    }
+
+    if candidate.is_some() {
+      return;
+    }
+
+    candidate = Some(idx);
+  }
+
+  match candidate {
+    Some(idx) if input_source_map.get_source_contents(idx).is_none() => {
+      input_source_map.set_source_contents(idx, Some(src.to_owned().into()));
+    },
+    _ => {},
   }
 }
 
@@ -104,7 +189,8 @@ pub fn transform(
   let _suppress = SuppressPanicStderr::new();
   let result = panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
     let cm: Arc<SourceMap> = Default::default();
-    let filename = FileName::Real(filename.into());
+    let file_path = PathBuf::from(filename);
+    let filename = FileName::Real(file_path.clone());
 
     let fm = cm.new_source_file(filename.clone().into(), code);
 
@@ -126,11 +212,16 @@ pub fn transform(
     let input_source_map = options.input_source_map.take().and_then(|json| {
       match swc_sourcemap::SourceMap::from_slice(json.as_bytes()) {
         Ok(mut map) => {
-          // Chaining preserves the input map's source contents. Remove them
-          // explicitly when the caller disables inlining so the option remains
-          // a reliable size and source-disclosure control.
-          if should_chain_input_source_map && !inline_sources_content {
-            clear_source_contents(&mut map);
+          // Chaining returns the input map as-is, so `inline_sources_content`
+          // has to be applied to *it* rather than to the printer's builder:
+          // seed this file's text where the chain left a hole, or strip the
+          // inherited text outright when the caller disabled inlining.
+          if should_chain_input_source_map {
+            if inline_sources_content {
+              backfill_source_contents(&mut map, &file_path, &fm.src);
+            } else {
+              clear_source_contents(&mut map);
+            }
           }
 
           Some(Arc::new(map))
@@ -144,6 +235,18 @@ pub fn transform(
         },
       }
     });
+
+    // Column granularity is not ours to choose once a map is being chained.
+    // `adjust_mappings` keeps the *input* map's tokens — columns and all — and
+    // only shifts them by one (line, col) delta per covering range in the map
+    // built here. Dropping columns from that map leaves exactly one range per
+    // generated line, so every token on the line is shifted by the delta
+    // computed for the first one. StyleX rewrites a line non-uniformly, so
+    // those columns come out wrong, and the map is no smaller for it: its size
+    // is the input map's token count either way. Emit ours in full and let the
+    // upstream map's granularity carry through.
+    let is_chaining = should_chain_input_source_map && input_source_map.is_some();
+    let emit_source_map_columns = emit_source_map_columns || is_chaining;
 
     let mut config: StyleXOptionsParams = options.try_into()?;
 
@@ -182,8 +285,13 @@ pub fn transform(
         let unresolved_mark = Mark::new();
         let top_level_mark = Mark::new();
 
-        let mut stylex: StyleXTransform<PluginCommentsProxy> =
-          StyleXTransform::new(PluginCommentsProxy, plugin_pass, &mut config);
+        // The same store the lexer filled and the printer will read. The
+        // alternative, `PluginCommentsProxy`, only forwards to a wasm plugin
+        // host — outside `wasm32` every one of its methods is a no-op, so a
+        // transform holding it can neither read an existing annotation nor
+        // attach a new one, and does so silently.
+        let mut stylex: StyleXTransform<&SingleThreadedComments> =
+          StyleXTransform::new(&comments, plugin_pass, &mut config);
 
         // Give the transform exact access to the parsed input so span-based
         // position lookups need no re-parsing, and to the input source map so
@@ -203,14 +311,13 @@ pub fn transform(
         let stylex_metadata = extract_stylex_metadata(env, &stylex)?;
         drop(stylex);
 
-        // StateManager shared this map during transformation. It has been
-        // dropped now, so transfer the remaining Arc into the printer instead
-        // of cloning every token and source-content string in a large map.
+        // StateManager shared this map during transformation and has just been
+        // dropped, so the Arc is normally unique here and unwraps for free.
+        // `print` takes `orig` by value, and `build_source_map_with_config`
+        // clones it again internally — this saves one of those two copies of
+        // every token and source-content string, not both.
         let original_source_map = if should_chain_input_source_map {
-          input_source_map.map(|map| match Arc::try_unwrap(map) {
-            Ok(map) => map,
-            Err(map) => (*map).clone(),
-          })
+          input_source_map.map(Arc::unwrap_or_clone)
         } else {
           None
         };

--- a/crates/stylex-rs-compiler/src/structs/mod.rs
+++ b/crates/stylex-rs-compiler/src/structs/mod.rs
@@ -49,6 +49,16 @@ pub struct StyleXOptions {
   #[napi(js_name = "unstable_moduleResolution")]
   pub unstable_module_resolution: Option<StyleXModuleResolution>,
   pub source_map: Option<SourceMaps>,
+  /// Embed the original source text in the emitted map's `sourcesContent`.
+  /// Defaults to `true` so tooling that reads the map (Chrome DevTools via
+  /// Next.js' `eval-source-map`, in particular) can render the authored file
+  /// without re-fetching `sources[0]`. Set to `false` for production maps
+  /// where size matters, or where the source shouldn't ship with the map.
+  pub inline_sources_content: Option<bool>,
+  /// Emit column positions in the source map's `mappings`. Defaults to `true`,
+  /// which maps individual expressions rather than whole lines. Set to `false`
+  /// for smaller, line-granularity maps (the `cheap-*` webpack devtools).
+  pub emit_source_map_columns: Option<bool>,
   /// JSON source map for the incoming `code`, produced by earlier tooling
   /// (e.g. a macro loader). When provided, debug source-map annotations are
   /// mapped back to the original authored file and the emitted source map is

--- a/crates/stylex-rs-compiler/src/tests/lib_tests.rs
+++ b/crates/stylex-rs-compiler/src/tests/lib_tests.rs
@@ -63,9 +63,6 @@ fn emit_source_map_columns_defaults_to_true() {
   assert!(!resolve_emit_source_map_columns(Some(false)));
 }
 
-const OURS: &str = "/abs/path/Button.tsx";
-const AUTHORED: &str = "export const a = 1;\n";
-
 /// Build a map whose `sources`/`sourcesContent` are exactly as given. A `None`
 /// content is serialized as JSON `null`, the shape earlier tooling emits when
 /// it knows a source but not its text.
@@ -103,87 +100,22 @@ fn contents_of(map: &swc_sourcemap::SourceMap) -> Vec<Option<String>> {
 }
 
 #[test]
-fn backfill_fills_a_lone_source_whatever_its_path_spelling() {
-  // A single-source map is unambiguously ours even when the previous tool
-  // spelled the path relatively or behind a `webpack://` scheme.
-  for spelling in ["Button.tsx", "./Button.tsx", "webpack://app/./Button.tsx"] {
-    let mut map = input_map(&[spelling], &[None]);
-
-    backfill_source_contents(&mut map, OURS, AUTHORED);
-
-    assert_eq!(contents_of(&map), vec![Some(AUTHORED.to_string())]);
-  }
-}
-
-#[test]
-fn backfill_keeps_existing_content() {
-  // The incoming map already resolves back to an earlier authored file; its
-  // text wins over ours.
-  let mut map = input_map(&[OURS], &[Some("// original\n")]);
-
-  backfill_source_contents(&mut map, OURS, AUTHORED);
-
-  assert_eq!(contents_of(&map), vec![Some("// original\n".to_string())]);
-}
-
-#[test]
-fn backfill_only_touches_the_matching_source_in_a_multi_source_map() {
-  let mut map = input_map(&["/abs/path/other.tsx", OURS], &[None, None]);
-
-  backfill_source_contents(&mut map, OURS, AUTHORED);
-
-  assert_eq!(contents_of(&map), vec![None, Some(AUTHORED.to_string())]);
-}
-
-#[test]
-fn backfill_is_a_noop_when_no_source_matches() {
-  // With several sources and no path match there is no way to tell which entry
-  // the authored text belongs to — guessing would inline it under a foreign
-  // file name.
-  let mut map = input_map(&["/abs/path/a.tsx", "/abs/path/b.tsx"], &[None, None]);
-
-  backfill_source_contents(&mut map, OURS, AUTHORED);
-
-  assert_eq!(contents_of(&map), vec![None, None]);
-}
-
-#[test]
-fn backfill_leaves_populated_neighbours_alone() {
-  let mut map = input_map(&["/abs/path/other.tsx", OURS], &[Some("// other\n"), None]);
-
-  backfill_source_contents(&mut map, OURS, AUTHORED);
-
-  assert_eq!(
-    contents_of(&map),
-    vec![Some("// other\n".to_string()), Some(AUTHORED.to_string())]
-  );
-}
-
-#[test]
-fn backfill_handles_a_map_with_no_sources() {
+fn clear_source_contents_handles_a_map_with_no_sources() {
   let mut map = input_map(&[], &[]);
 
-  backfill_source_contents(&mut map, OURS, AUTHORED);
+  clear_source_contents(&mut map);
 
   assert!(contents_of(&map).is_empty());
 }
 
 #[test]
-fn backfill_preserves_empty_string_content() {
-  // An empty source file is legitimately empty content, not a missing entry.
-  let mut map = input_map(&[OURS], &[Some("")]);
+fn clear_source_contents_removes_every_populated_entry() {
+  let mut map = input_map(
+    &["/abs/path/a.tsx", "/abs/path/b.tsx"],
+    &[Some("// a\n"), Some("")],
+  );
 
-  backfill_source_contents(&mut map, OURS, AUTHORED);
+  clear_source_contents(&mut map);
 
-  assert_eq!(contents_of(&map), vec![Some(String::new())]);
-}
-
-#[test]
-fn backfill_is_idempotent() {
-  let mut map = input_map(&[OURS], &[None]);
-
-  backfill_source_contents(&mut map, OURS, AUTHORED);
-  backfill_source_contents(&mut map, OURS, "// different\n");
-
-  assert_eq!(contents_of(&map), vec![Some(AUTHORED.to_string())]);
+  assert_eq!(contents_of(&map), vec![None, None]);
 }

--- a/crates/stylex-rs-compiler/src/tests/lib_tests.rs
+++ b/crates/stylex-rs-compiler/src/tests/lib_tests.rs
@@ -48,3 +48,142 @@ fn source_maps_config_inline_is_string() {
     other => panic!("expected Str(\"inline\"), got {:?}", other),
   }
 }
+
+#[test]
+fn inline_sources_content_defaults_to_true() {
+  assert!(resolve_inline_sources_content(None));
+  assert!(resolve_inline_sources_content(Some(true)));
+  assert!(!resolve_inline_sources_content(Some(false)));
+}
+
+#[test]
+fn emit_source_map_columns_defaults_to_true() {
+  assert!(resolve_emit_source_map_columns(None));
+  assert!(resolve_emit_source_map_columns(Some(true)));
+  assert!(!resolve_emit_source_map_columns(Some(false)));
+}
+
+const OURS: &str = "/abs/path/Button.tsx";
+const AUTHORED: &str = "export const a = 1;\n";
+
+/// Build a map whose `sources`/`sourcesContent` are exactly as given. A `None`
+/// content is serialized as JSON `null`, the shape earlier tooling emits when
+/// it knows a source but not its text.
+fn input_map(sources: &[&str], sources_content: &[Option<&str>]) -> swc_sourcemap::SourceMap {
+  fn json_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('\n', "\\n"))
+  }
+
+  fn json_array(items: impl Iterator<Item = String>) -> String {
+    format!("[{}]", items.collect::<Vec<_>>().join(","))
+  }
+
+  let sources = json_array(sources.iter().map(|source| json_string(source)));
+  let sources_content = json_array(
+    sources_content
+      .iter()
+      .map(|content| content.map_or_else(|| "null".to_string(), json_string)),
+  );
+
+  let json = format!(
+    r#"{{"version":3,"sources":{},"sourcesContent":{},"names":[],"mappings":""}}"#,
+    sources, sources_content
+  );
+
+  match swc_sourcemap::SourceMap::from_slice(json.as_bytes()) {
+    Ok(map) => map,
+    Err(err) => panic!("failed to build test source map: {}", err),
+  }
+}
+
+fn contents_of(map: &swc_sourcemap::SourceMap) -> Vec<Option<String>> {
+  (0..map.get_source_count())
+    .map(|idx| map.get_source_contents(idx).map(|src| src.to_string()))
+    .collect()
+}
+
+#[test]
+fn backfill_fills_a_lone_source_whatever_its_path_spelling() {
+  // A single-source map is unambiguously ours even when the previous tool
+  // spelled the path relatively or behind a `webpack://` scheme.
+  for spelling in ["Button.tsx", "./Button.tsx", "webpack://app/./Button.tsx"] {
+    let mut map = input_map(&[spelling], &[None]);
+
+    backfill_source_contents(&mut map, OURS, AUTHORED);
+
+    assert_eq!(contents_of(&map), vec![Some(AUTHORED.to_string())]);
+  }
+}
+
+#[test]
+fn backfill_keeps_existing_content() {
+  // The incoming map already resolves back to an earlier authored file; its
+  // text wins over ours.
+  let mut map = input_map(&[OURS], &[Some("// original\n")]);
+
+  backfill_source_contents(&mut map, OURS, AUTHORED);
+
+  assert_eq!(contents_of(&map), vec![Some("// original\n".to_string())]);
+}
+
+#[test]
+fn backfill_only_touches_the_matching_source_in_a_multi_source_map() {
+  let mut map = input_map(&["/abs/path/other.tsx", OURS], &[None, None]);
+
+  backfill_source_contents(&mut map, OURS, AUTHORED);
+
+  assert_eq!(contents_of(&map), vec![None, Some(AUTHORED.to_string())]);
+}
+
+#[test]
+fn backfill_is_a_noop_when_no_source_matches() {
+  // With several sources and no path match there is no way to tell which entry
+  // the authored text belongs to — guessing would inline it under a foreign
+  // file name.
+  let mut map = input_map(&["/abs/path/a.tsx", "/abs/path/b.tsx"], &[None, None]);
+
+  backfill_source_contents(&mut map, OURS, AUTHORED);
+
+  assert_eq!(contents_of(&map), vec![None, None]);
+}
+
+#[test]
+fn backfill_leaves_populated_neighbours_alone() {
+  let mut map = input_map(&["/abs/path/other.tsx", OURS], &[Some("// other\n"), None]);
+
+  backfill_source_contents(&mut map, OURS, AUTHORED);
+
+  assert_eq!(
+    contents_of(&map),
+    vec![Some("// other\n".to_string()), Some(AUTHORED.to_string())]
+  );
+}
+
+#[test]
+fn backfill_handles_a_map_with_no_sources() {
+  let mut map = input_map(&[], &[]);
+
+  backfill_source_contents(&mut map, OURS, AUTHORED);
+
+  assert!(contents_of(&map).is_empty());
+}
+
+#[test]
+fn backfill_preserves_empty_string_content() {
+  // An empty source file is legitimately empty content, not a missing entry.
+  let mut map = input_map(&[OURS], &[Some("")]);
+
+  backfill_source_contents(&mut map, OURS, AUTHORED);
+
+  assert_eq!(contents_of(&map), vec![Some(String::new())]);
+}
+
+#[test]
+fn backfill_is_idempotent() {
+  let mut map = input_map(&[OURS], &[None]);
+
+  backfill_source_contents(&mut map, OURS, AUTHORED);
+  backfill_source_contents(&mut map, OURS, "// different\n");
+
+  assert_eq!(contents_of(&map), vec![Some(AUTHORED.to_string())]);
+}

--- a/crates/stylex-rs-compiler/src/tests/lib_tests.rs
+++ b/crates/stylex-rs-compiler/src/tests/lib_tests.rs
@@ -119,3 +119,121 @@ fn clear_source_contents_removes_every_populated_entry() {
 
   assert_eq!(contents_of(&map), vec![None, None]);
 }
+
+// ── source_names_file ───────────────────────────────────────────────
+// Upstream tooling names the same file in several spellings; each of these
+// must resolve to the file being compiled, and near-misses must not.
+
+const COMPILED: &str = "/project/app/page.tsx";
+
+#[test]
+fn source_names_file_accepts_every_spelling_of_the_same_file() {
+  for source in [
+    "/project/app/page.tsx",
+    "app/page.tsx",
+    "./app/page.tsx",
+    "page.tsx",
+    "./page.tsx",
+    "file:///project/app/page.tsx",
+  ] {
+    assert!(
+      source_names_file(source, Path::new(COMPILED)),
+      "expected `{}` to name `{}`",
+      source,
+      COMPILED
+    );
+  }
+}
+
+#[test]
+fn source_names_file_rejects_a_different_file() {
+  for source in [
+    // A different file entirely.
+    "/project/app/layout.tsx",
+    // Shares a suffix of the *string* but not of the path components — the
+    // case a naive `ends_with` on `&str` would wrongly accept.
+    "my-page.tsx",
+    "/project/other/page.tsx",
+    // Longer than the compiled path, so it cannot be a suffix of it.
+    "/deeper/project/app/page.tsx",
+    // A `webpack://` URL keeps its namespace segment and stays unmatched.
+    "webpack://_N_E/./app/page.tsx",
+    "",
+  ] {
+    assert!(
+      !source_names_file(source, Path::new(COMPILED)),
+      "expected `{}` not to name `{}`",
+      source,
+      COMPILED
+    );
+  }
+}
+
+// ── backfill_source_contents ────────────────────────────────────────
+
+#[test]
+fn backfill_seeds_the_entry_naming_the_compiled_file() {
+  let mut map = input_map(&["page.tsx"], &[None]);
+
+  backfill_source_contents(&mut map, Path::new(COMPILED), "// authored\n");
+
+  assert_eq!(contents_of(&map), vec![Some("// authored\n".to_string())]);
+}
+
+#[test]
+fn backfill_leaves_existing_upstream_text_alone() {
+  let mut map = input_map(&["page.tsx"], &[Some("// from an earlier loader\n")]);
+
+  backfill_source_contents(&mut map, Path::new(COMPILED), "// this loader's input\n");
+
+  assert_eq!(
+    contents_of(&map),
+    vec![Some("// from an earlier loader\n".to_string())]
+  );
+}
+
+#[test]
+fn backfill_skips_sources_that_name_other_files() {
+  // The chain resolves back to files this compiler never saw. Their text is
+  // not ours to invent.
+  let mut map = input_map(
+    &["/project/app/other.tsx", "/project/lib/util.ts"],
+    &[None, None],
+  );
+
+  backfill_source_contents(&mut map, Path::new(COMPILED), "// this loader's input\n");
+
+  assert_eq!(contents_of(&map), vec![None, None]);
+}
+
+#[test]
+fn backfill_writes_nothing_when_two_entries_claim_the_file() {
+  // `page.tsx` and `app/page.tsx` both resolve to the compiled file. Neither
+  // can be filled with confidence, so neither is touched.
+  let mut map = input_map(&["page.tsx", "app/page.tsx"], &[None, None]);
+
+  backfill_source_contents(&mut map, Path::new(COMPILED), "// this loader's input\n");
+
+  assert_eq!(contents_of(&map), vec![None, None]);
+}
+
+#[test]
+fn backfill_fills_only_the_matching_entry_of_a_multi_source_map() {
+  let mut map = input_map(&["/project/lib/util.ts", "app/page.tsx"], &[None, None]);
+
+  backfill_source_contents(&mut map, Path::new(COMPILED), "// authored\n");
+
+  assert_eq!(
+    contents_of(&map),
+    vec![None, Some("// authored\n".to_string())]
+  );
+}
+
+#[test]
+fn backfill_handles_a_map_with_no_sources() {
+  let mut map = input_map(&[], &[]);
+
+  backfill_source_contents(&mut map, Path::new(COMPILED), "// authored\n");
+
+  assert!(contents_of(&map).is_empty());
+}

--- a/crates/stylex-rs-compiler/src/tests/structs_tests.rs
+++ b/crates/stylex-rs-compiler/src/tests/structs_tests.rs
@@ -27,6 +27,8 @@ fn empty_options() -> StyleXOptions {
     aliases: None,
     unstable_module_resolution: None,
     source_map: None,
+    inline_sources_content: None,
+    emit_source_map_columns: None,
     input_source_map: None,
     property_validation_mode: None,
     env: None,

--- a/crates/stylex-rs-compiler/src/utils/metadata.rs
+++ b/crates/stylex-rs-compiler/src/utils/metadata.rs
@@ -3,7 +3,7 @@
 use napi::{Env, Error, JsObject};
 use stylex_transform::StyleXTransform;
 use stylex_types::enums::data_structures::injectable_style::InjectableStyleBaseKind;
-use swc_core::plugin::proxies::PluginCommentsProxy;
+use swc_core::common::comments::Comments;
 
 #[derive(Debug, PartialEq, Eq)]
 struct MetadataStyleParts<'a> {
@@ -30,10 +30,13 @@ fn metadata_style_parts(style: &InjectableStyleBaseKind) -> MetadataStyleParts<'
   }
 }
 
-/// Extracts StyleX metadata from the transformation state
-pub(crate) fn extract_stylex_metadata(
+/// Extracts StyleX metadata from the transformation state.
+///
+/// Generic over the comment store: only `state` is read, so which store the
+/// transform carries is none of this function's business.
+pub(crate) fn extract_stylex_metadata<C: Comments>(
   env: Env,
-  stylex: &StyleXTransform<PluginCommentsProxy>,
+  stylex: &StyleXTransform<C>,
 ) -> Result<Vec<JsObject>, Error> {
   let mut stylex_metadata = Vec::with_capacity(stylex.state.metadata().len());
 

--- a/guidelines/coding/TESTING.md
+++ b/guidelines/coding/TESTING.md
@@ -18,3 +18,17 @@ Follow these steps in order when testing code for a task:
 - If improvements are requested by the user, implement them using the steps
   above.
 - Run `pnpm test` before considering any task complete.
+
+## Testing across the NAPI boundary
+
+The JS suites import `@stylexswc/rs-compiler`, which loads the prebuilt
+`crates/stylex-rs-compiler/dist/*.node`. They do not compile Rust.
+
+- After changing any crate, run `pnpm run --filter=@stylexswc/rs-compiler build`
+  before the JS suite. Skip it and the tests silently exercise the previous
+  binary -- they pass or fail for reasons unrelated to the edit.
+- Put logic that can be tested without the boundary behind a plain function and
+  cover it with `cargo nextest` in `src/tests/`; those tests are far faster and
+  pin down edge cases (empty input, ambiguity, malformed data) precisely.
+- Keep the JS specs for what only they can prove: that a value survives
+  serialization across the boundary and reaches the emitted artifact.

--- a/guidelines/stack/RUST.md
+++ b/guidelines/stack/RUST.md
@@ -9,11 +9,13 @@
 
 ## Key Modules
 
-- `StyleXTransform<C: Comments>` in `crates/stylex-shared/src/transform/mod.rs`
-  -- main SWC Fold visitor. All transform logic lives under
-  `crates/stylex-shared/src/transform/`.
-- `crates/stylex-shared/src/shared/structures/` -- core data models
-  (`StateManager`, `PluginPass`, `StyleXOptions`, etc.).
+- `StyleXTransform<C: Comments>` in
+  `crates/stylex-transform/src/transform/mod.rs` -- main SWC visitor. All
+  transform logic lives under `crates/stylex-transform/src/transform/`.
+- `crates/stylex-structures/` -- core data models (`StateManager`,
+  `PluginPass`, `StyleXOptions`, etc.).
+- `crates/stylex-rs-compiler/` -- the NAPI entry point: parses, drives the
+  transform, prints, and owns source-map and comment plumbing.
 - `crates/stylex-path-resolver/` -- path resolution and package.json parsing.
 - `crates/stylex-css-parser/` -- CSS value parsing using `cssparser` crate.
 
@@ -27,6 +29,28 @@
 - Use `serde` / `serde_json` for serialization. The compiler crate also uses
   `serde_plain` for simple string conversions.
 - Avoid using `unsafe` blocks unless absolutely necessary.
+
+## SWC Pitfalls
+
+These fail silently rather than at compile time, so they are worth knowing
+before touching the parse/print path in `crates/stylex-rs-compiler/src/lib.rs`.
+
+- Comments are not carried by the AST. The lexer, the transform and the printer
+  each need the _same_ `Comments` store, or comments are dropped -- taking
+  `/* webpackChunkName */` chunk names and `/* #__PURE__ */` annotations with
+  them. Pass one `SingleThreadedComments` to all three.
+- Do not hand a transform `PluginCommentsProxy` in this codebase. It only
+  forwards to a wasm plugin host; outside `wasm32` every method is a no-op, and
+  there is no wasm plugin build here. Prefer a real store, and keep helpers
+  generic over `C: Comments` rather than naming a concrete one.
+- `SourceMap::build_source_map_with_config` returns `orig` verbatim once its
+  mappings are adjusted whenever an input map is chained. Anything the printer
+  would have inlined -- `sourcesContent` above all -- is discarded, so options
+  of that kind must be applied to the input map before printing, not passed to
+  the printer and assumed to take effect.
+- `adjust_mappings` keeps the input map's own tokens and shifts each by one
+  delta per covering range, so the emitted column granularity of a chained map
+  is the upstream map's, not this compiler's.
 
 ## Commands
 

--- a/guidelines/stack/TYPESCRIPT.md
+++ b/guidelines/stack/TYPESCRIPT.md
@@ -5,9 +5,14 @@
 - Lint: Oxlint, configured once in the root `.oxlintrc.jsonc` with path
   overrides. There are no per-package lint configs or scripts; `pnpm lint` and
   `pnpm lint:check` each run a single process from the root.
-- Type-aware rules (`no-floating-promises`, `no-misused-promises`) run
-  separately via `pnpm lint:type-aware`, which needs `oxlint-tsgolint` and a
-  prior build. They are kept out of the default lint so it stays fast.
+- Type-aware rules run separately via `pnpm lint:type-aware`, which needs
+  `oxlint-tsgolint` and a prior build. They are kept out of the default lint so
+  it stays fast, which also means `pnpm lint:check` passing tells you nothing
+  about them -- run both before calling TypeScript work done.
+- Beyond the promise rules (`no-floating-promises`, `no-misused-promises`), the
+  type-aware pass is where redundant-assertion errors surface:
+  `no-unnecessary-type-assertion` and `non-nullable-type-assertion-style`. They
+  are errors, not warnings, and they land most often in test files.
 - Format: Oxfmt, configured once in the root `.oxfmtrc.json`. Taplo still owns
   TOML and rustfmt still owns Rust.
 
@@ -40,6 +45,13 @@
   (e.g., `as { [key: string]: unknown }`) to bypass the type system. Instead,
   utilize type guards, type predicates, or schemas (like Zod) to safely narrow
   types based on runtime logic.
+- Do not annotate an object literal with `as SomeOptions` when it is passed
+  straight to a parameter of that type -- the parameter already supplies the
+  contextual type, and the assertion only suppresses excess-property checking.
+  This is the single most common type-aware lint error in this repo's tests.
+- To drop `null`/`undefined` from a value you have just asserted is present,
+  use `value!`, not `value as string`. The assertion form re-states the type
+  (and goes stale when the type changes); `!` says only what is meant.
 
 ## Commands
 

--- a/packages/plugin-shared/__tests__/source-map-options.test.ts
+++ b/packages/plugin-shared/__tests__/source-map-options.test.ts
@@ -1,0 +1,70 @@
+// Shared by the webpack/rspack loader and the Turbopack loader, so it is
+// tested here directly rather than only through either one.
+import { SourceMaps } from '@stylexswc/rs-compiler';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { resolveSourceMapOptions } from '../src/source-map-options';
+
+describe('resolveSourceMapOptions', () => {
+  describe('sourceMap', () => {
+    test('leaves the compiler default alone when the host says maps are on', () => {
+      expect(resolveSourceMapOptions({}, true).sourceMap).toBeUndefined();
+    });
+
+    test('disables maps when the host says they are off', () => {
+      expect(resolveSourceMapOptions({}, false).sourceMap).toBe(SourceMaps.False);
+    });
+
+    test('keeps maps on when the host says nothing', () => {
+      // Turbopack's loader context may never define `this.sourceMap`. Treating
+      // that as "off" would silently strip the map from every file.
+      expect(resolveSourceMapOptions({}, undefined).sourceMap).toBeUndefined();
+    });
+
+    test('an explicit rsOptions.sourceMap wins over the host', () => {
+      expect(resolveSourceMapOptions({ sourceMap: SourceMaps.True }, false).sourceMap).toBe(
+        SourceMaps.True
+      );
+      expect(resolveSourceMapOptions({ sourceMap: SourceMaps.False }, true).sourceMap).toBe(
+        SourceMaps.False
+      );
+    });
+  });
+
+  describe('inlineSourcesContent', () => {
+    const { NODE_ENV } = process.env;
+
+    afterEach(() => {
+      process.env.NODE_ENV = NODE_ENV;
+    });
+
+    test('inlines in a development build', () => {
+      expect(resolveSourceMapOptions({ dev: true }, true).inlineSourcesContent).toBe(true);
+    });
+
+    test('does not inline in a production build', () => {
+      expect(resolveSourceMapOptions({ dev: false }, true).inlineSourcesContent).toBe(false);
+    });
+
+    test('falls back to NODE_ENV when dev is unset', () => {
+      // The Turbopack wiring passes plugin options through statically and never
+      // sets `dev`, so this fallback is the one that runs there.
+      process.env.NODE_ENV = 'production';
+      expect(resolveSourceMapOptions({}, undefined).inlineSourcesContent).toBe(false);
+
+      process.env.NODE_ENV = 'development';
+      expect(resolveSourceMapOptions({}, undefined).inlineSourcesContent).toBe(true);
+    });
+
+    test('an explicit value wins over the build mode', () => {
+      expect(
+        resolveSourceMapOptions({ dev: false, inlineSourcesContent: true }, true)
+          .inlineSourcesContent
+      ).toBe(true);
+      expect(
+        resolveSourceMapOptions({ dev: true, inlineSourcesContent: false }, true)
+          .inlineSourcesContent
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/plugin-shared/__tests__/utils.test.ts
+++ b/packages/plugin-shared/__tests__/utils.test.ts
@@ -1,11 +1,13 @@
 import path from 'path';
 
 import type { Rule as StyleXRule } from '@stylexjs/babel-plugin';
+import { SourceMaps } from '@stylexswc/rs-compiler';
 import { describe, expect, test } from 'vitest';
 
 import { DEFAULT_STYLEX_PACKAGES, VIRTUAL_CSS_PATTERN } from '../src/constants';
 import {
   buildVirtualCssPattern,
+  generateStyleXOutput,
   isAllowlistedPackage,
   parseStylexRulesFromIdentifier,
   shouldProcessFile,
@@ -99,5 +101,89 @@ describe('parseStylexRulesFromIdentifier', () => {
         'css|/repo/node_modules/@stylexswc/plugin-shared/dist/stylex.css|used-exports'
       )
     ).toBeNull();
+  });
+});
+
+describe('generateStyleXOutput', () => {
+  const resourcePath = path.join(path.sep, 'project', 'app', 'page.tsx');
+  const source = `import stylex from '@stylexjs/stylex';
+
+export const styles = stylex.create({ default: { color: 'red' } });
+`;
+  const rsOptions = { unstable_moduleResolution: { type: 'commonJS' } } as const;
+
+  test('emits a map when the bundler has source maps on', () => {
+    const { map } = generateStyleXOutput(resourcePath, source, { ...rsOptions }, undefined, true);
+
+    expect(map).toBeDefined();
+    expect(JSON.parse(map as string).sourcesContent).toStrictEqual([source]);
+  });
+
+  test('skips map generation when the bundler has source maps off', () => {
+    // webpack discards the map when `devtool` is false, so building one — and
+    // inlining the whole source into it — is wasted work.
+    const { map } = generateStyleXOutput(resourcePath, source, { ...rsOptions }, undefined, false);
+
+    expect(map).toBeUndefined();
+  });
+
+  test('still transforms the code when map generation is skipped', () => {
+    const { code, metadata } = generateStyleXOutput(
+      resourcePath,
+      source,
+      { ...rsOptions },
+      undefined,
+      false
+    );
+
+    expect(code).not.toContain('stylex.create');
+    expect(metadata.stylex.length).toBeGreaterThan(0);
+  });
+
+  test('an explicit rsOptions.sourceMap wins over the bundler setting', () => {
+    const { map } = generateStyleXOutput(
+      resourcePath,
+      source,
+      { ...rsOptions, sourceMap: SourceMaps.True },
+      undefined,
+      false
+    );
+
+    expect(map).toBeDefined();
+  });
+
+  test('an explicit rsOptions.sourceMap: False stays off when the bundler is on', () => {
+    const { map } = generateStyleXOutput(
+      resourcePath,
+      source,
+      { ...rsOptions, sourceMap: SourceMaps.False },
+      undefined,
+      true
+    );
+
+    expect(map).toBeUndefined();
+  });
+
+  test('defaults to emitting a map when the caller omits the flag', () => {
+    // Back-compat: the parameter was added after the fact, and callers that
+    // predate it must keep their previous behavior.
+    const { map } = generateStyleXOutput(resourcePath, source, { ...rsOptions });
+
+    expect(map).toBeDefined();
+  });
+
+  test('an undefined bundler flag keeps maps on', () => {
+    // Turbopack's loader context is a partial webpack shim and may leave
+    // `this.sourceMap` undefined. Only an explicit `false` may disable maps —
+    // treating "the host never said" as "off" would silently strip every map.
+    const { map } = generateStyleXOutput(
+      resourcePath,
+      source,
+      { ...rsOptions },
+      undefined,
+      undefined
+    );
+
+    expect(map).toBeDefined();
   });
 });

--- a/packages/plugin-shared/__tests__/utils.test.ts
+++ b/packages/plugin-shared/__tests__/utils.test.ts
@@ -104,6 +104,11 @@ describe('parseStylexRulesFromIdentifier', () => {
   });
 });
 
+/** `sourcesContent` of an emitted map, or `undefined` when it carries none. */
+function contentOf(map: string | undefined): string[] | undefined {
+  return (JSON.parse(map!) as { sourcesContent?: string[] }).sourcesContent;
+}
+
 describe('generateStyleXOutput', () => {
   const resourcePath = path.join(path.sep, 'project', 'app', 'page.tsx');
   const source = `import stylex from '@stylexjs/stylex';
@@ -113,10 +118,16 @@ export const styles = stylex.create({ default: { color: 'red' } });
   const rsOptions = { unstable_moduleResolution: { type: 'commonJS' } } as const;
 
   test('emits a map when the bundler has source maps on', () => {
-    const { map } = generateStyleXOutput(resourcePath, source, { ...rsOptions }, undefined, true);
+    const { map } = generateStyleXOutput(
+      resourcePath,
+      source,
+      { ...rsOptions, dev: true },
+      undefined,
+      true
+    );
 
     expect(map).toBeDefined();
-    expect(JSON.parse(map as string).sourcesContent).toStrictEqual([source]);
+    expect(contentOf(map)).toStrictEqual([source]);
   });
 
   test('skips map generation when the bundler has source maps off', () => {
@@ -170,6 +181,60 @@ export const styles = stylex.create({ default: { color: 'red' } });
     const { map } = generateStyleXOutput(resourcePath, source, { ...rsOptions });
 
     expect(map).toBeDefined();
+  });
+
+  describe('inlineSourcesContent', () => {
+    // The whole authored file goes into the map. Needed for DevTools in dev,
+    // pure payload — and a source disclosure — in a production build.
+    test('a development build inlines the source', () => {
+      const { map } = generateStyleXOutput(
+        resourcePath,
+        source,
+        { ...rsOptions, dev: true },
+        undefined,
+        true
+      );
+
+      expect(contentOf(map)).toStrictEqual([source]);
+    });
+
+    test('a production build does not', () => {
+      const { map } = generateStyleXOutput(
+        resourcePath,
+        source,
+        { ...rsOptions, dev: false },
+        undefined,
+        true
+      );
+
+      // The map is still emitted — only the embedded text is dropped.
+      expect(map).toBeDefined();
+      expect(contentOf(map)).toBeUndefined();
+    });
+
+    test('an explicit inlineSourcesContent wins over the build mode', () => {
+      const { map } = generateStyleXOutput(
+        resourcePath,
+        source,
+        { ...rsOptions, dev: false, inlineSourcesContent: true },
+        undefined,
+        true
+      );
+
+      expect(contentOf(map)).toStrictEqual([source]);
+    });
+
+    test('an explicit false is honoured in development too', () => {
+      const { map } = generateStyleXOutput(
+        resourcePath,
+        source,
+        { ...rsOptions, dev: true, inlineSourcesContent: false },
+        undefined,
+        true
+      );
+
+      expect(contentOf(map)).toBeUndefined();
+    });
   });
 
   test('an undefined bundler flag keeps maps on', () => {

--- a/packages/plugin-shared/package.json
+++ b/packages/plugin-shared/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.js"
     },
+    "./source-map-options": {
+      "types": "./dist/source-map-options.d.ts",
+      "import": "./dist/source-map-options.js",
+      "require": "./dist/source-map-options.js"
+    },
     "./stylex-loader": {
       "types": "./dist/stylex-loader.d.ts",
       "import": "./dist/stylex-loader.js",

--- a/packages/plugin-shared/src/index.ts
+++ b/packages/plugin-shared/src/index.ts
@@ -20,6 +20,11 @@ export type { RegisterStyleXRules } from './plugin-core';
 export { mergeStyleXRulesInto, publishStyleXRules } from './nextjs-registry';
 export type { StyleXRulesMap } from './nextjs-registry';
 
+// Also available as `@stylexswc/plugin-shared/source-map-options`, for loaders
+// that want it without pulling in the plugin core.
+export { resolveSourceMapOptions } from './source-map-options';
+export type { ResolvedSourceMapOptions } from './source-map-options';
+
 export {
   buildVirtualCssPattern,
   escapeRegExp,

--- a/packages/plugin-shared/src/source-map-options.ts
+++ b/packages/plugin-shared/src/source-map-options.ts
@@ -1,0 +1,53 @@
+import { SourceMaps } from '@stylexswc/rs-compiler';
+import type { StyleXOptions } from '@stylexswc/rs-compiler';
+
+/**
+ * The source-map decisions a bundler loader makes on the compiler's behalf.
+ *
+ * Kept in its own module — and out of the package entry — so a loader can pull
+ * it in without also loading the plugin core and its webpack dependencies.
+ */
+export type ResolvedSourceMapOptions = Pick<StyleXOptions, 'sourceMap' | 'inlineSourcesContent'>;
+
+/**
+ * Decide `sourceMap` and `inlineSourcesContent` for a loader run.
+ *
+ * Both are resolved from the host's own source-map setting rather than left to
+ * the compiler defaults, and both yield to an explicit `rsOptions` value. The
+ * result is meant to be spread over `normalizeRsOptions(...)` output; a
+ * `sourceMap` of `undefined` deliberately means "leave the compiler default
+ * alone", which is safe because `normalizeRsOptions` has no default for it.
+ *
+ * @param rsOptions the caller's raw (un-normalized) options — explicit values
+ *   here always win
+ * @param sourceMapsEnabled the host's setting, i.e. webpack's `this.sourceMap`.
+ *   `undefined` means the host never told us
+ */
+export function resolveSourceMapOptions(
+  rsOptions: Partial<StyleXOptions>,
+  sourceMapsEnabled?: boolean
+): ResolvedSourceMapOptions {
+  // The bundler drops the emitted map when its own `devtool` is off, so
+  // building one is pure waste. Only an explicit `false` disables it:
+  // `undefined` means the host never told us — Turbopack's loader context is a
+  // partial webpack shim and may not define `this.sourceMap` — and treating
+  // that as "off" would silently strip source maps from every file.
+  const sourceMap =
+    rsOptions.sourceMap ?? (sourceMapsEnabled === false ? SourceMaps.False : undefined);
+
+  // `sourcesContent` embeds the entire authored file in the map. That is what
+  // Chrome DevTools needs in development — without it, it re-fetches the source
+  // over `webpack-internal://` and fails — but in a production build it is pure
+  // payload, and it publishes the source to anyone who can reach the `.map`.
+  //
+  // Hence the default is the build mode rather than the compiler's own `true`.
+  // The asymmetry with `sourceMap` above is deliberate: a map with no
+  // `sourcesContent` still degrades gracefully — the bundler re-supplies the
+  // text from the module source, and a production `sources` URL is fetchable
+  // over http — whereas a missing map degrades to nothing at all. So "the host
+  // never told us" keeps the map and drops the inlined text.
+  const inlineSourcesContent =
+    rsOptions.inlineSourcesContent ?? rsOptions.dev ?? process.env.NODE_ENV !== 'production';
+
+  return { sourceMap, inlineSourcesContent };
+}

--- a/packages/plugin-shared/src/stylex-loader.ts
+++ b/packages/plugin-shared/src/stylex-loader.ts
@@ -61,7 +61,8 @@ export default async function stylexLoader(
       this.resourcePath,
       stringifiedInputCode,
       rsOptions,
-      inputSourceMap
+      inputSourceMap,
+      this.sourceMap
     );
 
     let parsedMap: SourceMap = undefined;

--- a/packages/plugin-shared/src/utils.ts
+++ b/packages/plugin-shared/src/utils.ts
@@ -1,12 +1,7 @@
 import path from 'path';
 
 import type { Rule as StyleXRule } from '@stylexjs/babel-plugin';
-import {
-  SourceMaps,
-  normalizeRsOptions,
-  shouldTransformFile,
-  transform,
-} from '@stylexswc/rs-compiler';
+import { normalizeRsOptions, shouldTransformFile, transform } from '@stylexswc/rs-compiler';
 import type { StyleXOptions, StyleXTransformResult } from '@stylexswc/rs-compiler';
 import type webpack from 'webpack';
 
@@ -15,6 +10,7 @@ import {
   VIRTUAL_CSS_PATTERN,
   VIRTUAL_STYLEX_CSS_DUMMY_IMPORT_PATTERN,
 } from './constants';
+import { resolveSourceMapOptions } from './source-map-options';
 import type { SourceMap } from './types';
 
 export function stringifyRequest(loaderContext: webpack.LoaderContext<unknown>, request: string) {
@@ -30,20 +26,10 @@ export function generateStyleXOutput(
   inputSourceMap?: SourceMap,
   sourceMapsEnabled?: boolean
 ): StyleXTransformResult {
-  const options = normalizeRsOptions(rsOptions ?? {});
-
-  // The bundler drops the emitted map when its own `devtool` is off, so
-  // building one is pure waste — and costly waste now that the authored source
-  // is inlined into it. An explicit `rsOptions.sourceMap` still wins: a caller
-  // that asks for a map gets one whatever the bundler is doing.
-  //
-  // Only an explicit `false` disables it. `undefined` means the host never told
-  // us — Turbopack's loader context is a partial webpack shim and may not
-  // define `this.sourceMap` — and treating that as "off" would silently strip
-  // source maps from every file.
-  if (sourceMapsEnabled === false && rsOptions?.sourceMap === undefined) {
-    options.sourceMap = SourceMaps.False;
-  }
+  const options: StyleXOptions = {
+    ...normalizeRsOptions(rsOptions ?? {}),
+    ...resolveSourceMapOptions(rsOptions ?? {}, sourceMapsEnabled),
+  };
 
   // Forward the previous loader's source map so debug source-map annotations
   // and the emitted map resolve to the original authored file instead of the

--- a/packages/plugin-shared/src/utils.ts
+++ b/packages/plugin-shared/src/utils.ts
@@ -1,7 +1,12 @@
 import path from 'path';
 
 import type { Rule as StyleXRule } from '@stylexjs/babel-plugin';
-import { normalizeRsOptions, shouldTransformFile, transform } from '@stylexswc/rs-compiler';
+import {
+  SourceMaps,
+  normalizeRsOptions,
+  shouldTransformFile,
+  transform,
+} from '@stylexswc/rs-compiler';
 import type { StyleXOptions, StyleXTransformResult } from '@stylexswc/rs-compiler';
 import type webpack from 'webpack';
 
@@ -22,9 +27,23 @@ export function generateStyleXOutput(
   resourcePath: string,
   inputSource: string,
   rsOptions: Partial<StyleXOptions>,
-  inputSourceMap?: SourceMap
+  inputSourceMap?: SourceMap,
+  sourceMapsEnabled?: boolean
 ): StyleXTransformResult {
   const options = normalizeRsOptions(rsOptions ?? {});
+
+  // The bundler drops the emitted map when its own `devtool` is off, so
+  // building one is pure waste — and costly waste now that the authored source
+  // is inlined into it. An explicit `rsOptions.sourceMap` still wins: a caller
+  // that asks for a map gets one whatever the bundler is doing.
+  //
+  // Only an explicit `false` disables it. `undefined` means the host never told
+  // us — Turbopack's loader context is a partial webpack shim and may not
+  // define `this.sourceMap` — and treating that as "off" would silently strip
+  // source maps from every file.
+  if (sourceMapsEnabled === false && rsOptions?.sourceMap === undefined) {
+    options.sourceMap = SourceMaps.False;
+  }
 
   // Forward the previous loader's source map so debug source-map annotations
   // and the emitted map resolve to the original authored file instead of the

--- a/packages/turbopack-plugin/package.json
+++ b/packages/turbopack-plugin/package.json
@@ -40,6 +40,7 @@
     }
   },
   "dependencies": {
+    "@stylexswc/plugin-shared": "0.18.3-rc.2",
     "@stylexswc/rs-compiler": "0.18.3-rc.2",
     "loader-utils": "^3.3.1"
   },

--- a/packages/turbopack-plugin/src/turbopack-loader.ts
+++ b/packages/turbopack-plugin/src/turbopack-loader.ts
@@ -47,7 +47,8 @@ export default async function stylexTurbopackLoader(
       this.resourcePath,
       stringifiedInputCode,
       rsOptions,
-      inputSourceMap
+      inputSourceMap,
+      this.sourceMap
     );
 
     // If metadata.stylex doesn't exist at all, we only need to return the transformed code

--- a/packages/turbopack-plugin/src/utils.ts
+++ b/packages/turbopack-plugin/src/utils.ts
@@ -1,4 +1,4 @@
-import { normalizeRsOptions, transform } from '@stylexswc/rs-compiler';
+import { SourceMaps, normalizeRsOptions, transform } from '@stylexswc/rs-compiler';
 import type { StyleXOptions, StyleXTransformResult } from '@stylexswc/rs-compiler';
 
 import type { SourceMap } from './types';
@@ -7,9 +7,21 @@ export function generateStyleXOutput(
   resourcePath: string,
   inputSource: string,
   rsOptions: Partial<StyleXOptions>,
-  inputSourceMap?: SourceMap
+  inputSourceMap?: SourceMap,
+  sourceMapsEnabled?: boolean
 ): StyleXTransformResult {
   const options = normalizeRsOptions(rsOptions ?? {});
+
+  // The bundler drops the emitted map when its own `devtool` is off, so
+  // building one is pure waste — and costly waste now that the authored source
+  // is inlined into it. An explicit `rsOptions.sourceMap` still wins.
+  //
+  // Only an explicit `false` disables it: Turbopack's loader context is a
+  // partial webpack shim that may not define `this.sourceMap`, and treating
+  // that `undefined` as "off" would silently strip every source map.
+  if (sourceMapsEnabled === false && rsOptions?.sourceMap === undefined) {
+    options.sourceMap = SourceMaps.False;
+  }
 
   // Forward the previous loader's source map so debug source-map annotations
   // and the emitted map resolve to the original authored file instead of the

--- a/packages/turbopack-plugin/src/utils.ts
+++ b/packages/turbopack-plugin/src/utils.ts
@@ -1,4 +1,5 @@
-import { SourceMaps, normalizeRsOptions, transform } from '@stylexswc/rs-compiler';
+import { resolveSourceMapOptions } from '@stylexswc/plugin-shared/source-map-options';
+import { normalizeRsOptions, transform } from '@stylexswc/rs-compiler';
 import type { StyleXOptions, StyleXTransformResult } from '@stylexswc/rs-compiler';
 
 import type { SourceMap } from './types';
@@ -10,18 +11,13 @@ export function generateStyleXOutput(
   inputSourceMap?: SourceMap,
   sourceMapsEnabled?: boolean
 ): StyleXTransformResult {
-  const options = normalizeRsOptions(rsOptions ?? {});
-
-  // The bundler drops the emitted map when its own `devtool` is off, so
-  // building one is pure waste — and costly waste now that the authored source
-  // is inlined into it. An explicit `rsOptions.sourceMap` still wins.
-  //
-  // Only an explicit `false` disables it: Turbopack's loader context is a
-  // partial webpack shim that may not define `this.sourceMap`, and treating
-  // that `undefined` as "off" would silently strip every source map.
-  if (sourceMapsEnabled === false && rsOptions?.sourceMap === undefined) {
-    options.sourceMap = SourceMaps.False;
-  }
+  // Shared with the webpack/rspack loader: Turbopack's loader context is a
+  // partial webpack shim, so the "host never told us" case this resolves is
+  // reached far more often here than there.
+  const options: StyleXOptions = {
+    ...normalizeRsOptions(rsOptions ?? {}),
+    ...resolveSourceMapOptions(rsOptions ?? {}, sourceMapsEnabled),
+  };
 
   // Forward the previous loader's source map so debug source-map annotations
   // and the emitted map resolve to the original authored file instead of the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1549,7 +1549,7 @@ importers:
         version: 8.0.1
       '@napi-rs/cli':
         specifier: ^3.8.2
-        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(supports-color@8.1.1)
+        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(supports-color@8.1.1)
       '@stylexjs/babel-plugin':
         specifier: ^0.19.0
         version: 0.19.0(supports-color@8.1.1)
@@ -1980,6 +1980,9 @@ importers:
 
   packages/turbopack-plugin:
     dependencies:
+      '@stylexswc/plugin-shared':
+        specifier: 0.18.3-rc.2
+        version: link:../plugin-shared
       '@stylexswc/rs-compiler':
         specifier: 0.18.3-rc.2
         version: link:../../crates/stylex-rs-compiler
@@ -13453,11 +13456,11 @@ snapshots:
       '@module-federation/runtime': 0.21.6
       '@module-federation/sdk': 0.21.6
 
-  '@napi-rs/cli@3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(supports-color@8.1.1)':
+  '@napi-rs/cli@3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(supports-color@8.1.1)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@26.1.2)
-      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)(supports-color@8.1.1)
-      '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)
+      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(supports-color@8.1.1)
+      '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@octokit/rest': 22.0.1
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       colorette: 2.0.20
@@ -13469,7 +13472,7 @@ snapshots:
       typanion: 3.14.0
       typescript: 6.0.3
     optionalDependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 2.0.0-alpha.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
@@ -13486,10 +13489,10 @@ snapshots:
       - node-addon-api
       - supports-color
 
-  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)(supports-color@8.1.1)':
+  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(supports-color@8.1.1)':
     dependencies:
-      '@napi-rs/lzma': 1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)
-      '@napi-rs/tar': 1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)
+      '@napi-rs/lzma': 1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/tar': 1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -13535,9 +13538,9 @@ snapshots:
   '@napi-rs/lzma-linux-x64-musl@1.4.5':
     optional: true
 
-  '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -13552,7 +13555,7 @@ snapshots:
   '@napi-rs/lzma-win32-x64-msvc@1.4.5':
     optional: true
 
-  '@napi-rs/lzma@1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/lzma@1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     optionalDependencies:
       '@napi-rs/lzma-android-arm-eabi': 1.4.5
       '@napi-rs/lzma-android-arm64': 1.4.5
@@ -13567,7 +13570,7 @@ snapshots:
       '@napi-rs/lzma-linux-s390x-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-musl': 1.4.5
-      '@napi-rs/lzma-wasm32-wasi': 1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)
+      '@napi-rs/lzma-wasm32-wasi': 1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@napi-rs/lzma-win32-arm64-msvc': 1.4.5
       '@napi-rs/lzma-win32-ia32-msvc': 1.4.5
       '@napi-rs/lzma-win32-x64-msvc': 1.4.5
@@ -13611,9 +13614,9 @@ snapshots:
   '@napi-rs/tar-linux-x64-musl@1.1.0':
     optional: true
 
-  '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -13628,7 +13631,7 @@ snapshots:
   '@napi-rs/tar-win32-x64-msvc@1.1.0':
     optional: true
 
-  '@napi-rs/tar@1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/tar@1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     optionalDependencies:
       '@napi-rs/tar-android-arm-eabi': 1.1.0
       '@napi-rs/tar-android-arm64': 1.1.0
@@ -13642,7 +13645,7 @@ snapshots:
       '@napi-rs/tar-linux-s390x-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-musl': 1.1.0
-      '@napi-rs/tar-wasm32-wasi': 1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)
+      '@napi-rs/tar-wasm32-wasi': 1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@napi-rs/tar-win32-arm64-msvc': 1.1.0
       '@napi-rs/tar-win32-ia32-msvc': 1.1.0
       '@napi-rs/tar-win32-x64-msvc': 1.1.0
@@ -13685,13 +13688,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)':
-    dependencies:
-      '@emnapi/core': 2.0.0-alpha.3
-      '@emnapi/runtime': 1.11.2
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
       '@emnapi/core': 2.0.0-alpha.3
@@ -13726,9 +13722,9 @@ snapshots:
   '@napi-rs/wasm-tools-linux-x64-musl@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -13743,7 +13739,7 @@ snapshots:
   '@napi-rs/wasm-tools-win32-x64-msvc@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools@1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-tools@1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     optionalDependencies:
       '@napi-rs/wasm-tools-android-arm-eabi': 1.0.1
       '@napi-rs/wasm-tools-android-arm64': 1.0.1
@@ -13754,7 +13750,7 @@ snapshots:
       '@napi-rs/wasm-tools-linux-arm64-musl': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-gnu': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-musl': 1.0.1
-      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@napi-rs/wasm-tools-win32-arm64-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-ia32-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-x64-msvc': 1.0.1


### PR DESCRIPTION
Chrome DevTools could not display StyleX-touched files under Next.js dev: the emitted map carried no `sourcesContent`, so DevTools fell back to fetching `sources[0]` over `webpack-internal://` and failed with net::ERR_UNKNOWN_URL_SCHEME.

`PrintArgs` was built with `..Default::default()`, which leaves both `inline_sources_content` and `emit_source_map_columns` at `false`. Both now default to `true` — matching @babel/generator, next-swc-loader (`inlineSourcesContent: this.sourceMap`) and webpack's SourceMapDevToolPlugin (`columns !== false`) — and both are exposed as options for callers who ship production maps and care about size or source disclosure.

Chained maps needed separate handling: `build_source_map_with_config` gates inlining on `orig.is_none()` and returns the input map with adjusted mappings, so the flag alone has no effect there. The authored text is now seeded into the input map before printing. Only entries with no content are touched, so a chain resolving to an earlier authored file keeps its own text.

Fixed while here:

- Comments were dropped entirely (parser and printer both received `None`), silently breaking `/* webpackChunkName */` chunk naming and `/* #__PURE__ */` tree-shaking annotations on every StyleX file.
- The loaders never consulted `this.sourceMap`, so a map was built and then discarded on every file when the bundler's devtool was off. Now gated on an explicit `false` only, since Turbopack's partial loader context may leave it undefined and treating that as "off" would strip every map.
- The exported `SourceMaps` runtime shim was typed as string literals, so `{ sourceMap: SourceMaps.False }` failed to typecheck — the exact usage the shim exists to enable.

BREAKING CHANGE: production source maps now embed the original source by default. Builds that serve `.map` files publicly should set `inlineSourcesContent: false` to avoid publishing their source.

Verified against apps/nextjs-example: dev server serves 273 mapped sources with 0 missing sourcesContent; production emits no maps by default, and full sourcesContent with productionBrowserSourceMaps enabled.

## Description

This pull request introduces significant improvements to the StyleX Rust compiler's handling of source maps and comment preservation. The main changes include adding support for the `inlineSourcesContent` and `emitSourceMapColumns` options (with robust defaulting and chaining behavior), ensuring that all comments (including those required for bundlers and minifiers) are preserved during transformation, and updating the TypeScript interface and tests to match these new features.

**Source map enhancements:**

* Added `inlineSourcesContent` and `emitSourceMapColumns` options (both default to `true`), allowing control over whether the original source text and column mappings are embedded in emitted source maps. These options are now passed through the TypeScript interface, respected in the Rust backend, and tested end-to-end. [[1]](diffhunk://#diff-f8bd27565762d42ad91d7d85bacade13b49c2f8fe122045bfff233b1f2ca8f1aR84-R85) [[2]](diffhunk://#diff-f8bd27565762d42ad91d7d85bacade13b49c2f8fe122045bfff233b1f2ca8f1aR202-R208) [[3]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R45-R96) [[4]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R149-R165) [[5]](diffhunk://#diff-dc7c30b4f9a4c9c61e67ff2a569bf1eccf0a6621727a9d4e25ca62c0133f88d8R380-R417) [[6]](diffhunk://#diff-17119c1de647dcf88aa0a9ed26ce4ca8f79c87614e582d4760923910af97ca28R30-R31) [[7]](diffhunk://#diff-17119c1de647dcf88aa0a9ed26ce4ca8f79c87614e582d4760923910af97ca28R424-R436) [[8]](diffhunk://#diff-18de8afa4bfca93d8371f3c1365ffa9de23acc03dfb74a1287376e1b453f3876R1-R206) [[9]](diffhunk://#diff-497e597f198e67394151bac90eed8af2d37a18d25044c45cdb0cf32ee45fadd9L83-R92)
* Improved source map chaining: when an input source map is provided, the compiler backfills missing `sourcesContent` entries with the authored source text, ensuring accurate debugging even when upstream maps are incomplete. [[1]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R45-R96) [[2]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R149-R165) [[3]](diffhunk://#diff-18de8afa4bfca93d8371f3c1365ffa9de23acc03dfb74a1287376e1b453f3876R1-R206)

**Comment preservation:**

* The compiler now collects and preserves all comments during transformation, including line, block, JSDoc, and special comments used by bundlers and minifiers (e.g., `/* webpackChunkName: "..." */`, `/* #__PURE__ */`). This prevents accidental loss of important annotations and is verified by new test cases. [[1]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32L19-R19) [[2]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R182-R195) [[3]](diffhunk://#diff-67613e7a8891343863b5bcd02719e429f086195fb8d1c698abce8da71019c2d6R1-R87) [[4]](diffhunk://#diff-dc7c30b4f9a4c9c61e67ff2a569bf1eccf0a6621727a9d4e25ca62c0133f88d8R130-R139)

**TypeScript interface and test updates:**

* Updated the TypeScript interface and default options to include `inlineSourcesContent` and `emitSourceMapColumns`, and ensured the `SourceMaps` enum is properly typed for ESM consumers. [[1]](diffhunk://#diff-f8bd27565762d42ad91d7d85bacade13b49c2f8fe122045bfff233b1f2ca8f1aR17-R34) [[2]](diffhunk://#diff-f8bd27565762d42ad91d7d85bacade13b49c2f8fe122045bfff233b1f2ca8f1aR84-R85)
* Added and updated tests to cover the new options, comment preservation, and correct source map emission in various scenarios. [[1]](diffhunk://#diff-67613e7a8891343863b5bcd02719e429f086195fb8d1c698abce8da71019c2d6R1-R87) [[2]](diffhunk://#diff-18de8afa4bfca93d8371f3c1365ffa9de23acc03dfb74a1287376e1b453f3876R1-R206) [[3]](diffhunk://#diff-17119c1de647dcf88aa0a9ed26ce4ca8f79c87614e582d4760923910af97ca28R30-R31) [[4]](diffhunk://#diff-17119c1de647dcf88aa0a9ed26ce4ca8f79c87614e582d4760923910af97ca28R424-R436) [[5]](diffhunk://#diff-497e597f198e67394151bac90eed8af2d37a18d25044c45cdb0cf32ee45fadd9L83-R92)

**Editor configuration:**

* Set the default JavaScript formatter in `.vscode/settings.json` to `oxc.oxc-vscode` for improved formatting consistency.

## Fixes

Closes #1202

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
