### PR TITLE
fix(transform): give each defineMarker export its own class

### DIFF
--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -421,6 +421,12 @@ pub struct StateManager {
   /// ([`ModuleBindingsCollector`]).
   pub(crate) binding_writes: FxHashSet<Id>,
   pub(crate) top_level_expressions: Vec<TopLevelExpression>,
+  /// Spans of the calls that initialise a top-level declarator bound to a
+  /// pattern rather than a name — `export const { foo } = stylex.create(…);`.
+  /// [`Self::top_level_expressions`] is keyed by the exported name and so has
+  /// no entry for them, but they are still program level, and a transform that
+  /// hoists its result out of a nested position must not hoist here.
+  pub(crate) pattern_bound_top_level_calls: FxHashSet<Span>,
   pub(crate) call_expressions: CallExpressionState,
   pub(crate) seen: FxHashMap<u64, Rc<SeenValue>>,
   pub(crate) cache: CacheState,
@@ -536,6 +542,7 @@ impl StateManager {
       declarations_state: DeclarationState::default(),
       binding_writes: FxHashSet::default(),
       top_level_expressions: vec![],
+      pattern_bound_top_level_calls: FxHashSet::default(),
       call_expressions: CallExpressionState::default(),
       jsx_spread_attr_exprs_map: FxHashMap::default(),
 

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1118,6 +1118,11 @@ impl StateManager {
   /// `defineMarker()` in a module is the same expression. Spans are unique per
   /// position and the discovery pass records them untouched, so they are what
   /// pins an entry to the call it was recorded from.
+  ///
+  /// A dummy span identifies nothing, so a span-less call never matches — a
+  /// synthesized call is not something the discovery pass can have recorded,
+  /// and matching one against a recorded entry would resurrect the very
+  /// conflation this lookup exists to avoid.
   pub(crate) fn find_top_level_expr_by_span(&self, call: &CallExpr) -> Option<&TopLevelExpression> {
     if call.span.is_dummy() {
       return None;
@@ -1135,7 +1140,12 @@ impl StateManager {
   /// span for the reason given on [`Self::find_top_level_expr_by_span`].
   ///
   /// Returns the position rather than a reference so callers can both read the
-  /// declarator and later rewrite its initializer without searching twice.
+  /// declarator and later rewrite its initializer without searching twice. The
+  /// position stays valid only while `declarations` is not pushed to or
+  /// reordered, which no transform does mid-call.
+  ///
+  /// Span-less calls never match, for the reason given on
+  /// [`Self::find_top_level_expr_by_span`].
   pub(crate) fn find_call_declaration_index_by_span(&self, call: &CallExpr) -> Option<usize> {
     if call.span.is_dummy() {
       return None;

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1110,6 +1110,44 @@ impl StateManager {
     })
   }
 
+  /// Find the top level expression recorded from *this* call node, matched by
+  /// span.
+  ///
+  /// [`Self::find_top_level_expr`] compares span-insensitively, so calls that
+  /// differ only in source position all resolve to the first of them — every
+  /// `defineMarker()` in a module is the same expression. Spans are unique per
+  /// position and the discovery pass records them untouched, so they are what
+  /// pins an entry to the call it was recorded from.
+  pub(crate) fn find_top_level_expr_by_span(&self, call: &CallExpr) -> Option<&TopLevelExpression> {
+    if call.span.is_dummy() {
+      return None;
+    }
+
+    self
+      .top_level_expressions
+      .iter()
+      .find(|TopLevelExpression(_, expr, _)| {
+        matches!(expr, Expr::Call(recorded_call) if recorded_call.span == call.span)
+      })
+  }
+
+  /// Position of the declarator initialised by *this* call node, matched by
+  /// span for the reason given on [`Self::find_top_level_expr_by_span`].
+  ///
+  /// Returns the position rather than a reference so callers can both read the
+  /// declarator and later rewrite its initializer without searching twice.
+  pub(crate) fn find_call_declaration_index_by_span(&self, call: &CallExpr) -> Option<usize> {
+    if call.span.is_dummy() {
+      return None;
+    }
+
+    self.declarations.iter().position(|decl| {
+      decl.init.as_ref().is_some_and(
+        |init| matches!(**init, Expr::Call(ref recorded_call) if recorded_call.span == call.span),
+      )
+    })
+  }
+
   pub(crate) fn find_call_declaration(&self, call: &CallExpr) -> Option<&VarDeclarator> {
     self.declarations.iter().find(|decl| {
       decl

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1149,7 +1149,9 @@ impl StateManager {
   /// Returns the position rather than a reference so callers can both read the
   /// declarator and later rewrite its initializer without searching twice. The
   /// position stays valid only while `declarations` is not pushed to or
-  /// reordered, which no transform does mid-call.
+  /// reordered — `apply_dynamic_style_functions` does push, so a caller that
+  /// holds one across a transform has to check that its own path cannot reach
+  /// there.
   ///
   /// Span-less calls never match, for the reason given on
   /// [`Self::find_top_level_expr_by_span`].

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1158,6 +1158,15 @@ impl StateManager {
     })
   }
 
+  /// The declarator initialised by *this* call node, for callers that only read
+  /// it. See [`Self::find_call_declaration_index_by_span`], which this defers
+  /// to, for how the match is made.
+  pub(crate) fn find_call_declaration_by_span(&self, call: &CallExpr) -> Option<&VarDeclarator> {
+    self
+      .declarations
+      .get(self.find_call_declaration_index_by_span(call)?)
+  }
+
   pub(crate) fn find_call_declaration(&self, call: &CallExpr) -> Option<&VarDeclarator> {
     self.declarations.iter().find(|decl| {
       decl

--- a/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
@@ -371,6 +371,28 @@ mod state_manager {
   }
 
   #[test]
+  fn find_top_level_expr_by_span_ignores_a_non_call_entry_at_the_same_position() {
+    let mut state = StateManager::default();
+
+    let call = call_at(span_at(1, 10));
+
+    state.top_level_expressions.push(TopLevelExpression(
+      TopLevelExpressionKind::NamedExport,
+      Expr::Ident(Ident {
+        span: span_at(1, 10),
+        sym: "notACall".into(),
+        optional: false,
+        ctxt: SyntaxContext::empty(),
+      }),
+      Some("notACall".into()),
+    ));
+
+    // The span is only ever consulted to tell two recorded *calls* apart, so a
+    // position match on some other expression is not a match.
+    assert!(state.find_top_level_expr_by_span(&call).is_none());
+  }
+
+  #[test]
   fn find_top_level_expr_by_span_never_matches_a_spanless_call() {
     let mut state = StateManager::default();
 

--- a/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
@@ -435,6 +435,34 @@ mod state_manager {
   }
 
   #[test]
+  fn find_call_declaration_by_span_reads_the_declarator_at_that_position() {
+    let mut state = StateManager::default();
+
+    let first = call_at(span_at(1, 10));
+    let second = call_at(span_at(20, 30));
+
+    state
+      .declarations
+      .push(var_declarator("first", Expr::Call(first)));
+    state
+      .declarations
+      .push(var_declarator("second", Expr::Call(second.clone())));
+
+    assert_eq!(
+      state
+        .find_call_declaration_by_span(&second)
+        .and_then(|decl| decl.name.as_ident())
+        .map(|ident| ident.sym.as_str()),
+      Some("second")
+    );
+    assert!(
+      state
+        .find_call_declaration_by_span(&call_at(span_at(40, 50)))
+        .is_none()
+    );
+  }
+
+  #[test]
   fn find_call_declaration_index_by_span_never_matches_a_spanless_call() {
     let mut state = StateManager::default();
 

--- a/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
@@ -2,12 +2,12 @@
 mod state_manager {
   use rustc_hash::FxHashSet;
   use swc_core::{
-    common::{DUMMY_SP, SyntaxContext},
+    common::{BytePos, DUMMY_SP, Span, SyntaxContext},
     ecma::ast::{
-      AssignPatProp, BindingIdent, Decl, Expr, ExprStmt, Ident, IdentName, ImportDecl, ImportPhase,
-      Lit, MemberExpr, MemberProp, Module, ModuleDecl, ModuleItem, ObjectLit, ObjectPat,
-      ObjectPatProp, Pat, Prop, PropName, PropOrSpread, Stmt, Str, VarDecl, VarDeclKind,
-      VarDeclarator,
+      AssignPatProp, BindingIdent, CallExpr, Callee, Decl, Expr, ExprStmt, Ident, IdentName,
+      ImportDecl, ImportPhase, Lit, MemberExpr, MemberProp, Module, ModuleDecl, ModuleItem,
+      ObjectLit, ObjectPat, ObjectPatProp, Pat, Prop, PropName, PropOrSpread, Stmt, Str, VarDecl,
+      VarDeclKind, VarDeclarator,
     },
   };
 
@@ -15,6 +15,8 @@ mod state_manager {
     DeclId, InsertionSlot, StateManager, build_decl_use_graph, compute_live_set,
     flush_pending_insertions,
   };
+  use stylex_enums::top_level_expression::TopLevelExpressionKind;
+  use stylex_structures::top_level_expression::TopLevelExpression;
   use stylex_utils::hash::stable_hash_unspanned;
 
   fn ident(name: &str) -> Ident {
@@ -312,5 +314,115 @@ mod state_manager {
 
     assert!(state.decl_uses.is_empty());
     assert!(state.roots.contains(&id("b")));
+  }
+
+  /// A zero-argument call, the shape every `defineMarker()` shares, carrying
+  /// only the position that tells two of them apart.
+  fn call_at(span: Span) -> CallExpr {
+    CallExpr {
+      span,
+      ctxt: SyntaxContext::empty(),
+      callee: Callee::Expr(Box::new(ident_expr("defineMarker"))),
+      args: vec![],
+      type_args: None,
+    }
+  }
+
+  fn span_at(lo: u32, hi: u32) -> Span {
+    Span {
+      lo: BytePos(lo),
+      hi: BytePos(hi),
+    }
+  }
+
+  #[test]
+  fn find_top_level_expr_by_span_pins_the_entry_recorded_from_that_call() {
+    let mut state = StateManager::default();
+
+    let first = call_at(span_at(1, 10));
+    let second = call_at(span_at(20, 30));
+
+    state.top_level_expressions.push(TopLevelExpression(
+      TopLevelExpressionKind::NamedExport,
+      Expr::Call(first.clone()),
+      Some("first".into()),
+    ));
+    state.top_level_expressions.push(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      Expr::Call(second.clone()),
+      Some("second".into()),
+    ));
+
+    // The two calls are equal ignoring spans, so only the span tells the
+    // entries apart.
+    assert_eq!(
+      state.find_top_level_expr_by_span(&second).map(|tpe| &tpe.0),
+      Some(&TopLevelExpressionKind::Stmt)
+    );
+    assert_eq!(
+      state.find_top_level_expr_by_span(&first).map(|tpe| &tpe.0),
+      Some(&TopLevelExpressionKind::NamedExport)
+    );
+    assert!(
+      state
+        .find_top_level_expr_by_span(&call_at(span_at(40, 50)))
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn find_top_level_expr_by_span_never_matches_a_spanless_call() {
+    let mut state = StateManager::default();
+
+    state.top_level_expressions.push(TopLevelExpression(
+      TopLevelExpressionKind::NamedExport,
+      Expr::Call(call_at(DUMMY_SP)),
+      Some("synthesized".into()),
+    ));
+
+    assert!(
+      state
+        .find_top_level_expr_by_span(&call_at(DUMMY_SP))
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn find_call_declaration_index_by_span_pins_the_declarator_that_call_initialises() {
+    let mut state = StateManager::default();
+
+    let first = call_at(span_at(1, 10));
+    let second = call_at(span_at(20, 30));
+
+    state
+      .declarations
+      .push(var_declarator("first", Expr::Call(first.clone())));
+    state
+      .declarations
+      .push(var_declarator("second", Expr::Call(second.clone())));
+    state
+      .declarations
+      .push(var_declarator("notACall", ident_expr("other")));
+
+    assert_eq!(state.find_call_declaration_index_by_span(&second), Some(1));
+    assert_eq!(state.find_call_declaration_index_by_span(&first), Some(0));
+    assert_eq!(
+      state.find_call_declaration_index_by_span(&call_at(span_at(40, 50))),
+      None
+    );
+  }
+
+  #[test]
+  fn find_call_declaration_index_by_span_never_matches_a_spanless_call() {
+    let mut state = StateManager::default();
+
+    state
+      .declarations
+      .push(var_declarator("synthesized", Expr::Call(call_at(DUMMY_SP))));
+
+    assert_eq!(
+      state.find_call_declaration_index_by_span(&call_at(DUMMY_SP)),
+      None
+    );
   }
 }

--- a/crates/stylex-transform/src/shared/utils/common.rs
+++ b/crates/stylex-transform/src/shared/utils/common.rs
@@ -296,15 +296,18 @@ pub fn fill_top_level_expressions(module: &Module, state: &mut StateManager) {
     ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
       if let Decl::Var(decl_var) = &export_decl.decl {
         for decl in &decl_var.decls {
-          if let Some(decl_init) = decl.init.as_ref() {
-            let ident_sym = match decl.name.as_ident() {
-              Some(i) => i.sym.clone(),
-              None => stylex_panic!("{}", VAR_DECL_NAME_NOT_IDENT),
-            };
+          // A declarator bound to a pattern rather than a name exports no
+          // single name to record, so it is skipped here exactly as it is in
+          // the statement arm below — `export const { a } = expr;` is ordinary
+          // JavaScript, and an API that does require a name reports that
+          // itself, against the call the author wrote.
+          if let Some(decl_init) = decl.init.as_ref()
+            && let Some(ident) = decl.name.as_ident()
+          {
             state.top_level_expressions.push(TopLevelExpression(
               TopLevelExpressionKind::NamedExport,
               decl_init.as_ref().clone(),
-              Some(ident_sym),
+              Some(ident.sym.clone()),
             ));
             fill_state_declarations(state, decl);
           }

--- a/crates/stylex-transform/src/shared/utils/common.rs
+++ b/crates/stylex-transform/src/shared/utils/common.rs
@@ -353,12 +353,19 @@ pub fn fill_top_level_expressions(module: &Module, state: &mut StateManager) {
 }
 
 pub fn fill_state_declarations(state: &mut StateManager, decl: &VarDeclarator) {
-  // Dedup span-insensitively so the same declaration seen on multiple passes
-  // is stored once, while the live AST's spans are kept intact.
+  // Dedup on position first, then content. Every filler runs in the `Discover`
+  // cycle over the pristine AST, so the same declaration seen on more than one
+  // of those passes carries the same span and is still stored once — while two
+  // declarations that merely *read* the same, `var m = f(); var m = f();`, stay
+  // two entries. Collapsing those lost the second one, and a transform that
+  // pins a call to its declarator by span then found nothing to rewrite.
+  //
+  // Content is still compared span-insensitively, which is what decides the
+  // synthesized declarators that share `DUMMY_SP`.
   if !state
     .declarations
     .iter()
-    .any(|existing| existing.eq_ignore_span(decl))
+    .any(|existing| existing.span == decl.span && existing.eq_ignore_span(decl))
   {
     state.declarations.push(decl.clone());
   }

--- a/crates/stylex-transform/src/shared/utils/common.rs
+++ b/crates/stylex-transform/src/shared/utils/common.rs
@@ -22,9 +22,7 @@ use crate::shared::{
   },
   utils::ast::convertors::{convert_str_lit_to_atom, convert_wtf8_to_atom},
 };
-use stylex_constants::constants::messages::{
-  INVALID_UTF8, SPREAD_NOT_SUPPORTED, VAR_DECL_NAME_NOT_IDENT,
-};
+use stylex_constants::constants::messages::{INVALID_UTF8, SPREAD_NOT_SUPPORTED};
 use stylex_regex::regex::JSON_REGEX;
 
 use super::ast::convertors::expand_shorthand_prop;
@@ -300,16 +298,20 @@ pub fn fill_top_level_expressions(module: &Module, state: &mut StateManager) {
           // single name to record, so it is skipped here exactly as it is in
           // the statement arm below — `export const { a } = expr;` is ordinary
           // JavaScript, and an API that does require a name reports that
-          // itself, against the call the author wrote.
-          if let Some(decl_init) = decl.init.as_ref()
-            && let Some(ident) = decl.name.as_ident()
-          {
-            state.top_level_expressions.push(TopLevelExpression(
-              TopLevelExpressionKind::NamedExport,
-              decl_init.as_ref().clone(),
-              Some(ident.sym.clone()),
-            ));
-            fill_state_declarations(state, decl);
+          // itself, against the call the author wrote. Its position is still
+          // worth keeping: nothing else marks the call as program level.
+          if let Some(decl_init) = decl.init.as_ref() {
+            match decl.name.as_ident() {
+              Some(ident) => {
+                state.top_level_expressions.push(TopLevelExpression(
+                  TopLevelExpressionKind::NamedExport,
+                  decl_init.as_ref().clone(),
+                  Some(ident.sym.clone()),
+                ));
+                fill_state_declarations(state, decl);
+              },
+              None => record_pattern_bound_top_level_call(state, decl_init),
+            }
           }
         }
       }
@@ -334,25 +336,35 @@ pub fn fill_top_level_expressions(module: &Module, state: &mut StateManager) {
     },
     ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => {
       for decl in &var.decls {
-        if let Some(decl_init) = decl.init.as_ref()
-          && decl.name.as_ident().is_some()
-        {
-          let stmt_ident_sym = match decl.name.as_ident() {
-            Some(i) => i.sym.clone(),
-            None => stylex_panic!("{}", VAR_DECL_NAME_NOT_IDENT),
-          };
-          state.top_level_expressions.push(TopLevelExpression(
-            TopLevelExpressionKind::Stmt,
-            decl_init.as_ref().clone(),
-            Some(stmt_ident_sym),
-          ));
+        if let Some(decl_init) = decl.init.as_ref() {
+          match decl.name.as_ident() {
+            Some(stmt_ident) => {
+              state.top_level_expressions.push(TopLevelExpression(
+                TopLevelExpressionKind::Stmt,
+                decl_init.as_ref().clone(),
+                Some(stmt_ident.sym.clone()),
+              ));
 
-          fill_state_declarations(state, decl);
+              fill_state_declarations(state, decl);
+            },
+            None => record_pattern_bound_top_level_call(state, decl_init),
+          }
         }
       }
     },
     _ => {},
   });
+}
+
+/// Remember where a call sits when it initialises a top-level declarator that
+/// binds a pattern, the one program-level position no recorded top-level
+/// expression covers. See [`StateManager::pattern_bound_top_level_calls`].
+fn record_pattern_bound_top_level_call(state: &mut StateManager, decl_init: &Expr) {
+  if let Expr::Call(call) = decl_init
+    && !call.span.is_dummy()
+  {
+    state.pattern_bound_top_level_calls.insert(call.span);
+  }
 }
 
 pub fn fill_state_declarations(state: &mut StateManager, decl: &VarDeclarator) {

--- a/crates/stylex-transform/src/shared/utils/common.rs
+++ b/crates/stylex-transform/src/shared/utils/common.rs
@@ -294,25 +294,7 @@ pub fn fill_top_level_expressions(module: &Module, state: &mut StateManager) {
     ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
       if let Decl::Var(decl_var) = &export_decl.decl {
         for decl in &decl_var.decls {
-          // A declarator bound to a pattern rather than a name exports no
-          // single name to record, so it is skipped here exactly as it is in
-          // the statement arm below — `export const { a } = expr;` is ordinary
-          // JavaScript, and an API that does require a name reports that
-          // itself, against the call the author wrote. Its position is still
-          // worth keeping: nothing else marks the call as program level.
-          if let Some(decl_init) = decl.init.as_ref() {
-            match decl.name.as_ident() {
-              Some(ident) => {
-                state.top_level_expressions.push(TopLevelExpression(
-                  TopLevelExpressionKind::NamedExport,
-                  decl_init.as_ref().clone(),
-                  Some(ident.sym.clone()),
-                ));
-                fill_state_declarations(state, decl);
-              },
-              None => record_pattern_bound_top_level_call(state, decl_init),
-            }
-          }
+          record_top_level_declarator(state, TopLevelExpressionKind::NamedExport, decl);
         }
       }
     },
@@ -336,44 +318,57 @@ pub fn fill_top_level_expressions(module: &Module, state: &mut StateManager) {
     },
     ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => {
       for decl in &var.decls {
-        if let Some(decl_init) = decl.init.as_ref() {
-          match decl.name.as_ident() {
-            Some(stmt_ident) => {
-              state.top_level_expressions.push(TopLevelExpression(
-                TopLevelExpressionKind::Stmt,
-                decl_init.as_ref().clone(),
-                Some(stmt_ident.sym.clone()),
-              ));
-
-              fill_state_declarations(state, decl);
-            },
-            None => record_pattern_bound_top_level_call(state, decl_init),
-          }
-        }
+        record_top_level_declarator(state, TopLevelExpressionKind::Stmt, decl);
       }
     },
     _ => {},
   });
 }
 
-/// Remember where a call sits when it initialises a top-level declarator that
-/// binds a pattern, the one program-level position no recorded top-level
-/// expression covers. See [`StateManager::pattern_bound_top_level_calls`].
-fn record_pattern_bound_top_level_call(state: &mut StateManager, decl_init: &Expr) {
-  if let Expr::Call(call) = decl_init
-    && !call.span.is_dummy()
-  {
-    state.pattern_bound_top_level_calls.insert(call.span);
+/// Record one declarator of a top-level variable declaration, `kind` telling
+/// an exported one from a plain statement.
+///
+/// A declarator bound to a pattern rather than a name declares no single name
+/// to record, so it contributes no top-level expression — `export const { a } =
+/// expr;` is ordinary JavaScript, and an API that does require a name reports
+/// that itself, against the call the author wrote. Its position is still worth
+/// keeping: nothing else marks the call as program level.
+fn record_top_level_declarator(
+  state: &mut StateManager,
+  kind: TopLevelExpressionKind,
+  decl: &VarDeclarator,
+) {
+  let Some(decl_init) = decl.init.as_ref() else {
+    return;
+  };
+
+  match decl.name.as_ident() {
+    Some(ident) => {
+      state.top_level_expressions.push(TopLevelExpression(
+        kind,
+        decl_init.as_ref().clone(),
+        Some(ident.sym.clone()),
+      ));
+
+      fill_state_declarations(state, decl);
+    },
+    None => {
+      if let Expr::Call(call) = decl_init.as_ref()
+        && !call.span.is_dummy()
+      {
+        state.pattern_bound_top_level_calls.insert(call.span);
+      }
+    },
   }
 }
 
 pub fn fill_state_declarations(state: &mut StateManager, decl: &VarDeclarator) {
   // Dedup on position first, then content. Every filler runs in the `Discover`
   // cycle over the pristine AST, so the same declaration seen on more than one
-  // of those passes carries the same span and is still stored once — while two
+  // of those passes carries the same span and is stored once — while two
   // declarations that merely *read* the same, `var m = f(); var m = f();`, stay
-  // two entries. Collapsing those lost the second one, and a transform that
-  // pins a call to its declarator by span then found nothing to rewrite.
+  // two entries, as a lookup that pins a call to its declarator by span needs
+  // them to be.
   //
   // Content is still compared span-insensitively, which is what decides the
   // synthesized declarators that share `DUMMY_SP`.

--- a/crates/stylex-transform/src/shared/utils/tests/common_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/tests/common_tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use swc_core::{
-  common::{DUMMY_SP, FileName, SyntaxContext},
+  common::{BytePos, DUMMY_SP, FileName, Span, SyntaxContext},
   ecma::ast::{
     BinaryOp, BindingIdent, Decl, ExportDecl, Expr, Ident, Lit, Module, ModuleDecl, ModuleItem,
     Number, Pat, Stmt, Str, VarDecl, VarDeclKind, VarDeclarator,
@@ -568,6 +568,41 @@ mod fill_state_declarations_tests {
     let decl2 = make_var_declarator("y", make_num_expr(2.0));
     fill_state_declarations(&mut state, &decl1);
     fill_state_declarations(&mut state, &decl2);
+    assert_eq!(state.declarations.len(), 2);
+  }
+
+  /// `var m = f(); var m = f();` — two declarations that read the same but sit
+  /// at different positions. Collapsing them loses the second one, and a
+  /// transform that pins a call to its declarator by span then finds nothing
+  /// to rewrite, leaving the call in the output.
+  #[test]
+  fn adds_identical_declarations_from_different_positions() {
+    let mut state = StateManager::default();
+
+    let first = VarDeclarator {
+      span: Span {
+        lo: BytePos(1),
+        hi: BytePos(10),
+      },
+      ..make_var_declarator("m", make_num_expr(1.0))
+    };
+    let second = VarDeclarator {
+      span: Span {
+        lo: BytePos(20),
+        hi: BytePos(30),
+      },
+      ..make_var_declarator("m", make_num_expr(1.0))
+    };
+
+    fill_state_declarations(&mut state, &first);
+    fill_state_declarations(&mut state, &second);
+
+    assert_eq!(state.declarations.len(), 2);
+
+    // Re-recording either one on a later discovery pass is still a no-op.
+    fill_state_declarations(&mut state, &first);
+    fill_state_declarations(&mut state, &second);
+
     assert_eq!(state.declarations.len(), 2);
   }
 }

--- a/crates/stylex-transform/src/shared/utils/tests/common_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/tests/common_tests.rs
@@ -1998,7 +1998,7 @@ mod get_var_decl_by_ident_fn_map_panic_tests {
 
 mod fill_top_level_non_ident_pattern_tests {
   use super::*;
-  use swc_core::ecma::ast::{ArrayPat, ObjectPat};
+  use swc_core::ecma::ast::{ArrayPat, CallExpr, Callee, ObjectPat};
 
   /// `export const [ a ] = expr;` exports no single name to record, so it is
   /// skipped rather than rejected — it is ordinary JavaScript, and the APIs
@@ -2037,10 +2037,10 @@ mod fill_top_level_non_ident_pattern_tests {
     assert!(state.declarations.is_empty());
   }
 
+  /// A statement declarator bound to a pattern declares no single name, so it
+  /// contributes no top-level expression either.
   #[test]
   fn stmt_var_with_object_pattern_skipped() {
-    // Stmt var decls skip non-ident patterns (line 467:
-    // `decl.name.as_ident().is_some()`)
     let mut state = StateManager::default();
     let decl = VarDeclarator {
       span: DUMMY_SP,
@@ -2067,6 +2067,95 @@ mod fill_top_level_non_ident_pattern_tests {
     fill_top_level_expressions(&module, &mut state);
     // Object pattern is skipped, no expressions added
     assert!(state.top_level_expressions.is_empty());
+  }
+
+  /// A pattern-bound declarator initialised by a call keeps the call's
+  /// position, which is what marks it program level.
+  #[test]
+  fn export_decl_with_pattern_records_the_initializing_call_position() {
+    let call_span = Span {
+      lo: BytePos(11),
+      hi: BytePos(30),
+    };
+
+    let mut state = StateManager::default();
+    fill_top_level_expressions(
+      &pattern_bound_export(Expr::Call(make_call_expr(call_span))),
+      &mut state,
+    );
+
+    assert!(state.top_level_expressions.is_empty());
+    assert_eq!(
+      state
+        .pattern_bound_top_level_calls
+        .iter()
+        .copied()
+        .collect::<Vec<_>>(),
+      vec![call_span]
+    );
+  }
+
+  /// A span-less call identifies no position, so there is nothing to record —
+  /// see `StateManager::find_top_level_expr_by_span` for why a dummy span is
+  /// never a match.
+  #[test]
+  fn export_decl_with_pattern_ignores_a_span_less_call() {
+    let mut state = StateManager::default();
+    fill_top_level_expressions(
+      &pattern_bound_export(Expr::Call(make_call_expr(DUMMY_SP))),
+      &mut state,
+    );
+
+    assert!(state.pattern_bound_top_level_calls.is_empty());
+  }
+
+  /// A pattern-bound declarator initialised by anything else records nothing.
+  #[test]
+  fn export_decl_with_pattern_ignores_a_non_call_initializer() {
+    let mut state = StateManager::default();
+    fill_top_level_expressions(&pattern_bound_export(make_num_expr(1.0)), &mut state);
+
+    assert!(state.pattern_bound_top_level_calls.is_empty());
+  }
+
+  fn make_call_expr(span: Span) -> CallExpr {
+    CallExpr {
+      span,
+      ctxt: SyntaxContext::empty(),
+      callee: Callee::Expr(Box::new(Expr::Ident(make_ident("defineMarker")))),
+      args: vec![],
+      type_args: None,
+    }
+  }
+
+  /// `export const { a } = <init>;`
+  fn pattern_bound_export(init: Expr) -> Module {
+    let decl = VarDeclarator {
+      span: DUMMY_SP,
+      name: Pat::Object(ObjectPat {
+        span: DUMMY_SP,
+        props: vec![],
+        optional: false,
+        type_ann: None,
+      }),
+      init: Some(Box::new(init)),
+      definite: false,
+    };
+
+    Module {
+      span: DUMMY_SP,
+      body: vec![ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+        span: DUMMY_SP,
+        decl: Decl::Var(Box::new(VarDecl {
+          span: DUMMY_SP,
+          kind: VarDeclKind::Const,
+          declare: false,
+          decls: vec![decl],
+          ctxt: SyntaxContext::empty(),
+        })),
+      }))],
+      shebang: None,
+    }
   }
 }
 

--- a/crates/stylex-transform/src/shared/utils/tests/common_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/tests/common_tests.rs
@@ -1993,16 +1993,18 @@ mod get_var_decl_by_ident_fn_map_panic_tests {
 }
 
 // ──────────────────────────────────────────────
-// fill_top_level_expressions - non-ident var pattern panic
+// fill_top_level_expressions - non-ident var patterns
 // ──────────────────────────────────────────────
 
 mod fill_top_level_non_ident_pattern_tests {
   use super::*;
   use swc_core::ecma::ast::{ArrayPat, ObjectPat};
 
+  /// `export const [ a ] = expr;` exports no single name to record, so it is
+  /// skipped rather than rejected — it is ordinary JavaScript, and the APIs
+  /// that do require a name report that against the call themselves.
   #[test]
-  #[should_panic]
-  fn panics_for_array_pattern_in_export_decl() {
+  fn export_decl_with_array_pattern_skipped() {
     let mut state = StateManager::default();
     let decl = VarDeclarator {
       span: DUMMY_SP,
@@ -2030,6 +2032,9 @@ mod fill_top_level_non_ident_pattern_tests {
       shebang: None,
     };
     fill_top_level_expressions(&module, &mut state);
+
+    assert!(state.top_level_expressions.is_empty());
+    assert!(state.declarations.is_empty());
   }
 
   #[test]

--- a/crates/stylex-transform/src/shared/utils/validators.rs
+++ b/crates/stylex-transform/src/shared/utils/validators.rs
@@ -436,16 +436,31 @@ pub(crate) fn validate_stylex_define_marker_indent(call: &CallExpr, state: &mut 
   // marker through behind an exported one.
   let define_marker_top_level_expr = match state.find_top_level_expr_by_span(call) {
     Some(define_marker_top_level_expr) => define_marker_top_level_expr,
+    // Missing from the top level does not mean unbound. A call in a nested
+    // scope still initialises a declarator, and the discovery pass records
+    // declarators from every scope, so what that declarator looks like is what
+    // separates the two failures: bound to a plain identifier and the export is
+    // what is missing, bound to anything else — a destructuring pattern — and
+    // the variable is. Answered from the recorded declarations, on the error
+    // path only, so nothing is re-walked to tell them apart.
+    //
     // The call itself is the fault site. `defineMarker()` takes no arguments —
     // the check above has already panicked otherwise — so there is never an
     // argument to point at, unlike the `defineVars` / `defineConsts` validators
     // this shape was copied from.
-    None => build_code_frame_error_and_panic(
-      &call_expr,
-      &call_expr,
-      &unbound_call_value(STYLEX_DEFINE_MARKER),
-      state,
-    ),
+    None => {
+      let is_bound_to_a_bare_variable = state
+        .find_call_declaration_by_span(call)
+        .is_some_and(|declaration| declaration.name.as_ident().is_some());
+
+      let error_message = if is_bound_to_a_bare_variable {
+        non_export_named_declaration(STYLEX_DEFINE_MARKER)
+      } else {
+        unbound_call_value(STYLEX_DEFINE_MARKER)
+      };
+
+      build_code_frame_error_and_panic(&call_expr, &call_expr, &error_message, state)
+    },
   };
 
   if !is_variable_named_exported(define_marker_top_level_expr, state) {

--- a/crates/stylex-transform/src/shared/utils/validators.rs
+++ b/crates/stylex-transform/src/shared/utils/validators.rs
@@ -420,11 +420,14 @@ pub(crate) fn validate_stylex_define_marker_indent(call: &CallExpr, state: &mut 
     return;
   }
 
-  let call_expr = Expr::from(call.clone());
+  // Cloned only where it is about to be reported, as `validate_stylex_create`
+  // does: every path that needs it diverges, so the call that compiles pays
+  // nothing.
+  let fault_expr = || Expr::from(call.clone());
 
   if !call.args.is_empty() {
     build_code_frame_error_and_panic_at(
-      &call_expr,
+      &fault_expr(),
       &illegal_argument_length(STYLEX_DEFINE_MARKER, 0),
       state,
     );
@@ -459,13 +462,13 @@ pub(crate) fn validate_stylex_define_marker_indent(call: &CallExpr, state: &mut 
         unbound_call_value(STYLEX_DEFINE_MARKER)
       };
 
-      build_code_frame_error_and_panic(&call_expr, &call_expr, &error_message, state)
+      build_code_frame_error_and_panic_at(&fault_expr(), &error_message, state)
     },
   };
 
   if !is_variable_named_exported(define_marker_top_level_expr, state) {
     build_code_frame_error_and_panic_at(
-      &call_expr,
+      &fault_expr(),
       &non_export_named_declaration(STYLEX_DEFINE_MARKER),
       state,
     );

--- a/crates/stylex-transform/src/shared/utils/validators.rs
+++ b/crates/stylex-transform/src/shared/utils/validators.rs
@@ -436,14 +436,13 @@ pub(crate) fn validate_stylex_define_marker_indent(call: &CallExpr, state: &mut 
   // marker through behind an exported one.
   let define_marker_top_level_expr = match state.find_top_level_expr_by_span(call) {
     Some(define_marker_top_level_expr) => define_marker_top_level_expr,
+    // The call itself is the fault site. `defineMarker()` takes no arguments —
+    // the check above has already panicked otherwise — so there is never an
+    // argument to point at, unlike the `defineVars` / `defineConsts` validators
+    // this shape was copied from.
     None => build_code_frame_error_and_panic(
       &call_expr,
-      &call
-        .args
-        .get(2)
-        .cloned()
-        .unwrap_or_else(|| create_expr_or_spread(call_expr.clone()))
-        .expr,
+      &call_expr,
       &unbound_call_value(STYLEX_DEFINE_MARKER),
       state,
     ),

--- a/crates/stylex-transform/src/shared/utils/validators.rs
+++ b/crates/stylex-transform/src/shared/utils/validators.rs
@@ -430,7 +430,11 @@ pub(crate) fn validate_stylex_define_marker_indent(call: &CallExpr, state: &mut 
     );
   }
 
-  let define_marker_top_level_expr = match state.find_top_level_expr(call, |_| false, None) {
+  // Matched by span: two `defineMarker()` calls are indistinguishable without
+  // their positions, so a span-insensitive lookup would validate every call in
+  // the module against the first one's declaration and let an unexported
+  // marker through behind an exported one.
+  let define_marker_top_level_expr = match state.find_top_level_expr_by_span(call) {
     Some(define_marker_top_level_expr) => define_marker_top_level_expr,
     None => build_code_frame_error_and_panic(
       &call_expr,

--- a/crates/stylex-transform/src/transform/stylex/transform_define_marker_call.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_define_marker_call.rs
@@ -44,6 +44,9 @@ where
     // declarator, hashing every export to one class. The span does carry it.
     let parent_var_decl_index = self.state.find_call_declaration_index_by_span(call)?;
 
+    // Kept as the interned `Atom` the binding already carries: it only ever
+    // feeds `gen_file_based_identifier`, which takes `&str`, so re-allocating
+    // it as a `String` would buy nothing.
     let export_name = self
       .state
       .declarations
@@ -51,7 +54,7 @@ where
       .name
       .as_ident()?
       .sym
-      .to_string();
+      .clone();
 
     let file_name = match self
       .state
@@ -83,6 +86,11 @@ where
     // returns a marker object in place of. A `when` selector in the same file
     // resolves the marker through that declaration, so it has to see the
     // object rather than the call it can no longer evaluate.
+    //
+    // The index taken above still addresses that declarator: nothing between
+    // here and there takes `&mut self.state` — `get_filename_for_hashing`
+    // borrows it shared, and the rest only reads `options` — so the vector
+    // cannot have been pushed to or reordered.
     if let Some(declaration) = self.state.declarations.get_mut(parent_var_decl_index) {
       declaration.init = Some(Box::new(marker_obj_ast.clone()));
     }

--- a/crates/stylex-transform/src/transform/stylex/transform_define_marker_call.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_define_marker_call.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use rustc_hash::FxHashMap;
 use stylex_macros::stylex_panic;
 use swc_core::{
-  common::{EqIgnoreSpan, comments::Comments},
+  common::comments::Comments,
   ecma::ast::{CallExpr, Expr},
 };
 
@@ -37,11 +37,21 @@ where
       return None;
     }
 
-    let (var_name, parent_var_decl) = self.get_call_var_name(call);
+    // The marker's identity is its export name, so the call has to be tied
+    // back to the declarator it initialises. Nothing in the AST carries that
+    // link, and a span-insensitive lookup resolves every `defineMarker()` in
+    // the module — they are all the same expression — to the first
+    // declarator, hashing every export to one class. The span does carry it.
+    let parent_var_decl_index = self.state.find_call_declaration_index_by_span(call)?;
 
-    let parent_var_decl = parent_var_decl?;
-
-    parent_var_decl.name.as_ident()?;
+    let export_name = self
+      .state
+      .declarations
+      .get(parent_var_decl_index)?
+      .name
+      .as_ident()?
+      .sym
+      .to_string();
 
     let file_name = match self
       .state
@@ -51,15 +61,7 @@ where
       None => stylex_panic!("{}", cannot_generate_hash(STYLEX_DEFINE_MARKER)),
     };
 
-    let export_name = match var_name {
-      Some(name) => name,
-      None => stylex_panic!(
-        "defineMarker(): The variable name could not be determined. Ensure the call is bound to a named variable."
-      ),
-    };
     let export_id = gen_file_based_identifier(&file_name, &export_name, None);
-
-    self.state.export_id = Some(export_id.clone());
 
     let hash = create_hash(&export_id);
     let mut id = String::with_capacity(self.state.options.class_name_prefix.len() + hash.len());
@@ -81,17 +83,7 @@ where
     // returns a marker object in place of. A `when` selector in the same file
     // resolves the marker through that declaration, so it has to see the
     // object rather than the call it can no longer evaluate.
-    //
-    // Matched on the call rather than on `export_name`, as
-    // `StateManager::update_references` does for the other transforms: it
-    // pins the one declaration this call initialises instead of the first
-    // one that happens to share its name, and it makes a second pass a no-op
-    // once the call has been replaced.
-    if let Some(declaration) = self.state.declarations.iter_mut().find(|declaration| {
-      declaration.init.as_ref().is_some_and(|init| {
-        matches!(**init, Expr::Call(ref existing_call) if existing_call.eq_ignore_span(call))
-      })
-    }) {
+    if let Some(declaration) = self.state.declarations.get_mut(parent_var_decl_index) {
       declaration.init = Some(Box::new(marker_obj_ast.clone()));
     }
 

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
@@ -199,6 +199,9 @@ where
     let result = if is_create_call {
       validate_stylex_create(call, &mut self.state);
 
+      // A call bound to a top-level pattern — `export const { foo } =
+      // stylex.create(…);` — is program level too, and the recorded top-level
+      // expressions, keyed by the name a pattern does not give, cannot say so.
       let is_program_level = self
         .state
         .find_top_level_expr(
@@ -206,7 +209,11 @@ where
           |tpe: &TopLevelExpression| matches!(tpe.1, Expr::Array(_)),
           None,
         )
-        .is_some();
+        .is_some()
+        || self
+          .state
+          .pattern_bound_top_level_calls
+          .contains(&call.span);
 
       let mut first_arg = call.args.first()?.expr.clone();
 

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
@@ -202,18 +202,22 @@ where
       // A call bound to a top-level pattern — `export const { foo } =
       // stylex.create(…);` — is program level too, and the recorded top-level
       // expressions, keyed by the name a pattern does not give, cannot say so.
+      //
+      // Asked first: it is a hash lookup on two integers, where
+      // `find_top_level_expr` compares this call against every recorded one
+      // with `eq_ignore_span` — a deep walk of the whole style object.
       let is_program_level = self
         .state
-        .find_top_level_expr(
-          call,
-          |tpe: &TopLevelExpression| matches!(tpe.1, Expr::Array(_)),
-          None,
-        )
-        .is_some()
+        .pattern_bound_top_level_calls
+        .contains(&call.span)
         || self
           .state
-          .pattern_bound_top_level_calls
-          .contains(&call.span);
+          .find_top_level_expr(
+            call,
+            |tpe: &TopLevelExpression| matches!(tpe.1, Expr::Array(_)),
+            None,
+          )
+          .is_some();
 
       let mut first_arg = call.args.first()?.expr.clone();
 

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/destructured_export_of_a_create_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/destructured_export_of_a_create_call.js
@@ -1,0 +1,7 @@
+import * as stylex from '@stylexjs/stylex';
+export const { foo } = {
+    foo: {
+        kMwMTN: "x1e2nbdu",
+        $$css: true
+    }
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/destructured_statement_of_a_create_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/static_styles.rs/destructured_statement_of_a_create_call.js
@@ -1,0 +1,8 @@
+import * as stylex from '@stylexjs/stylex';
+const { foo } = {
+    foo: {
+        kMwMTN: "x1e2nbdu",
+        $$css: true
+    }
+};
+console.log(foo);

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/marker_beside_a_destructured_export.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/marker_beside_a_destructured_export.js
@@ -1,0 +1,11 @@
+import * as stylex from '@stylexjs/stylex';
+export const marker = {
+    x1allf69: "x1allf69",
+    $$css: true
+};
+export const { a } = {
+    a: 1
+};
+export const [b] = [
+    2
+];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/marker_redeclared_under_the_same_name.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/marker_redeclared_under_the_same_name.js
@@ -1,0 +1,10 @@
+import * as stylex from '@stylexjs/stylex';
+var dupMarker = {
+    x2er63d: "x2er63d",
+    $$css: true
+};
+var dupMarker = {
+    x2er63d: "x2er63d",
+    $$css: true
+};
+export { dupMarker };

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/multiple_marker_exports_in_one_declaration.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/multiple_marker_exports_in_one_declaration.js
@@ -1,0 +1,8 @@
+import * as stylex from '@stylexjs/stylex';
+export const firstMarker = {
+    xtat8jp: "xtat8jp",
+    $$css: true
+}, secondMarker = {
+    x15y46n2: "x15y46n2",
+    $$css: true
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/multiple_marker_exports_in_one_file.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/multiple_marker_exports_in_one_file.js
@@ -1,0 +1,9 @@
+import * as stylex from '@stylexjs/stylex';
+export const firstMarker = {
+    xtat8jp: "xtat8jp",
+    $$css: true
+};
+export const secondMarker = {
+    x15y46n2: "x15y46n2",
+    $$css: true
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/multiple_markers_exported_by_a_separate_export_statement.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_marker_test/define_marker_transform.rs/multiple_markers_exported_by_a_separate_export_statement.js
@@ -1,0 +1,10 @@
+import * as stylex from '@stylexjs/stylex';
+const firstMarker = {
+    xtat8jp: "xtat8jp",
+    $$css: true
+};
+const secondMarker = {
+    x15y46n2: "x15y46n2",
+    $$css: true
+};
+export { firstMarker, secondMarker };

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_when_test/when_functions_transform.rs/when_ancestor_with_two_same_file_custom_markers.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_when_test/when_functions_transform.rs/when_ancestor_with_two_same_file_custom_markers.js
@@ -1,0 +1,29 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as stylex from '@stylexjs/stylex';
+export const firstMarker = {
+    xfjtvvr: "xfjtvvr",
+    $$css: true
+};
+export const secondMarker = {
+    x6012g7: "x6012g7",
+    $$css: true
+};
+_inject2({
+    ltr: ".x1t391ir{background-color:blue}",
+    priority: 3000
+});
+_inject2({
+    ltr: ".xnqavsz.xnqavsz:where(.xfjtvvr:hover *){background-color:red}",
+    priority: 3011.3
+});
+_inject2({
+    ltr: ".x10zg2pa.x10zg2pa:where(.x6012g7:focus *){background-color:green}",
+    priority: 3011.5
+});
+export const styles = {
+    foo: {
+        kWkggS: "x1t391ir xnqavsz x10zg2pa",
+        $$css: true
+    }
+};

--- a/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/static_styles.rs
@@ -979,3 +979,32 @@ stylex_test!(
     })?.root;
   "#
 );
+
+// A call bound to a top-level pattern is already program level, so its result
+// stays inline rather than being hoisted into a temporary.
+stylex_test!(
+  destructured_export_of_a_create_call,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const { foo } = stylex.create({
+      foo: {
+        color: 'red',
+      },
+    });
+  "#
+);
+
+stylex_test!(
+  destructured_statement_of_a_create_call,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    const { foo } = stylex.create({
+      foo: {
+        color: 'red',
+      },
+    });
+    console.log(foo);
+  "#
+);

--- a/crates/stylex-transform/tests/transform_stylex_define_marker_test/define_marker_transform.rs
+++ b/crates/stylex-transform/tests/transform_stylex_define_marker_test/define_marker_transform.rs
@@ -72,3 +72,19 @@ stylex_test!(
     export const baz = defineMarker();
   "#
 );
+
+// A redeclared marker. Both declarations are compiled, and to the same class —
+// they name one export, and the class is derived from that name. Leaving either
+// call in place would throw at runtime, where `defineMarker` exists only to
+// report that it was never compiled away.
+stylex_test!(
+  marker_redeclared_under_the_same_name,
+  |tr| stylex_transform(tr.comments.clone(), |b| b
+    .with_filename(FileName::Real("/stylex/packages/markers.stylex.ts".into()))),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    var dupMarker = stylex.defineMarker();
+    var dupMarker = stylex.defineMarker();
+    export { dupMarker };
+  "#
+);

--- a/crates/stylex-transform/tests/transform_stylex_define_marker_test/define_marker_transform.rs
+++ b/crates/stylex-transform/tests/transform_stylex_define_marker_test/define_marker_transform.rs
@@ -88,3 +88,16 @@ stylex_test!(
     export { dupMarker };
   "#
 );
+
+// A destructured export alongside a marker is ordinary JavaScript: the marker
+// compiles and the destructuring is left alone.
+stylex_test!(
+  marker_beside_a_destructured_export,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const marker = stylex.defineMarker();
+    export const { a } = { a: 1 };
+    export const [ b ] = [ 2 ];
+  "#
+);

--- a/crates/stylex-transform/tests/transform_stylex_define_marker_test/define_marker_transform.rs
+++ b/crates/stylex-transform/tests/transform_stylex_define_marker_test/define_marker_transform.rs
@@ -29,6 +29,29 @@ stylex_test!(
 );
 
 stylex_test!(
+  multiple_marker_exports_in_one_file,
+  |tr| stylex_transform(tr.comments.clone(), |b| b
+    .with_filename(FileName::Real("/stylex/packages/markers.stylex.ts".into()))),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const firstMarker = stylex.defineMarker();
+    export const secondMarker = stylex.defineMarker();
+  "#
+);
+
+stylex_test!(
+  multiple_markers_exported_by_a_separate_export_statement,
+  |tr| stylex_transform(tr.comments.clone(), |b| b
+    .with_filename(FileName::Real("/stylex/packages/markers.stylex.ts".into()))),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    const firstMarker = stylex.defineMarker();
+    const secondMarker = stylex.defineMarker();
+    export { firstMarker, secondMarker };
+  "#
+);
+
+stylex_test!(
   named_import_call,
   |tr| stylex_transform(tr.comments.clone(), |b| b),
   r#"

--- a/crates/stylex-transform/tests/transform_stylex_define_marker_test/define_marker_transform.rs
+++ b/crates/stylex-transform/tests/transform_stylex_define_marker_test/define_marker_transform.rs
@@ -39,6 +39,19 @@ stylex_test!(
   "#
 );
 
+// Two declarators under one `export const`: `fill_top_level_expressions`
+// records these from a loop over the declaration's `decls`, a different path
+// to the one-statement-per-marker form above.
+stylex_test!(
+  multiple_marker_exports_in_one_declaration,
+  |tr| stylex_transform(tr.comments.clone(), |b| b
+    .with_filename(FileName::Real("/stylex/packages/markers.stylex.ts".into()))),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const firstMarker = stylex.defineMarker(), secondMarker = stylex.defineMarker();
+  "#
+);
+
 stylex_test!(
   multiple_markers_exported_by_a_separate_export_statement,
   |tr| stylex_transform(tr.comments.clone(), |b| b

--- a/crates/stylex-transform/tests/transform_stylex_when_test/when_functions_transform.rs
+++ b/crates/stylex-transform/tests/transform_stylex_when_test/when_functions_transform.rs
@@ -156,6 +156,40 @@ stylex_test!(
   "#
 );
 
+// Two markers defined in the same file: each selector has to resolve to the
+// class of the marker it names, not to the first marker in the file.
+stylex_test!(
+  when_ancestor_with_two_same_file_custom_markers,
+  |tr| build_test_transform(tr.comments.clone(), |b| b
+    .with_treeshake_compensation(true)
+    .with_runtime_injection()
+    .with_cwd(std::path::PathBuf::from("/stylex/packages/"))
+    .with_filename(swc_core::common::FileName::Real(
+      "/stylex/packages/vars.stylex.js".into()
+    ))
+    .with_unstable_module_resolution(ModuleResolution {
+      root_dir: Some("/stylex/packages/".to_string()),
+      theme_file_extension: None,
+      ..ModuleResolution::common_js(None)
+    })),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+
+    export const firstMarker = stylex.defineMarker();
+    export const secondMarker = stylex.defineMarker();
+
+    export const styles = stylex.create({
+      foo: {
+        backgroundColor: {
+          default: 'blue',
+          [stylex.when.ancestor(':hover', firstMarker)]: 'red',
+          [stylex.when.ancestor(':focus', secondMarker)]: 'green',
+        },
+      },
+    });
+  "#
+);
+
 // A marker that evaluates to null or undefined is the same as no marker at
 // all, so the selector falls back to the prefixed default marker rather than
 // treating the value as an unresolvable marker.

--- a/crates/stylex-transform/tests/validation_stylex_define_marker_test/define_marker_functions_validation.rs
+++ b/crates/stylex-transform/tests/validation_stylex_define_marker_test/define_marker_functions_validation.rs
@@ -108,3 +108,56 @@ stylex_test_panic!(
     const second = stylex.defineMarker();
   "#
 );
+
+// A call in a nested scope is bound to a variable, just never to an export, so
+// the missing export is what it is told about.
+stylex_test_panic!(
+  invalid_export_marker_in_a_nested_scope,
+  "The return value of defineMarker() must be bound to a named export.",
+  |tr| define_marker_transform(tr.comments.clone()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    function useMarker() {
+      const marker = stylex.defineMarker();
+      return marker;
+    }
+  "#
+);
+
+stylex_test_panic!(
+  invalid_export_marker_in_a_nested_scope_after_an_exported_one,
+  "The return value of defineMarker() must be bound to a named export.",
+  |tr| define_marker_transform(tr.comments.clone()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const first = stylex.defineMarker();
+    function useMarker() {
+      const second = stylex.defineMarker();
+      return second;
+    }
+  "#
+);
+
+// Bound to a destructuring pattern rather than a plain identifier: here it is
+// the variable that is wrong, not the export.
+stylex_test_panic!(
+  invalid_binding_destructured_marker,
+  "defineMarker() calls must be bound to a bare variable.",
+  |tr| define_marker_transform(tr.comments.clone()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    const { marker } = stylex.defineMarker();
+    export { marker };
+  "#
+);
+
+// Not bound to a variable at all.
+stylex_test_panic!(
+  invalid_binding_bare_call_statement,
+  "defineMarker() calls must be bound to a bare variable.",
+  |tr| define_marker_transform(tr.comments.clone()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    stylex.defineMarker();
+  "#
+);

--- a/crates/stylex-transform/tests/validation_stylex_define_marker_test/define_marker_functions_validation.rs
+++ b/crates/stylex-transform/tests/validation_stylex_define_marker_test/define_marker_functions_validation.rs
@@ -95,3 +95,16 @@ stylex_test_panic!(
     export { marker as themeMarker };
   "#
 );
+
+// Each call is validated against its own declaration: an unexported marker is
+// still an error when an exported one precedes it in the same file.
+stylex_test_panic!(
+  invalid_export_unexported_marker_after_an_exported_one,
+  "The return value of defineMarker() must be bound to a named export.",
+  |tr| define_marker_transform(tr.comments.clone()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const first = stylex.defineMarker();
+    const second = stylex.defineMarker();
+  "#
+);

--- a/crates/stylex-transform/tests/validation_stylex_define_marker_test/define_marker_functions_validation.rs
+++ b/crates/stylex-transform/tests/validation_stylex_define_marker_test/define_marker_functions_validation.rs
@@ -139,7 +139,8 @@ stylex_test_panic!(
 );
 
 // Bound to a destructuring pattern rather than a plain identifier: here it is
-// the variable that is wrong, not the export.
+// the variable that is wrong, not the export. Exported or not, and whichever
+// pattern it is.
 stylex_test_panic!(
   invalid_binding_destructured_marker,
   "defineMarker() calls must be bound to a bare variable.",
@@ -148,6 +149,26 @@ stylex_test_panic!(
     import * as stylex from '@stylexjs/stylex';
     const { marker } = stylex.defineMarker();
     export { marker };
+  "#
+);
+
+stylex_test_panic!(
+  invalid_binding_destructured_marker_export,
+  "defineMarker() calls must be bound to a bare variable.",
+  |tr| define_marker_transform(tr.comments.clone()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const { marker } = stylex.defineMarker();
+  "#
+);
+
+stylex_test_panic!(
+  invalid_binding_array_destructured_marker_export,
+  "defineMarker() calls must be bound to a bare variable.",
+  |tr| define_marker_transform(tr.comments.clone()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const [ marker ] = stylex.defineMarker();
   "#
 );
 


### PR DESCRIPTION
A `defineMarker()` call was matched against the recorded declarations with `eq_ignore_span`. Every such call in a module is the same expression once spans are ignored, so each one resolved to the first declarator: one export name, one hash, one class for every marker in the file. State on one marked element could then match a rule written for another marker.

Match the call by span instead. Spans are unique per source position and the discovery pass records them untouched, so they are what ties a call to the declarator it initialises. The same lookup now backs the validator, which previously checked every call against the first marker's declaration and let an unexported marker through behind an exported one.

Drop the `state.export_id` write: nothing reads it, since `defineVars` and `defineConsts` set it themselves before use.

Closes #1241

## Description

This pull request improves the handling of multiple `defineMarker()` calls in a single file, ensuring that each call is uniquely identified and transformed based on its source position (span), rather than treating all calls as the same due to their structural similarity. This resolves issues where multiple markers in the same file were previously conflated, causing incorrect exports and selector resolution. The changes include new span-based lookup methods, refactoring of the transform logic, and expanded test coverage to verify correct behavior.

**Key changes:**

### Core logic improvements

* Added `find_top_level_expr_by_span` and `find_call_declaration_index_by_span` methods to `StateManager` to enable span-based lookup of marker calls and their declarations, ensuring each `defineMarker()` call is correctly associated with its declaration and export.
* Updated the `validate_stylex_define_marker_indent` validator to use the new span-based lookup, preventing validation from incorrectly matching multiple calls to the same declaration.
* Refactored `transform_define_marker_call.rs` to use span-based declaration lookup, ensuring each marker export is generated with the correct name and initialization, and fixing issues where all markers were hashed to the same class. [[1]](diffhunk://#diff-99d078eecc267330caef1f88e898253498d090882b3d4408703c7495e9d661dcL40-R54) [[2]](diffhunk://#diff-99d078eecc267330caef1f88e898253498d090882b3d4408703c7495e9d661dcL54-L63) [[3]](diffhunk://#diff-99d078eecc267330caef1f88e898253498d090882b3d4408703c7495e9d661dcL84-R86)

### Test coverage

* Added new tests to verify correct handling of multiple `defineMarker()` calls in one file, both when exported directly and via separate export statements, and to ensure selectors resolve to the correct marker. [[1]](diffhunk://#diff-1ef2ccbbceca9451defd4a975199bb513c6a8f215a3ed75de713e5e484a78025R31-R53) [[2]](diffhunk://#diff-25be45e6fd6f55deb53ad5e7e447dfb72386b9a29477feb1fea35203b9f2f345R1-R10) [[3]](diffhunk://#diff-d9ba758bae9033c01b3ca44f2e8ec10886fde9fb4e3c11feda068ead69caaac7R1-R29) [[4]](diffhunk://#diff-0fe6b18f55bcc992609f2710beab8a618e33dfbecdce0c9069ba57a83be0d030R159-R192)
* Added a validation test to ensure that an unexported marker is still reported as an error even if an exported marker precedes it in the same file, confirming correct per-call validation.

### Test utilities

* Added helper functions (`call_at`, `span_at`) and unit tests for the new span-based lookup methods in `state_manager_test.rs`, verifying their correctness and edge cases.

These changes ensure robust support for multiple custom markers in a single file, with correct export, transformation, and selector resolution semantics.

## Fixes

Fixes #1241

## Additional Info

(Optional) Add any other relevant information about the pull request here.

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
