### PR TITLE
fix(unplugin): resolve the stylesheet link against Vite's base

### DIFF
--- a/packages/unplugin/CONTEXT.md
+++ b/packages/unplugin/CONTEXT.md
@@ -24,6 +24,13 @@ use, picked by preference: `index.css`, then `style.css`, then `main.css`, then
 the first `.css` asset present.
 _Avoid_: target file, output css, main stylesheet
 
+**Stylesheet href**:
+The URL written into the injected `<link>` tag, as opposed to the path the CSS
+asset is emitted at. The two differ whenever a host serves the bundle from
+somewhere other than the origin root — Vite's `base` — so the emitted path stays
+root-relative while the href is resolved against that base.
+_Avoid_: css url, link path, asset url
+
 **Bundler source**:
 An asset's content object. webpack and Rspack each declare their own
 incompatible `Source`, so the shared injection helper is generic over it —

--- a/packages/unplugin/CONTEXT.md
+++ b/packages/unplugin/CONTEXT.md
@@ -28,7 +28,9 @@ _Avoid_: target file, output css, main stylesheet
 The URL written into the injected `<link>` tag, as opposed to the path the CSS
 asset is emitted at. The two differ whenever a host serves the bundle from
 somewhere other than the origin root — Vite's `base` — so the emitted path stays
-root-relative while the href is resolved against that base.
+root-relative while the href is resolved against that base. In dev there is a
+third form again: the served path, which stays base-less because that is what
+HMR payloads carry and what the CSS middleware matches.
 _Avoid_: css url, link path, asset url
 
 **Bundler source**:

--- a/packages/unplugin/__tests__/resolveStylesheetHref.test.ts
+++ b/packages/unplugin/__tests__/resolveStylesheetHref.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+
+import resolveStylesheetHref from '../src/utils/resolveStylesheetHref';
+
+describe('resolveStylesheetHref', () => {
+  test('should return the root-relative path unchanged for the default base', () => {
+    expect(resolveStylesheetHref('/', '/stylex.css')).toBe('/stylex.css');
+  });
+
+  test('should return the root-relative path unchanged when no base is known', () => {
+    expect(resolveStylesheetHref(undefined, '/stylex.css')).toBe('/stylex.css');
+  });
+
+  test('should return the root-relative path unchanged for an empty base', () => {
+    expect(resolveStylesheetHref('', '/stylex.css')).toBe('/stylex.css');
+  });
+
+  test('should prefix a sub-path base', () => {
+    expect(resolveStylesheetHref('/app/', '/stylex.css')).toBe('/app/stylex.css');
+  });
+
+  test('should prefix a full-URL base', () => {
+    expect(resolveStylesheetHref('https://cdn.example.com/app/', '/stylex.css')).toBe(
+      'https://cdn.example.com/app/stylex.css'
+    );
+  });
+
+  test('should not double the slash when the base has no trailing slash', () => {
+    expect(resolveStylesheetHref('/app', '/stylex.css')).toBe('/app/stylex.css');
+  });
+
+  test('should produce a document-relative href for a relative base', () => {
+    expect(resolveStylesheetHref('./', '/stylex.css', '/index.html')).toBe('./stylex.css');
+  });
+
+  test('should climb out of a nested document for a relative base', () => {
+    expect(resolveStylesheetHref('./', '/stylex.css', '/pages/about.html')).toBe('../stylex.css');
+  });
+
+  test('should climb once per nested level for a relative base', () => {
+    expect(resolveStylesheetHref('./', '/stylex.css', '/a/b/c.html')).toBe('../../stylex.css');
+  });
+
+  test('should fall back to the document itself when no document path is known', () => {
+    expect(resolveStylesheetHref('./', '/stylex.css')).toBe('./stylex.css');
+  });
+
+  test('should preserve a hashed file name', () => {
+    expect(resolveStylesheetHref('https://cdn.example.com/app/', '/stylex.ca990dcb.css')).toBe(
+      'https://cdn.example.com/app/stylex.ca990dcb.css'
+    );
+  });
+
+  test('should preserve a nested assets directory', () => {
+    expect(resolveStylesheetHref('/app/', '/assets/stylex.css')).toBe('/app/assets/stylex.css');
+  });
+
+  test('should treat a dotted base that is not the relative base as an ordinary prefix', () => {
+    expect(resolveStylesheetHref('/../app/', '/stylex.css', '/pages/about.html')).toBe(
+      '/../app/stylex.css'
+    );
+  });
+
+  test('should ignore the document path unless the base is relative', () => {
+    expect(resolveStylesheetHref('/app/', '/stylex.css', '/pages/about.html')).toBe(
+      '/app/stylex.css'
+    );
+  });
+});

--- a/packages/unplugin/__tests__/resolveStylesheetHref.test.ts
+++ b/packages/unplugin/__tests__/resolveStylesheetHref.test.ts
@@ -55,10 +55,17 @@ describe('resolveStylesheetHref', () => {
     expect(resolveStylesheetHref('/app/', '/assets/stylex.css')).toBe('/app/assets/stylex.css');
   });
 
+  // `/a.b/` rather than something like `/../app/`: a base whose first character
+  // is a dot never reaches here, because Vite warns and falls back to `/`, and
+  // a dot segment is collapsed away when it resolves the base as a URL.
   test('should treat a dotted base that is not the relative base as an ordinary prefix', () => {
-    expect(resolveStylesheetHref('/../app/', '/stylex.css', '/pages/about.html')).toBe(
-      '/../app/stylex.css'
+    expect(resolveStylesheetHref('/a.b/', '/stylex.css', '/pages/about.html')).toBe(
+      '/a.b/stylex.css'
     );
+  });
+
+  test('should not eat a character when the file name has no leading slash', () => {
+    expect(resolveStylesheetHref('./', 'stylex.css', '/index.html')).toBe('./stylex.css');
   });
 
   test('should ignore the document path unless the base is relative', () => {

--- a/packages/unplugin/__tests__/vite.test.ts
+++ b/packages/unplugin/__tests__/vite.test.ts
@@ -1,7 +1,7 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { createServer } from 'vite';
+import { build, createServer } from 'vite';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import type { UnpluginStylexRSOptions } from '../src/types';
@@ -14,17 +14,26 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
 });
 
-async function transformFixture(
-  files: Record<string, string>,
-  transformCss: (css: string) => string,
-  options: UnpluginStylexRSOptions = {}
-): Promise<void> {
-  const root = await mkdtemp(path.join(process.cwd(), '.stylex-define-consts-'));
+// Stands in for the runtime so the fixtures never need the real package
+// installed; the compiler only cares that the import resolves.
+const stylexRuntimeStub = {
+  name: 'stylex-runtime-stub',
+  resolveId(id: string) {
+    return id === '@stylexjs/stylex' ? '\0stylex-runtime-stub' : null;
+  },
+  load(id: string) {
+    return id === '\0stylex-runtime-stub' ? 'export const create = value => value;' : null;
+  },
+};
+
+// Each fixture gets its own root so the temp directories cannot collide, and
+// every root is registered for the afterEach cleanup.
+async function writeFixtureRoot(prefix: string, files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(path.join(process.cwd(), prefix));
   roots.push(root);
 
   await Promise.all([
     writeFile(path.join(root, 'package.json'), JSON.stringify({ type: 'module' })),
-    writeFile(path.join(root, 'stylex.css'), `${placeholder}\n`),
     ...Object.entries(files).map(async ([file, source]) => {
       const filePath = path.join(root, file);
       await mkdir(path.dirname(filePath), { recursive: true });
@@ -32,20 +41,25 @@ async function transformFixture(
     }),
   ]);
 
+  return root;
+}
+
+async function transformFixture(
+  files: Record<string, string>,
+  transformCss: (css: string) => string,
+  options: UnpluginStylexRSOptions = {}
+): Promise<void> {
+  const root = await writeFixtureRoot('.stylex-define-consts-', {
+    'stylex.css': `${placeholder}\n`,
+    ...files,
+  });
+
   const server = await createServer({
     root,
     logLevel: 'silent',
     optimizeDeps: { noDiscovery: true },
     plugins: [
-      {
-        name: 'stylex-runtime-stub',
-        resolveId(id) {
-          return id === '@stylexjs/stylex' ? '\0stylex-runtime-stub' : null;
-        },
-        load(id) {
-          return id === '\0stylex-runtime-stub' ? 'export const create = value => value;' : null;
-        },
-      },
+      stylexRuntimeStub,
       stylexSwc({
         ...options,
         useCssPlaceholder: placeholder,
@@ -66,6 +80,53 @@ async function transformFixture(
   } finally {
     await server.close();
   }
+}
+
+const buildFixtureSource = `import * as stylex from '@stylexjs/stylex';
+
+export const styles = stylex.create({
+  root: { color: 'red' },
+});
+`;
+
+const buildFixtureHtml =
+  '<!doctype html><html><head></head><body><script type="module" src="/main.js"></script></body></html>\n';
+
+// Builds for real rather than calling the href helper directly: what only a
+// build can settle is which base Vite actually hands the plugin. The per-base
+// string cases are covered far more precisely in resolveStylesheetHref.test.ts.
+async function buildIndexHtml(base: string, pages: string[] = []): Promise<Record<string, string>> {
+  const root = await writeFixtureRoot('.stylex-vite-base-', {
+    'index.html': buildFixtureHtml,
+    'main.js': buildFixtureSource,
+    ...Object.fromEntries(pages.map(page => [page, buildFixtureHtml])),
+  });
+
+  await build({
+    base,
+    build: {
+      write: true,
+      rolldownOptions: { input: ['index.html', ...pages].map(page => path.join(root, page)) },
+    },
+    logLevel: 'silent',
+    plugins: [
+      stylexRuntimeStub,
+      stylexSwc({
+        fileName: 'stylex.css',
+        rsOptions: { dev: false, unstable_moduleResolution: { type: 'commonJS' } },
+      }),
+    ],
+    root,
+  });
+
+  const built = await Promise.all(
+    ['index.html', ...pages].map(async page => [
+      page,
+      await readFile(path.join(root, 'dist', page), 'utf8'),
+    ])
+  );
+
+  return Object.fromEntries(built);
 }
 
 const containerConsts = `import * as stylex from '@stylexjs/stylex';
@@ -225,5 +286,24 @@ export const styles = stylex.create({
     );
 
     expect(transformCss).not.toHaveBeenCalled();
+  });
+
+  test('should inject a root-relative stylesheet link for the default base', async () => {
+    const built = await buildIndexHtml('/');
+
+    expect(built['index.html']).toContain('href="/stylex.css"');
+  });
+
+  test('should inject the stylesheet link under a full-URL base', async () => {
+    const built = await buildIndexHtml('https://cdn.example.com/app/');
+
+    expect(built['index.html']).toContain('href="https://cdn.example.com/app/stylex.css"');
+  });
+
+  test('should resolve the stylesheet link against a relative base per document', async () => {
+    const built = await buildIndexHtml('./', ['pages/about.html']);
+
+    expect(built['index.html']).toContain('href="./stylex.css"');
+    expect(built['pages/about.html']).toContain('href="../stylex.css"');
   });
 });

--- a/packages/unplugin/__tests__/vite.test.ts
+++ b/packages/unplugin/__tests__/vite.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { build, createServer } from 'vite';
+import type { Plugin, PluginOption } from 'vite';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import type { UnpluginStylexRSOptions } from '../src/types';
@@ -18,13 +19,13 @@ afterEach(async () => {
 // installed; the compiler only cares that the import resolves.
 const stylexRuntimeStub = {
   name: 'stylex-runtime-stub',
-  resolveId(id: string) {
+  resolveId(id) {
     return id === '@stylexjs/stylex' ? '\0stylex-runtime-stub' : null;
   },
-  load(id: string) {
+  load(id) {
     return id === '\0stylex-runtime-stub' ? 'export const create = value => value;' : null;
   },
-};
+} satisfies Plugin;
 
 // Each fixture gets its own root so the temp directories cannot collide, and
 // every root is registered for the afterEach cleanup.
@@ -92,41 +93,84 @@ export const styles = stylex.create({
 const buildFixtureHtml =
   '<!doctype html><html><head></head><body><script type="module" src="/main.js"></script></body></html>\n';
 
+// One document pulling in one StyleX module is all either host below needs to
+// reach the link injection.
+const linkFixtureFiles: Record<string, string> = {
+  'index.html': buildFixtureHtml,
+  'main.js': buildFixtureSource,
+};
+
+// The host is the only thing the two fixtures disagree about, so `dev` is the
+// only knob: everything that decides the injected href is shared.
+function linkFixturePlugins(dev: boolean): PluginOption[] {
+  return [
+    stylexRuntimeStub,
+    stylexSwc({
+      fileName: 'stylex.css',
+      rsOptions: { dev, unstable_moduleResolution: { type: 'commonJS' } },
+    }),
+  ];
+}
+
 // Builds for real rather than calling the href helper directly: what only a
 // build can settle is which base Vite actually hands the plugin. The per-base
 // string cases are covered far more precisely in resolveStylesheetHref.test.ts.
 async function buildIndexHtml(base: string, pages: string[] = []): Promise<Record<string, string>> {
   const root = await writeFixtureRoot('.stylex-vite-base-', {
-    'index.html': buildFixtureHtml,
-    'main.js': buildFixtureSource,
+    ...linkFixtureFiles,
     ...Object.fromEntries(pages.map(page => [page, buildFixtureHtml])),
   });
 
   await build({
     base,
     build: {
+      // Spelled out because the assertions read the emitted HTML back off disk.
       write: true,
       rolldownOptions: { input: ['index.html', ...pages].map(page => path.join(root, page)) },
     },
+    configFile: false,
     logLevel: 'silent',
-    plugins: [
-      stylexRuntimeStub,
-      stylexSwc({
-        fileName: 'stylex.css',
-        rsOptions: { dev: false, unstable_moduleResolution: { type: 'commonJS' } },
-      }),
-    ],
+    plugins: linkFixturePlugins(false),
     root,
   });
 
   const built = await Promise.all(
-    ['index.html', ...pages].map(async page => [
-      page,
-      await readFile(path.join(root, 'dist', page), 'utf8'),
-    ])
+    ['index.html', ...pages].map(
+      async (page): Promise<[string, string]> => [
+        page,
+        await readFile(path.join(root, 'dist', page), 'utf8'),
+      ]
+    )
   );
 
   return Object.fromEntries(built);
+}
+
+// The dev server is the one host where the injected href and the path the CSS
+// middleware answers on are allowed to differ, and it resolves `base` on its
+// own terms, so it needs its own fixture rather than the build one above.
+async function transformDevIndexHtml(base: string): Promise<string> {
+  const root = await writeFixtureRoot('.stylex-vite-dev-base-', linkFixtureFiles);
+
+  const server = await createServer({
+    base,
+    configFile: false,
+    logLevel: 'silent',
+    optimizeDeps: { noDiscovery: true },
+    plugins: linkFixturePlugins(true),
+    root,
+    server: { middlewareMode: true, preTransformRequests: false },
+  });
+
+  try {
+    // Collects the rules the injection needs; nothing has requested the module
+    // yet at the point the document is transformed.
+    await server.transformRequest('/main.js');
+
+    return await server.transformIndexHtml('/index.html', buildFixtureHtml);
+  } finally {
+    await server.close();
+  }
 }
 
 const containerConsts = `import * as stylex from '@stylexjs/stylex';
@@ -294,6 +338,12 @@ export const styles = stylex.create({
     expect(built['index.html']).toContain('href="/stylex.css"');
   });
 
+  test('should inject the stylesheet link under a sub-path base', async () => {
+    const built = await buildIndexHtml('/app/');
+
+    expect(built['index.html']).toContain('href="/app/stylex.css"');
+  });
+
   test('should inject the stylesheet link under a full-URL base', async () => {
     const built = await buildIndexHtml('https://cdn.example.com/app/');
 
@@ -305,5 +355,11 @@ export const styles = stylex.create({
 
     expect(built['index.html']).toContain('href="./stylex.css"');
     expect(built['pages/about.html']).toContain('href="../stylex.css"');
+  });
+
+  test('should inject a base-prefixed stylesheet link in dev', async () => {
+    const html = await transformDevIndexHtml('/app/');
+
+    expect(html).toContain('href="/app/stylex.css"');
   });
 });

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -8,12 +8,13 @@ import type { StyleXMetadata, TransformedOptions } from '@stylexswc/rs-compiler'
 import { createUnplugin } from 'unplugin';
 import type { UnpluginFactory, UnpluginInstance } from 'unplugin';
 import type { Connect } from 'vite';
-import type { HotPayload, ModuleNode, UserConfig, ViteDevServer } from 'vite';
+import type { HotPayload, ModuleNode, ViteDevServer } from 'vite';
 
 import type { UnpluginStylexRSOptions } from './types';
 import generateHash from './utils/generateHash';
 import getStyleXRules from './utils/getStyleXRules';
 import normalizeOptions, { identityTransformCss } from './utils/normalizeOptions';
+import resolveStylesheetHref from './utils/resolveStylesheetHref';
 
 type StyleXRules = Record<string, StyleXMetadata['stylex']>;
 
@@ -299,7 +300,9 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
   // Mutable state for each compilation - reset in buildStart
   const stylexRules: StyleXRules = {};
 
-  let viteConfig: UserConfig | null = null;
+  // Each field is read from the hook that reports the value we actually want,
+  // which is not the same hook for both. Stays null for hosts other than Vite.
+  let viteConfig: { assetsDir?: string; base?: string } | null = null;
 
   let hasCssToExtract = false;
   let cssFileName: string | null = null;
@@ -498,13 +501,17 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
 
     vite: {
       config(config) {
-        viteConfig = {
-          build: config.build,
-          base: config.base,
-        };
+        // Deliberately the *user* `assetsDir`: leaving it unset keeps the
+        // stylesheet at the output root, whereas the resolved config always
+        // reports Vite's `assets` default and would relocate it.
+        viteConfig = { ...viteConfig, assetsDir: config.build?.assetsDir };
       },
 
       configResolved(config) {
+        // `base`, unlike `assetsDir`, is wanted in its resolved form: the user
+        // value may be unset or missing the trailing slash Vite normalizes in.
+        viteConfig = { ...viteConfig, base: config.base };
+
         config.optimizeDeps.exclude = config.optimizeDeps.exclude || [];
         config.optimizeDeps.exclude.push('@stylexjs/open-props');
       },
@@ -642,7 +649,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           stylexRules,
           normalizedOptions,
           transformedOptions,
-          viteConfig?.build?.assetsDir
+          viteConfig?.assetsDir
         );
 
         if (!collectedCSS) return;
@@ -740,7 +747,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           stylexRules,
           normalizedOptions,
           transformedOptions,
-          viteConfig?.build?.assetsDir
+          viteConfig?.assetsDir
         );
 
         if (!collectedCSS) return undefined;
@@ -793,7 +800,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           stylexRules,
           normalizedOptions,
           transformedOptions,
-          viteConfig?.build?.assetsDir
+          viteConfig?.assetsDir
         );
 
         if (!processedFileName) {
@@ -804,6 +811,9 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
 
         if (isDev) {
           wsSend ||= ctx.server?.ws.send.bind(ctx.server.ws);
+          // Deliberately the base-less path, unlike the href below. It is matched
+          // against request URLs, which Vite has already stripped the base from,
+          // and sent as an HMR path, which is likewise base-less.
           cssFileName ||= normalizedFileName;
         }
 
@@ -812,7 +822,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
             tag: 'link',
             attrs: {
               rel: 'stylesheet',
-              href: normalizedFileName,
+              href: resolveStylesheetHref(viteConfig?.base, normalizedFileName, ctx.path),
             },
             injectTo: 'head',
           },

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -300,9 +300,11 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
   // Mutable state for each compilation - reset in buildStart
   const stylexRules: StyleXRules = {};
 
-  // Each field is read from the hook that reports the value we actually want,
-  // which is not the same hook for both. Stays null for hosts other than Vite.
-  let viteConfig: { assetsDir?: string; base?: string } | null = null;
+  // Not one config snapshot: each is read from the hook that reports the value
+  // we actually want, which is a different hook for each. Both stay undefined
+  // for hosts other than Vite.
+  let viteUserAssetsDir: string | undefined;
+  let viteResolvedBase: string | undefined;
 
   let hasCssToExtract = false;
   let cssFileName: string | null = null;
@@ -503,14 +505,16 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
       config(config) {
         // Deliberately the *user* `assetsDir`: leaving it unset keeps the
         // stylesheet at the output root, whereas the resolved config always
-        // reports Vite's `assets` default and would relocate it.
-        viteConfig = { ...viteConfig, assetsDir: config.build?.assetsDir };
+        // reports Vite's `assets` default and would relocate it. The cost is
+        // that an `assetsDir` a later plugin's `config` hook returns is merged
+        // in after this runs, so it is invisible here.
+        viteUserAssetsDir = config.build?.assetsDir;
       },
 
       configResolved(config) {
         // `base`, unlike `assetsDir`, is wanted in its resolved form: the user
         // value may be unset or missing the trailing slash Vite normalizes in.
-        viteConfig = { ...viteConfig, base: config.base };
+        viteResolvedBase = config.base;
 
         config.optimizeDeps.exclude = config.optimizeDeps.exclude || [];
         config.optimizeDeps.exclude.push('@stylexjs/open-props');
@@ -649,7 +653,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           stylexRules,
           normalizedOptions,
           transformedOptions,
-          viteConfig?.assetsDir
+          viteUserAssetsDir
         );
 
         if (!collectedCSS) return;
@@ -685,6 +689,10 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         server.middlewares.use(
           (req: IncomingMessage, res: ServerResponse, next: Connect.NextFunction) => {
             const requestedCssFileName = cssFileName;
+            // A substring match on purpose: `cssFileName` is base-less, while
+            // this middleware runs ahead of Vite's base middleware, so a
+            // non-root base is still attached to `req.url` here. The HMR
+            // timestamp query is likewise only tolerated by matching loosely.
             if (!requestedCssFileName || !req.url?.includes(requestedCssFileName)) {
               next();
               return;
@@ -747,7 +755,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           stylexRules,
           normalizedOptions,
           transformedOptions,
-          viteConfig?.assetsDir
+          viteUserAssetsDir
         );
 
         if (!collectedCSS) return undefined;
@@ -800,7 +808,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           stylexRules,
           normalizedOptions,
           transformedOptions,
-          viteConfig?.assetsDir
+          viteUserAssetsDir
         );
 
         if (!processedFileName) {
@@ -811,9 +819,11 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
 
         if (isDev) {
           wsSend ||= ctx.server?.ws.send.bind(ctx.server.ws);
-          // Deliberately the base-less path, unlike the href below. It is matched
-          // against request URLs, which Vite has already stripped the base from,
-          // and sent as an HMR path, which is likewise base-less.
+          // Deliberately the base-less path, unlike the href below. It is sent
+          // as an HMR path, which is base-less, and matched against request
+          // URLs, which still carry the base: the middleware is registered from
+          // `configureServer`, so it runs ahead of Vite's own base middleware.
+          // Hence the substring match there rather than an exact one.
           cssFileName ||= normalizedFileName;
         }
 
@@ -822,7 +832,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
             tag: 'link',
             attrs: {
               rel: 'stylesheet',
-              href: resolveStylesheetHref(viteConfig?.base, normalizedFileName, ctx.path),
+              href: resolveStylesheetHref(viteResolvedBase, normalizedFileName, ctx.path),
             },
             injectTo: 'head',
           },

--- a/packages/unplugin/src/utils/resolveStylesheetHref.ts
+++ b/packages/unplugin/src/utils/resolveStylesheetHref.ts
@@ -1,3 +1,7 @@
+const RELATIVE_BASE = './';
+const LEADING_SLASH = /^\//;
+const TRAILING_SLASH = /\/$/;
+
 /**
  * Resolves the href for the injected stylesheet link against the host's base,
  * so the stylesheet is served from wherever the rest of the bundle is served
@@ -6,6 +10,10 @@
  * The root-relative path stays the fallback, which is what keeps a nested route
  * resolving the stylesheet against the origin rather than against its own
  * directory.
+ *
+ * Only `base` is honoured. A host that rewrites asset URLs one by one — Vite's
+ * `experimental.renderBuiltUrl` — does not reach the injected link, so the
+ * stylesheet stays on the base while such a host's own assets may not.
  *
  * @param base The host's resolved base. Vite normalizes this to a trailing
  *   slash, but an unset or unnormalized value is tolerated.
@@ -28,13 +36,13 @@ export default function resolveStylesheetHref(
   // Vite normalizes every relative base to exactly `./` when it resolves the
   // config, so anything else starting with a dot is an ordinary prefix.
   if (base === RELATIVE_BASE) {
-    return `${climbToOutputRoot(documentPath)}${rootRelativeFileName.slice(1)}`;
+    const documentRelativeFileName = rootRelativeFileName.replace(LEADING_SLASH, '');
+
+    return `${climbToOutputRoot(documentPath)}${documentRelativeFileName}`;
   }
 
-  return `${base.replace(/\/$/, '')}${rootRelativeFileName}`;
+  return `${base.replace(TRAILING_SLASH, '')}${rootRelativeFileName}`;
 }
-
-const RELATIVE_BASE = './';
 
 // The document path is a URL path, not a file system path: hosts normalize the
 // separator to `/` before it gets here, so this stays correct on Windows.

--- a/packages/unplugin/src/utils/resolveStylesheetHref.ts
+++ b/packages/unplugin/src/utils/resolveStylesheetHref.ts
@@ -1,0 +1,45 @@
+/**
+ * Resolves the href for the injected stylesheet link against the host's base,
+ * so the stylesheet is served from wherever the rest of the bundle is served
+ * from: a sub-path, a CDN origin, or the document itself for a relative base.
+ *
+ * The root-relative path stays the fallback, which is what keeps a nested route
+ * resolving the stylesheet against the origin rather than against its own
+ * directory.
+ *
+ * @param base The host's resolved base. Vite normalizes this to a trailing
+ *   slash, but an unset or unnormalized value is tolerated.
+ * @param rootRelativeFileName The emitted asset path, with a leading slash.
+ * @param documentPath The path of the HTML document the link is injected into,
+ *   needed only for a relative base, where the href resolves against the
+ *   document rather than the origin.
+ */
+export default function resolveStylesheetHref(
+  base: string | undefined,
+  rootRelativeFileName: string,
+  documentPath?: string
+): string {
+  if (!base || base === '/') {
+    return rootRelativeFileName;
+  }
+
+  // A relative base makes the whole output origin-agnostic, so the href has to
+  // climb back to the output root the same way the host's own asset URLs do.
+  // Vite normalizes every relative base to exactly `./` when it resolves the
+  // config, so anything else starting with a dot is an ordinary prefix.
+  if (base === RELATIVE_BASE) {
+    return `${climbToOutputRoot(documentPath)}${rootRelativeFileName.slice(1)}`;
+  }
+
+  return `${base.replace(/\/$/, '')}${rootRelativeFileName}`;
+}
+
+const RELATIVE_BASE = './';
+
+// The document path is a URL path, not a file system path: hosts normalize the
+// separator to `/` before it gets here, so this stays correct on Windows.
+function climbToOutputRoot(documentPath: string | undefined): string {
+  const depth = documentPath ? documentPath.split('/').filter(Boolean).length - 1 : 0;
+
+  return depth > 0 ? '../'.repeat(depth) : RELATIVE_BASE;
+}


### PR DESCRIPTION
The injected production stylesheet link was always root-relative, so a non-root or full-URL base served the stylesheet from the application origin rather than from where the rest of the bundle is served, and could 404.

Resolve the href against the base Vite settles on once it has resolved its config, since the user value may be unset or missing the trailing slash. The default base keeps the root-relative form, so a nested route still resolves the stylesheet against the origin. A relative base instead climbs back to the output root per document, the same way the host emits its own asset URLs.

The dev server keeps matching and invalidating the base-less path, which is what request URLs and HMR paths carry.

Closes #1242

## Description

This pull request improves how the plugin resolves and injects stylesheet links in Vite-based builds, ensuring that the correct `href` is used for different `base` configurations (including sub-paths, full URLs, and relative bases). It introduces a new utility for resolving stylesheet URLs, updates the plugin to use it, and adds comprehensive tests to verify correct behavior across scenarios.

**Core logic improvements:**

- Added a new utility function `resolveStylesheetHref` in `src/utils/resolveStylesheetHref.ts` to correctly resolve the injected stylesheet link's `href` based on Vite's `base` config and the HTML document path. This ensures that the stylesheet is always referenced correctly, whether the site is served from the root, a sub-path, a CDN, or with a relative base.
- Updated the plugin's main logic in `src/index.ts` to use the new `resolveStylesheetHref` utility when injecting the stylesheet `<link>`, and to handle Vite's `base` and `assetsDir` configs more robustly. Now, the correct path is injected in all deployment scenarios, and the internal handling of Vite config is simplified. [[1]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL11-R17) [[2]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL302-R305) [[3]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL501-R514) [[4]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL645-R652) [[5]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL743-R750) [[6]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL796-R803) [[7]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dR814-R816) [[8]](diffhunk://#diff-8bf2d1e88ad06d96b1a2b006ccad2b27e73cd3613b10ae478844fe391bb8ad0dL815-R825)

**Testing and documentation:**

- Added a dedicated test suite for `resolveStylesheetHref` covering various `base` and document path combinations, ensuring correctness across edge cases.
- Extended Vite integration tests to verify that the correct stylesheet link is injected for root-relative, full-URL, and relative `base` values, including multi-page builds. [[1]](diffhunk://#diff-294c94cf276f45e311f5572c276778e21aa3bb71d390afd8d204b5caf95d6864L1-R4) [[2]](diffhunk://#diff-294c94cf276f45e311f5572c276778e21aa3bb71d390afd8d204b5caf95d6864L17-R62) [[3]](diffhunk://#diff-294c94cf276f45e311f5572c276778e21aa3bb71d390afd8d204b5caf95d6864R85-R131) [[4]](diffhunk://#diff-294c94cf276f45e311f5572c276778e21aa3bb71d390afd8d204b5caf95d6864R290-R308)
- Updated `CONTEXT.md` to clarify the meaning of "stylesheet href" and its distinction from the asset path, improving documentation for future maintainers and users.

These changes make the plugin more robust and reliable in a variety of deployment environments, and provide thorough test coverage for the new logic.

## Fixes

Fixes #1242

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
