### PR TITLE
Fix hashing and character handling in stylex-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,12 +189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base62"
-version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2925,7 +2919,6 @@ dependencies = [
 name = "stylex_utils"
 version = "0.18.4-rc.1"
 dependencies = [
- "base62",
  "indexmap",
  "murmur2",
  "radix_fmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ strip = "symbols"
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-base62 = { version = "2.2.4" }
 color-backtrace = { version = "0.7.2" }
 colored = { version = "3.1.1" }
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/stylex-regex/src/regex.rs
+++ b/crates/stylex-regex/src/regex.rs
@@ -18,10 +18,11 @@ pub static LENGTH_UNIT_TESTER_REGEX: Lazy<Regex> = Lazy::new(|| {
 pub static CLEAN_CSS_VAR: Lazy<Regex> =
   Lazy::new(|| Regex::new(r#"\\3(\d) "#).expect("Clean CSS var regex is valid"));
 
-// Updated: More permissive CSS variable name matching (allows dots,
-// underscores, etc.)
+// The character class is spelled out rather than written as `[\w-]`: `\w` is
+// Unicode-aware here but ASCII-only in the `/^var\(--[a-zA-Z0-9-_]+\)$/` this
+// mirrors, so `[\w-]` also accepted names like `var(--épaisseur)`.
 pub static IS_CSS_VAR: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r#"^var\(--[\w-]+\)$"#).expect("Is CSS var regex is valid"));
+  Lazy::new(|| Regex::new(r#"^var\(--[a-zA-Z0-9-_]+\)$"#).expect("Is CSS var regex is valid"));
 
 // Improved: Using positive lookbehind to avoid capturing the prefix
 // This simplifies replacement from "$1-$2" to "-$1"

--- a/crates/stylex-regex/src/tests/regex_static_coverage_test.rs
+++ b/crates/stylex-regex/src/tests/regex_static_coverage_test.rs
@@ -30,6 +30,12 @@ fn core_cleanup_patterns_match() {
   // Unicode-aware `\w` would have accepted them.
   assert!(!IS_CSS_VAR.is_match("var(--épaisseur)").unwrap());
   assert!(!IS_CSS_VAR.is_match("var(--日本)").unwrap());
+  // The `-` before `_` is a literal, not a `0x2D`–`0x5F` range: the class is
+  // copied verbatim from upstream's `/^var\(--[a-zA-Z0-9-_]+\)$/`, and if
+  // `fancy-regex` read it as a range these punctuation names would match.
+  assert!(!IS_CSS_VAR.is_match("var(--a:b)").unwrap());
+  assert!(!IS_CSS_VAR.is_match("var(--a.b)").unwrap());
+  assert!(!IS_CSS_VAR.is_match("var(--a[b)").unwrap());
   assert!(DASHIFY_REGEX.is_match("fooBar").unwrap());
 }
 

--- a/crates/stylex-regex/src/tests/regex_static_coverage_test.rs
+++ b/crates/stylex-regex/src/tests/regex_static_coverage_test.rs
@@ -24,7 +24,12 @@ fn css_value_parsers_match_expected_tokens() {
 fn core_cleanup_patterns_match() {
   assert!(CLEAN_CSS_VAR.is_match(r"\31 ").unwrap());
   assert!(IS_CSS_VAR.is_match("var(--token_1)").unwrap());
+  assert!(IS_CSS_VAR.is_match("var(--token-1)").unwrap());
   assert!(!IS_CSS_VAR.is_match("var(token)").unwrap());
+  // The name class is ASCII: `/^var\(--[a-zA-Z0-9-_]+\)$/` rejects these, and a
+  // Unicode-aware `\w` would have accepted them.
+  assert!(!IS_CSS_VAR.is_match("var(--épaisseur)").unwrap());
+  assert!(!IS_CSS_VAR.is_match("var(--日本)").unwrap());
   assert!(DASHIFY_REGEX.is_match("fooBar").unwrap());
 }
 

--- a/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
+++ b/crates/stylex-transform/src/shared/utils/js/evaluate/mod.rs
@@ -84,7 +84,7 @@ use stylex_enums::{
 };
 use stylex_structures::{named_import_source::ImportSources, stylex_env::EnvEntry};
 use stylex_utils::{
-  collection::sort_numbers_factory, hash::stable_hash_unspanned, string::char_code_at,
+  collection::sort_numbers_factory, hash::stable_hash_unspanned, string::char_code_at_f64,
   swc::get_default_expr_ctx,
 };
 

--- a/crates/stylex-transform/src/shared/utils/js/evaluate/nodes/call_expression.rs
+++ b/crates/stylex-transform/src/shared/utils/js/evaluate/nodes/call_expression.rs
@@ -1278,7 +1278,7 @@ pub(in super::super) fn evaluate(
                 stylex_panic!("The first argument of String.charCodeAt() must be a number.")
               });
 
-              let char_code = char_code_at(&base_str, *char_index as usize).unwrap_or_else(|| {
+              let char_code = char_code_at_f64(&base_str, *char_index).unwrap_or_else(|| {
                 stylex_panic!("String.charCodeAt() returned no result for the given index.")
               });
 

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/non_ascii_hash_parity.rs/content_with_astral_character.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/non_ascii_hash_parity.rs/content_with_astral_character.js
@@ -1,13 +1,13 @@
 import _inject from "@stylexjs/stylex/lib/stylex-inject";
 var _inject2 = _inject;
-import * as stylex from "@stylexjs/stylex";
+import * as stylex from '@stylexjs/stylex';
 _inject2({
-    ltr: '.xn9malq{--shape:"•"}',
-    priority: 1
+    ltr: '.xw4zyq6{content:"🎉"}',
+    priority: 3000
 });
 export const styles = {
-    shape: {
-        "--shape": "xn9malq",
+    root: {
+        kah6P1: "xw4zyq6",
         $$css: true
     }
 };

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/non_ascii_hash_parity.rs/content_with_non_ascii_character.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/non_ascii_hash_parity.rs/content_with_non_ascii_character.js
@@ -1,0 +1,21 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as stylex from '@stylexjs/stylex';
+_inject2({
+    ltr: '.xe0tt08{content:"•"}',
+    priority: 3000
+});
+_inject2({
+    ltr: ".xwywlkd{content:'•'}",
+    priority: 3000
+});
+export const styles = {
+    a: {
+        kah6P1: "xe0tt08",
+        $$css: true
+    },
+    b: {
+        kah6P1: "xwywlkd",
+        $$css: true
+    }
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/non_ascii_hash_parity.rs/custom_property_with_non_ascii_name.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/non_ascii_hash_parity.rs/custom_property_with_non_ascii_name.js
@@ -1,13 +1,13 @@
 import _inject from "@stylexjs/stylex/lib/stylex-inject";
 var _inject2 = _inject;
-import * as stylex from "@stylexjs/stylex";
+import * as stylex from '@stylexjs/stylex';
 _inject2({
-    ltr: '.xn9malq{--shape:"•"}',
+    ltr: ".xwcqdah{--épaisseur:1px}",
     priority: 1
 });
 export const styles = {
-    shape: {
-        "--shape": "xn9malq",
+    root: {
+        "--épaisseur": "xwcqdah",
         $$css: true
     }
 };

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/non_ascii_hash_parity.rs/font_family_with_non_ascii_name.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/non_ascii_hash_parity.rs/font_family_with_non_ascii_name.js
@@ -1,13 +1,13 @@
 import _inject from "@stylexjs/stylex/lib/stylex-inject";
 var _inject2 = _inject;
-import * as stylex from "@stylexjs/stylex";
+import * as stylex from '@stylexjs/stylex';
 _inject2({
-    ltr: '.xn9malq{--shape:"•"}',
-    priority: 1
+    ltr: ".xp6ipyb{font-family:日本語}",
+    priority: 3000
 });
 export const styles = {
-    shape: {
-        "--shape": "xn9malq",
+    root: {
+        kMv6JI: "xp6ipyb",
         $$css: true
     }
 };

--- a/crates/stylex-transform/tests/transform_stylex_create_test/mod.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/mod.rs
@@ -2,4 +2,5 @@ mod debug_options;
 mod dynamic_styles;
 mod env;
 mod legacy_deprecated;
+mod non_ascii_hash_parity;
 mod static_styles;

--- a/crates/stylex-transform/tests/transform_stylex_create_test/non_ascii_hash_parity.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/non_ascii_hash_parity.rs
@@ -1,0 +1,67 @@
+//! Class name hashes for values carrying non-ASCII characters.
+//!
+//! The hash is defined over UTF-16 code units masked to their low byte, so a
+//! non-ASCII value must not be hashed as UTF-8 bytes. Regression coverage for
+//! https://github.com/Dwlad90/stylex-swc-plugin/issues/1248, where the emitted
+//! CSS text was already byte-identical to `@stylexjs/babel-plugin` but the class
+//! names diverged — the two compilers could not be mixed across SSR and client.
+//!
+//! Runtime injection is enabled so each snapshot records the emitted CSS text
+//! alongside the class name: the class name is what regressed, but pinning the
+//! rule text next to it is what proves the two still agree. The `content`
+//! snapshot must read `.xe0tt08{content:"•"}` and `.xwywlkd{content:'•'}`, which
+//! is exactly what `@stylexjs/babel-plugin@0.19.0` emits for the same input.
+
+use crate::utils::prelude::*;
+
+fn stylex_transform(
+  comments: TestComments,
+  customize: impl FnOnce(TestBuilder) -> TestBuilder,
+) -> impl Pass {
+  build_test_transform(comments, customize)
+}
+
+stylex_test!(
+  content_with_non_ascii_character,
+  |tr| stylex_transform(tr.comments.clone(), |b| b.with_runtime_injection()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const styles = stylex.create({
+      a: { content: '•' },
+      b: { content: "'•'" },
+    });
+  "#
+);
+
+stylex_test!(
+  font_family_with_non_ascii_name,
+  |tr| stylex_transform(tr.comments.clone(), |b| b.with_runtime_injection()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const styles = stylex.create({
+      root: { fontFamily: '日本語' },
+    });
+  "#
+);
+
+stylex_test!(
+  custom_property_with_non_ascii_name,
+  |tr| stylex_transform(tr.comments.clone(), |b| b.with_runtime_injection()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const styles = stylex.create({
+      root: { '--épaisseur': '1px' },
+    });
+  "#
+);
+
+stylex_test!(
+  content_with_astral_character,
+  |tr| stylex_transform(tr.comments.clone(), |b| b.with_runtime_injection()),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const styles = stylex.create({
+      root: { content: '🎉' },
+    });
+  "#
+);

--- a/crates/stylex-utils/CONTEXT.md
+++ b/crates/stylex-utils/CONTEXT.md
@@ -10,7 +10,17 @@ share.
 A base-36 murmur2 digest of a string, via `create_hash`. This is what class
 names and variable names are built from, so its output is user-visible and
 stable across runs — changing the algorithm changes every generated class name.
+The digest is taken over the string's **UTF-16 code units, each masked to its
+low byte**, not over its UTF-8 bytes: that is how `murmurhash2_32_gc` is
+defined, and the two encodings agree only while the input is ASCII. Hashing
+bytes instead silently produces a different class name for identical CSS.
 _Avoid_: digest, checksum, id
+
+**Short hash**:
+`create_short_hash` — the same murmur2 value reduced modulo `62^5` and written
+in base 62, used for the object keys of a compiled style. Zero encodes as the
+empty string rather than `"0"`, matching `toBase62`.
+_Avoid_: small hash, truncated hash
 
 **Key hash**:
 `create_key_hash(namespace, key)` — the hash of `namespace.key`, which is how a

--- a/crates/stylex-utils/Cargo.toml
+++ b/crates/stylex-utils/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [dependencies]
-base62.workspace = true
 indexmap.workspace = true
 murmur2.workspace = true
 radix_fmt.workspace = true

--- a/crates/stylex-utils/src/hash.rs
+++ b/crates/stylex-utils/src/hash.rs
@@ -21,6 +21,7 @@ use swc_core::{
 
 const MAX_UNSPANNED_HASH_COLLECTION_LEN: usize = 128;
 const BASE36_DIGITS: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+const BASE62_DIGITS: &[u8; 62] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 /// Hashes a float value by converting to its bit representation first.
 pub fn hash_f64(value: f64) -> u64 {
@@ -30,10 +31,37 @@ pub fn hash_f64(value: f64) -> u64 {
   hasher.finish()
 }
 
+/// Runs murmur2 over the string's UTF-16 code units, each masked to its low
+/// byte.
+///
+/// `murmurhash2_32_gc` derives its block count from `str.length` and reads each
+/// byte as `str.charCodeAt(i) & 0xff`, so the hash is defined over UTF-16 code
+/// units rather than UTF-8 bytes. The two encodings only coincide while the
+/// input is ASCII; past that, hashing UTF-8 bytes yields a different class name
+/// for byte-identical CSS — which is visible in `content` values, non-ASCII
+/// `font-family` names, unicode custom properties, and export ids derived from
+/// a non-ASCII file path.
+///
+/// Masking each code unit to its low byte is lossy in exactly the same way the
+/// original is: `\u{1F389}` hashes as its two surrogate halves, `0xD83C` and
+/// `0xDF89`, contributing `0x3C` and `0x89`.
+#[inline]
+fn murmur2_code_units(value: &str) -> u32 {
+  // Every ASCII scalar is a single UTF-16 code unit below `0x80`, so its low
+  // byte is already its UTF-8 byte — hash in place, without a buffer.
+  if value.is_ascii() {
+    return murmur2::murmur2(value.as_bytes(), 1);
+  }
+
+  let code_units: Vec<u8> = value.encode_utf16().map(|unit| unit as u8).collect();
+
+  murmur2::murmur2(&code_units, 1)
+}
+
 /// Creates a base-36 hash of a string using murmur2.
 #[inline]
 pub fn create_hash(value: &str) -> String {
-  to_base36(murmur2::murmur2(value.as_bytes(), 1))
+  to_base36(murmur2_code_units(value))
 }
 
 /// Creates a StyleX key hash without allocating through `format!`.
@@ -47,30 +75,51 @@ pub fn create_key_hash(namespace: &str, key: &str) -> String {
   create_hash(&value)
 }
 
-/// `u32::MAX` in base-36 is `"1z141z3"` (7 chars), so a 7-byte stack buffer
-/// is sufficient for every input. We write digits least-significant-first
-/// from the back of the buffer and `String::from(&str)` once at the end —
-/// avoiding both the special-case `"0".to_string()` allocation and the
-/// pre-loop divisor calculation in the previous implementation.
-fn to_base36(mut value: u32) -> String {
-  let mut buf = [0u8; 7];
+/// Writes `value` in the radix implied by `digits`, least-significant digit
+/// first from the back of `buf`, and collects the populated suffix.
+///
+/// A zero value writes no digits at all, leaving the representation of zero to
+/// the caller — the two callers disagree about it, which is the whole reason
+/// they stay separate wrappers.
+///
+/// `buf` must be wide enough for the largest `value` the caller admits; a
+/// narrower buffer panics on the underflow rather than truncating silently.
+fn to_radix(mut value: u32, digits: &[u8], buf: &mut [u8]) -> String {
+  let radix = digits.len() as u32;
   let mut idx = buf.len();
 
-  if value == 0 {
+  while value > 0 {
     idx -= 1;
-    buf[idx] = b'0';
-  } else {
-    while value > 0 {
-      idx -= 1;
-      buf[idx] = BASE36_DIGITS[(value % 36) as usize];
-      value /= 36;
-    }
+    buf[idx] = digits[(value % radix) as usize];
+    value /= radix;
   }
 
-  // SAFETY: `BASE36_DIGITS` only ever contains ASCII alphanumerics, so the
-  // populated slice is guaranteed valid UTF-8.
-  debug_assert!(std::str::from_utf8(&buf[idx..]).is_ok());
-  unsafe { std::str::from_utf8_unchecked(&buf[idx..]) }.to_owned()
+  // `digits` holds only ASCII alphanumerics, so widening each byte to a `char`
+  // is exact — and collecting checks the encoding instead of asserting it.
+  buf[idx..].iter().map(|&digit| char::from(digit)).collect()
+}
+
+/// `u32::MAX` in base-36 is `"1z141z3"`, so 7 digits covers every input.
+///
+/// Zero is `"0"`, matching `(0).toString(36)`.
+fn to_base36(value: u32) -> String {
+  if value == 0 {
+    return "0".to_owned();
+  }
+
+  to_radix(value, BASE36_DIGITS, &mut [0u8; 7])
+}
+
+/// `62u32.pow(5) - 1` in base-62 is `"zzzzz"`, so 5 digits covers every value
+/// `create_short_hash` reduces into range.
+///
+/// Zero is the empty string: `toBase62` loops `while (_num > 0)` and so returns
+/// `''` rather than `"0"`. That is reachable — the murmur2 value lands on a
+/// multiple of `62^5` for roughly one input in 916 million — and the empty
+/// string is what upstream emits, so it is reproduced here rather than
+/// corrected.
+fn to_base62(value: u32) -> String {
+  to_radix(value, BASE62_DIGITS, &mut [0u8; 5])
 }
 
 /// Deterministic hash using `DefaultHasher` (SipHash-based).
@@ -135,8 +184,8 @@ pub fn stable_hash_unspanned_call(call: &CallExpr) -> u64 {
 
 /// Creates a short base-62 hash of a string using murmur2.
 pub fn create_short_hash(value: &str) -> String {
-  let hash = murmur2::murmur2(value.as_bytes(), 1) % (62u32.pow(5));
-  base62::encode(hash)
+  let hash = murmur2_code_units(value) % (62u32.pow(5));
+  to_base62(hash)
 }
 
 fn hash_expr_unspanned<H: Hasher>(expr: &Expr, state: &mut H) -> bool {

--- a/crates/stylex-utils/src/hash.rs
+++ b/crates/stylex-utils/src/hash.rs
@@ -45,6 +45,13 @@ pub fn hash_f64(value: f64) -> u64 {
 /// Masking each code unit to its low byte is lossy in exactly the same way the
 /// original is: `\u{1F389}` hashes as its two surrogate halves, `0xD83C` and
 /// `0xDF89`, contributing `0x3C` and `0x89`.
+///
+/// Limitation: a `&str` cannot hold an *unpaired* surrogate, while a JS string
+/// literal can (`Str::value` is a `Wtf8Atom`). An input that reached this
+/// function has therefore already lost any lone surrogate, and no masking
+/// choice here can reproduce the byte babel would have contributed for it. Such
+/// literals are vanishingly rare in style values and are the one input class
+/// where the two compilers can still disagree.
 #[inline]
 fn murmur2_code_units(value: &str) -> u32 {
   // Every ASCII scalar is a single UTF-16 code unit below `0x80`, so its low
@@ -53,7 +60,12 @@ fn murmur2_code_units(value: &str) -> u32 {
     return murmur2::murmur2(value.as_bytes(), 1);
   }
 
-  let code_units: Vec<u8> = value.encode_utf16().map(|unit| unit as u8).collect();
+  // A non-ASCII scalar always costs at least as many UTF-8 bytes as UTF-16 code
+  // units (2 or 3 bytes for one unit, 4 for a surrogate pair), so the UTF-8
+  // length is an upper bound that sizes the buffer in one allocation —
+  // `EncodeUtf16`'s own lower-bound hint would under-reserve and reallocate.
+  let mut code_units = Vec::with_capacity(value.len());
+  code_units.extend(value.encode_utf16().map(|unit| (unit & 0xff) as u8));
 
   murmur2::murmur2(&code_units, 1)
 }
@@ -83,10 +95,22 @@ pub fn create_key_hash(namespace: &str, key: &str) -> String {
 /// they stay separate wrappers.
 ///
 /// `buf` must be wide enough for the largest `value` the caller admits; a
-/// narrower buffer panics on the underflow rather than truncating silently.
+/// narrower buffer panics rather than truncating silently — the `debug_assert`
+/// names the requirement, and in release the index of the wrapped `idx` still
+/// panics instead of writing a wrong digit.
+///
+/// The assertion carries no formatted message on purpose: its arguments would be
+/// evaluated only on a failure no caller can reach, leaving regions that no test
+/// can ever cover.
 fn to_radix(mut value: u32, digits: &[u8], buf: &mut [u8]) -> String {
   let radix = digits.len() as u32;
   let mut idx = buf.len();
+
+  debug_assert!(
+    u64::from(radix)
+      .checked_pow(buf.len() as u32)
+      .is_none_or(|capacity| capacity > u64::from(value))
+  );
 
   while value > 0 {
     idx -= 1;
@@ -94,9 +118,14 @@ fn to_radix(mut value: u32, digits: &[u8], buf: &mut [u8]) -> String {
     value /= radix;
   }
 
-  // `digits` holds only ASCII alphanumerics, so widening each byte to a `char`
-  // is exact — and collecting checks the encoding instead of asserting it.
-  buf[idx..].iter().map(|&digit| char::from(digit)).collect()
+  // `digits` holds only ASCII alphanumerics, so the populated suffix is valid
+  // UTF-8 by construction. Validating it is a single pass over at most 7 bytes
+  // and copies once, where widening each byte to a `char` would re-encode digit
+  // by digit; `unwrap_or_default` keeps the check without `unsafe` and without
+  // an `expect` the project forbids.
+  std::str::from_utf8(&buf[idx..])
+    .map(str::to_owned)
+    .unwrap_or_default()
 }
 
 /// `u32::MAX` in base-36 is `"1z141z3"`, so 7 digits covers every input.

--- a/crates/stylex-utils/src/string.rs
+++ b/crates/stylex-utils/src/string.rs
@@ -55,6 +55,26 @@ pub fn char_code_at(s: &str, index: usize) -> Option<u32> {
   s.encode_utf16().nth(index).map(u32::from)
 }
 
+/// `char_code_at` for an index that arrived as a JS number, applying
+/// `charCodeAt`'s own argument coercion.
+///
+/// `charCodeAt` runs `ToIntegerOrInfinity` on its argument: `NaN` becomes `0`,
+/// fractional values truncate toward zero, and any negative or infinite index is
+/// out of range. `index as usize` saturates rather than wrapping, so a bare cast
+/// would silently turn `charCodeAt(-1)` — which JS answers with `NaN` — into the
+/// code unit at index 0.
+pub fn char_code_at_f64(s: &str, index: f64) -> Option<u32> {
+  if index.is_nan() {
+    return char_code_at(s, 0);
+  }
+
+  if index < 0.0 || index.is_infinite() {
+    return None;
+  }
+
+  char_code_at(s, index as usize)
+}
+
 #[cfg(test)]
 #[path = "tests/string_test.rs"]
 mod tests;

--- a/crates/stylex-utils/src/string.rs
+++ b/crates/stylex-utils/src/string.rs
@@ -9,8 +9,13 @@ use stylex_regex::regex::DASHIFY_REGEX;
 /// This is used to convert JavaScript-style CSS property names (e.g.
 /// `marginTop`, `WebkitTransform`) to their CSS equivalents (`margin-top`,
 /// `-webkit-transform`).
+/// `dashify` lowercases unconditionally, so the borrowed fast path is only
+/// sound for input the lowercasing cannot change. ASCII without an uppercase
+/// letter qualifies; anything non-ASCII does not, because a scalar can lowercase
+/// to something other than itself while satisfying neither `is_uppercase` nor
+/// `is_lowercase` — a titlecase scalar such as `ǅ` lowercases to `ǆ`.
 pub fn dashify(s: &str) -> Cow<'_, str> {
-  if !s.chars().any(char::is_uppercase) {
+  if s.is_ascii() && !s.bytes().any(|byte| byte.is_ascii_uppercase()) {
     return Cow::Borrowed(s);
   }
 

--- a/crates/stylex-utils/src/string.rs
+++ b/crates/stylex-utils/src/string.rs
@@ -38,10 +38,16 @@ pub fn wrap_key_in_quotes(key: &str, should_wrap_in_quotes: bool) -> Cow<'_, str
   }
 }
 
-/// Returns the Unicode code point of the character at the given index,
-/// or `None` if the index is out of bounds.
+/// Returns the UTF-16 code unit at the given index, or `None` if the index is
+/// out of bounds.
+///
+/// `charCodeAt` indexes by UTF-16 code unit and returns a single code unit, so
+/// an astral scalar occupies two indices and reads back as its surrogate halves
+/// — `"🎉"` is `0xD83C` at 0 and `0xDF89` at 1, never the `0x1F389` scalar.
+/// Indexing by `char` instead would return the whole scalar and shift every
+/// index that follows one.
 pub fn char_code_at(s: &str, index: usize) -> Option<u32> {
-  s.chars().nth(index).map(|c| c as u32)
+  s.encode_utf16().nth(index).map(u32::from)
 }
 
 #[cfg(test)]

--- a/crates/stylex-utils/src/tests/hash_test.rs
+++ b/crates/stylex-utils/src/tests/hash_test.rs
@@ -75,6 +75,46 @@ mod create_hash_tests {
     }
   }
 
+  /// The ASCII fast path skips the UTF-16 buffer on the claim that an ASCII
+  /// scalar's low code-unit byte *is* its UTF-8 byte. Pin that claim against the
+  /// general path rather than trusting it, since every ASCII class name in the
+  /// codebase is produced by the branch this test is the only check on.
+  #[test]
+  fn ascii_fast_path_agrees_with_the_utf16_path() {
+    for input in [
+      "",
+      "a",
+      "ab",
+      "abc",
+      "hello",
+      "<>content\"x\"null",
+      "a very long input string",
+    ] {
+      let code_units: Vec<u8> = input
+        .encode_utf16()
+        .map(|unit| (unit & 0xff) as u8)
+        .collect();
+
+      assert_eq!(
+        create_hash(input),
+        radix_fmt::radix(murmur2::murmur2(&code_units, 1), 36).to_string(),
+        "input: {:?}",
+        input
+      );
+    }
+  }
+
+  /// A hash of exactly zero renders as `"0"` in base 36 — `(0).toString(36)` —
+  /// where the same value renders as the empty string in base 62. The two
+  /// wrappers disagree deliberately, so each side needs a reachable case;
+  /// `murmur2("k4127446806") == 0` is this one, and
+  /// `matches_upstream_empty_short_hash_when_value_is_a_multiple_of_62_pow_5`
+  /// covers the other.
+  #[test]
+  fn matches_upstream_hash_when_value_is_zero() {
+    assert_eq!(create_hash("k4127446806"), "0");
+  }
+
   /// The ASCII fast path and the UTF-16 path must agree wherever both apply.
   #[test]
   fn matches_upstream_hash_for_ascii() {

--- a/crates/stylex-utils/src/tests/hash_test.rs
+++ b/crates/stylex-utils/src/tests/hash_test.rs
@@ -40,9 +40,51 @@ mod create_hash_tests {
 
   #[test]
   fn matches_radix_fmt_base36_output() {
-    for input in ["", "hello", "world", "日本語", "a very long input string"] {
+    // ASCII only: this pins `to_base36` against `radix_fmt`, and ASCII is the
+    // range where the raw murmur2-over-bytes value is still the hashed value.
+    // Non-ASCII parity is covered by `matches_upstream_hash_for_non_ascii`.
+    for input in ["", "hello", "world", "a very long input string"] {
       let raw = murmur2::murmur2(input.as_bytes(), 1);
       assert_eq!(create_hash(input), radix_fmt::radix(raw, 36).to_string());
+    }
+  }
+
+  /// Golden vectors produced by running `murmurhash2_32_gc` from
+  /// `@stylexjs/babel-plugin@0.19.0`'s `src/shared/hash.js` (`hash`, i.e. seed
+  /// 1, base 36) over each input.
+  ///
+  /// These are the values a class name must be built from for the two compilers
+  /// to be interchangeable. The `content` pair is the reproduction from
+  /// https://github.com/Dwlad90/stylex-swc-plugin/issues/1248, where both
+  /// compilers emitted byte-identical CSS under different class names.
+  #[test]
+  fn matches_upstream_hash_for_non_ascii() {
+    for (input, expected) in [
+      ("<>content\"•\"null", "e0tt08"),
+      ("<>content'•'null", "wywlkd"),
+      ("•", "19lqsls"),
+      ("日本語", "csni84"),
+      ("<>font-family\"日本語\"null", "1v1enns"),
+      ("--épaisseur", "xirl07"),
+      // Astral scalars hash as their surrogate halves, matching `charCodeAt`.
+      ("🎉", "yd2se2"),
+      ("<>content\"🎉\"null", "w4zyq6"),
+      ("a🎉b", "yp8u9f"),
+    ] {
+      assert_eq!(create_hash(input), expected, "input: {:?}", input);
+    }
+  }
+
+  /// The ASCII fast path and the UTF-16 path must agree wherever both apply.
+  #[test]
+  fn matches_upstream_hash_for_ascii() {
+    for (input, expected) in [
+      ("", "ph554m"),
+      ("hello", "1a4283y"),
+      ("world", "ck8emq"),
+      ("a very long input string", "1ida9zx"),
+    ] {
+      assert_eq!(create_hash(input), expected, "input: {:?}", input);
     }
   }
 
@@ -155,6 +197,38 @@ mod create_short_hash_tests {
   fn produces_short_output() {
     // base62 encoded, mod 62^5, should be at most 5 chars
     assert!(create_short_hash("test").len() <= 5);
+  }
+
+  /// Golden vectors produced by running `createShortHash` from
+  /// `@stylexjs/babel-plugin@0.19.0`'s `src/shared/hash.js` over each input.
+  #[test]
+  fn matches_upstream_short_hash() {
+    for (input, expected) in [
+      ("", "gFYqE"),
+      ("hello", "2hHSQ"),
+      ("a very long input string", "aTxoT"),
+      ("<>content\"•\"null", "vNlxw"),
+      ("<>content'•'null", "AuiFx"),
+      ("日本語", "qMRvw"),
+      ("--épaisseur", "DAgHH"),
+      ("🎉", "GcIck"),
+      // Fewer than 5 chars whenever the value needs fewer base-62 digits.
+      ("•", "cBiC"),
+    ] {
+      assert_eq!(create_short_hash(input), expected, "input: {:?}", input);
+    }
+  }
+
+  /// `toBase62` loops `while (_num > 0)`, so a value of zero yields the empty
+  /// string rather than `"0"`. `murmur2("k580145052") == 2748398496 == 3 * 62^5`,
+  /// making this the reachable case rather than a hypothetical one.
+  ///
+  /// The empty string is what upstream emits, so it is reproduced rather than
+  /// corrected — diverging here would reintroduce the class of mismatch this
+  /// module exists to close.
+  #[test]
+  fn matches_upstream_empty_short_hash_when_value_is_a_multiple_of_62_pow_5() {
+    assert_eq!(create_short_hash("k580145052"), "");
   }
 }
 

--- a/crates/stylex-utils/src/tests/string_test.rs
+++ b/crates/stylex-utils/src/tests/string_test.rs
@@ -59,6 +59,22 @@ mod dashify_tests {
     assert_eq!(dashify("opacity"), "opacity");
   }
 
+  /// The lowercasing is unconditional, so it must reach scalars that the
+  /// `[A-Z]` hyphenation pass does not match. Expectations produced by running
+  /// `str.replace(/(^|[a-z])([A-Z])/g, '$1-$2').toLowerCase()`.
+  #[test]
+  fn lowercases_non_ascii_without_hyphenating() {
+    // Titlecase: neither uppercase nor lowercase, but lowercases to `ǆ`.
+    assert_eq!(dashify("ǅ"), "ǆ");
+    assert_eq!(dashify("ǅBar"), "ǆbar");
+    // Uppercase outside ASCII lowercases without gaining a hyphen, because
+    // `[A-Z]` does not match it.
+    assert_eq!(dashify("Ä"), "ä");
+    // Already-lowercase non-ASCII is unchanged.
+    assert_eq!(dashify("é"), "é");
+    assert_eq!(dashify("naïveColor"), "naïve-color");
+  }
+
   #[test]
   fn handles_single_uppercase() {
     assert_eq!(dashify("A"), "-a");

--- a/crates/stylex-utils/src/tests/string_test.rs
+++ b/crates/stylex-utils/src/tests/string_test.rs
@@ -166,6 +166,27 @@ mod char_code_at_tests {
     assert_eq!(char_code_at("🎉", 2), None);
   }
 
+  /// `charCodeAt` coerces its argument with `ToIntegerOrInfinity`, which a bare
+  /// `as usize` does not reproduce: the cast saturates, so `-1.0` would land on
+  /// index 0.
+  #[test]
+  fn coerces_a_numeric_index_like_to_integer_or_infinity() {
+    use crate::string::char_code_at_f64;
+
+    // `NaN` coerces to 0, so `"abc".charCodeAt(NaN) === 97`.
+    assert_eq!(char_code_at_f64("abc", f64::NAN), Some(97));
+    // Fractional indices truncate toward zero.
+    assert_eq!(char_code_at_f64("abc", 1.9), Some(98));
+    assert_eq!(char_code_at_f64("abc", 0.0), Some(97));
+    // Negative and infinite indices are out of range — `NaN` in JS — rather
+    // than index 0 or a saturated `usize`.
+    assert_eq!(char_code_at_f64("abc", -1.0), None);
+    assert_eq!(char_code_at_f64("abc", -0.5), None);
+    assert_eq!(char_code_at_f64("abc", f64::NEG_INFINITY), None);
+    assert_eq!(char_code_at_f64("abc", f64::INFINITY), None);
+    assert_eq!(char_code_at_f64("abc", 3.0), None);
+  }
+
   #[test]
   fn astral_scalars_shift_following_indices() {
     // `"a🎉b".charCodeAt(3) === 98` — the surrogate pair consumes indices 1

--- a/crates/stylex-utils/src/tests/string_test.rs
+++ b/crates/stylex-utils/src/tests/string_test.rs
@@ -120,7 +120,7 @@ mod char_code_at_tests {
   use crate::string::char_code_at;
 
   #[test]
-  fn returns_code_point_at_index() {
+  fn returns_code_unit_at_index() {
     assert_eq!(char_code_at("abc", 0), Some(97)); // 'a'
     assert_eq!(char_code_at("abc", 1), Some(98)); // 'b'
     assert_eq!(char_code_at("abc", 2), Some(99)); // 'c'
@@ -135,5 +135,26 @@ mod char_code_at_tests {
   #[test]
   fn handles_unicode() {
     assert_eq!(char_code_at("é", 0), Some(0xe9));
+    // `"日本語".charCodeAt(i)` — one code unit per scalar in the BMP.
+    assert_eq!(char_code_at("日本語", 0), Some(26085));
+    assert_eq!(char_code_at("日本語", 1), Some(26412));
+    assert_eq!(char_code_at("日本語", 2), Some(35486));
+  }
+
+  #[test]
+  fn indexes_astral_scalars_by_code_unit() {
+    // `"🎉".length === 2`, and the two indices read back as the surrogate
+    // halves rather than the `0x1F389` scalar.
+    assert_eq!(char_code_at("🎉", 0), Some(55356)); // 0xD83C
+    assert_eq!(char_code_at("🎉", 1), Some(57225)); // 0xDF89
+    assert_eq!(char_code_at("🎉", 2), None);
+  }
+
+  #[test]
+  fn astral_scalars_shift_following_indices() {
+    // `"a🎉b".charCodeAt(3) === 98` — the surrogate pair consumes indices 1
+    // and 2, so `'b'` lands at 3, not at 2.
+    assert_eq!(char_code_at("a🎉b", 0), Some(97));
+    assert_eq!(char_code_at("a🎉b", 3), Some(98));
   }
 }

--- a/packages/unplugin/__tests__/vite.test.ts
+++ b/packages/unplugin/__tests__/vite.test.ts
@@ -135,12 +135,10 @@ async function buildIndexHtml(base: string, pages: string[] = []): Promise<Recor
   });
 
   const built = await Promise.all(
-    ['index.html', ...pages].map(
-      async (page): Promise<[string, string]> => [
-        page,
-        await readFile(path.join(root, 'dist', page), 'utf8'),
-      ]
-    )
+    ['index.html', ...pages].map(async (page): Promise<[string, string]> => [
+      page,
+      await readFile(path.join(root, 'dist', page), 'utf8'),
+    ])
   );
 
   return Object.fromEntries(built);


### PR DESCRIPTION
## Description

This pull request improves the handling of non-ASCII characters throughout the hashing, string processing, and CSS variable matching logic in the StyleX codebase. The main focus is to ensure that class name hashes, short hashes, and string utilities behave identically to the upstream `@stylexjs/babel-plugin`, especially for non-ASCII input. It also introduces comprehensive regression tests to guarantee cross-compiler consistency and updates documentation to clarify the hashing algorithm.

**Hashing and Encoding Improvements:**

* The core hashing logic for both `create_hash` and `create_short_hash` now operates on UTF-16 code units masked to their low byte, matching the behavior of upstream JavaScript implementations. This ensures class names and short hashes are consistent for non-ASCII input, fixing previous mismatches. [[1]](diffhunk://#diff-1267e0929dc8c89eb9ef17519d6a63bea3f6e9ea0efb817833b3a887c0b7fbc7R34-R64) [[2]](diffhunk://#diff-1267e0929dc8c89eb9ef17519d6a63bea3f6e9ea0efb817833b3a887c0b7fbc7L138-R188)
* The base-36 and base-62 encoding functions have been rewritten for correctness and performance, including handling of zero values and ASCII/non-ASCII parity.
* The `base62` crate dependency has been removed in favor of an internal implementation. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L57) [[2]](diffhunk://#diff-1d9628b3469e88b469a6940eacaa4cce9f4db4cf7e04520f12ff3c9fa2e91765L16)

**String and Regex Utilities:**

* The `dashify` function now properly handles non-ASCII input by only using the ASCII fast path where safe, and lowercases all input unconditionally to match JavaScript behavior. [[1]](diffhunk://#diff-0da9e9aa0126e58d77b13d00e974f50ca29be361da3dc462d758b8c626c75ab3R12-R18) [[2]](diffhunk://#diff-239c1cdc206efbbc84119f227cb0e0facce1aa4c7266931b5d63268f4dc0e197R62-R77)
* The `char_code_at` utility is updated to return UTF-16 code units, matching JavaScript's `charCodeAt`, and includes clarifying documentation.
* The CSS variable name regex is now ASCII-only, fixing over-permissiveness for Unicode variable names. [[1]](diffhunk://#diff-e9c0eae6e17a0d1243021c689eb4597e5e23f77aa42335a11f7769a33b9d1db9L21-R25) [[2]](diffhunk://#diff-519a29b59699dd0c3e6d8b723032429d00c5ce3bd66be87b424bd3b038cfa749R27-R32)

**Testing and Regression Coverage:**

* Extensive new tests ensure that hashing and string utilities match upstream outputs for both ASCII and non-ASCII input, including golden vectors and edge cases. [[1]](diffhunk://#diff-389ac41f84807f0ab79ebadb6fa43e1eb2ec8690d8a0f5c107d9bac7576957b9L43-R90) [[2]](diffhunk://#diff-389ac41f84807f0ab79ebadb6fa43e1eb2ec8690d8a0f5c107d9bac7576957b9R201-R232) [[3]](diffhunk://#diff-239c1cdc206efbbc84119f227cb0e0facce1aa4c7266931b5d63268f4dc0e197R62-R77)
* A new test module, `non_ascii_hash_parity`, and associated snapshot files verify that runtime CSS injection and class names remain in sync with the Babel plugin for non-ASCII content. [[1]](diffhunk://#diff-1ee20b22bb8f4c1c60755db85eeb6cfa956471077f49c17865741ebcb9c127dbR5) [[2]](diffhunk://#diff-1b676e622bd6b6df17e01279c35098ec28e038f2c1857666fe63e2cb8955570fR1-R67) [[3]](diffhunk://#diff-29625be5f4b6485d72b651da864274f7ef1772cf82dbaf3cf594c4e3a9c82b5dR1-R13) [[4]](diffhunk://#diff-a1158e51c0647dc096498b7b8523c6a2dcc5b1bd75dcf1004645097cda35b758R1-R21) [[5]](diffhunk://#diff-801ffb2a76b01a41670f86e9480ba27562a0a635e6d67f90650322a523954d37R1-R13) [[6]](diffhunk://#diff-997d0c84a6243f5990fa238a226a00d604514eb83d578bb19e71225d8b6c3ab0R1-R13) [[7]](diffhunk://#diff-3a399745b7260775c9bd21af9b2ffd6bae276a3baa80dcc522bc1dce1fc405d5L5-R10)

**Documentation:**

* The hashing algorithm and its rationale are now clearly documented, including the use of UTF-16 code units and base-62 encoding edge cases.

---

**Hashing and encoding updates:**

- Hashing functions (`create_hash`, `create_short_hash`) now operate over UTF-16 code units masked to their low byte, matching upstream JavaScript and fixing non-ASCII class name mismatches. [[1]](diffhunk://#diff-1267e0929dc8c89eb9ef17519d6a63bea3f6e9ea0efb817833b3a887c0b7fbc7R34-R64) [[2]](diffhunk://#diff-1267e0929dc8c89eb9ef17519d6a63bea3f6e9ea0efb817833b3a887c0b7fbc7L138-R188)
- Internal base-36 and base-62 encoding implementations replace the `base62` crate and handle edge cases like zero values, ensuring parity with upstream. [[1]](diffhunk://#diff-1267e0929dc8c89eb9ef17519d6a63bea3f6e9ea0efb817833b3a887c0b7fbc7L50-R122) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L57) [[3]](diffhunk://#diff-1d9628b3469e88b469a6940eacaa4cce9f4db4cf7e04520f12ff3c9fa2e91765L16)

**String and regex utilities:**

- `dashify` and `char_code_at` functions updated for correct non-ASCII handling and documentation, ensuring consistent behavior with JavaScript. [[1]](diffhunk://#diff-0da9e9aa0126e58d77b13d00e974f50ca29be361da3dc462d758b8c626c75ab3R12-R18) [[2]](diffhunk://#diff-0da9e9aa0126e58d77b13d00e974f50ca29be361da3dc462d758b8c626c75ab3L41-R55) [[3]](diffhunk://#diff-239c1cdc206efbbc84119f227cb0e0facce1aa4c7266931b5d63268f4dc0e197R62-R77)
- CSS variable regex tightened to only allow ASCII variable names, preventing acceptance of Unicode names. [[1]](diffhunk://#diff-e9c0eae6e17a0d1243021c689eb4597e5e23f77aa42335a11f7769a33b9d1db9L21-R25) [[2]](diffhunk://#diff-519a29b59699dd0c3e6d8b723032429d00c5ce3bd66be87b424bd3b038cfa749R27-R32)

**Testing and regression coverage:**

- New and expanded tests verify hash and string utility outputs for both ASCII and non-ASCII input, including golden vectors for cross-compiler consistency. [[1]](diffhunk://#diff-389ac41f84807f0ab79ebadb6fa43e1eb2ec8690d8a0f5c107d9bac7576957b9L43-R90) [[2]](diffhunk://#diff-389ac41f84807f0ab79ebadb6fa43e1eb2ec8690d8a0f5c107d9bac7576957b9R201-R232) [[3]](diffhunk://#diff-239c1cdc206efbbc84119f227cb0e0facce1aa4c7266931b5d63268f4dc0e197R62-R77)
- Added `non_ascii_hash_parity` test module and snapshot files to guarantee runtime and SSR/client CSS class name agreement for non-ASCII content. [[1]](diffhunk://#diff-1ee20b22bb8f4c1c60755db85eeb6cfa956471077f49c17865741ebcb9c127dbR5) [[2]](diffhunk://#diff-1b676e622bd6b6df17e01279c35098ec28e038f2c1857666fe63e2cb8955570fR1-R67) [[3]](diffhunk://#diff-29625be5f4b6485d72b651da864274f7ef1772cf82dbaf3cf594c4e3a9c82b5dR1-R13) [[4]](diffhunk://#diff-a1158e51c0647dc096498b7b8523c6a2dcc5b1bd75dcf1004645097cda35b758R1-R21) [[5]](diffhunk://#diff-801ffb2a76b01a41670f86e9480ba27562a0a635e6d67f90650322a523954d37R1-R13) [[6]](diffhunk://#diff-997d0c84a6243f5990fa238a226a00d604514eb83d578bb19e71225d8b6c3ab0R1-R13) [[7]](diffhunk://#diff-3a399745b7260775c9bd21af9b2ffd6bae276a3baa80dcc522bc1dce1fc405d5L5-R10)

**Documentation:**

- Hashing algorithm and encoding rationale are now clearly documented, including edge cases and the importance of UTF-16 code unit handling.

## Fixes

Fixes #1248

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
