### PR TITLE
Optimize performance of stylexswc with allocator and indexing improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "postcss_value_parser"
-version = "0.18.5"
+version = "0.18.6-rc.1"
 dependencies = [
  "criterion",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3476,6 +3476,7 @@ dependencies = [
  "swc_config",
  "swc_core",
  "swc_ecma_parser",
+ "swc_malloc",
  "swc_sourcemap",
  "testing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,6 +2011,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3239,6 +3257,7 @@ dependencies = [
  "swc_compiler_base",
  "swc_core",
  "swc_ecma_parser",
+ "swc_malloc",
  "swc_sourcemap",
 ]
 
@@ -3951,6 +3970,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_malloc"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d222be9e55e86fd6ee32e97c7b12829692329ac8bbed652dcd6c2e1d488af935"
+dependencies = [
+ "mimalloc",
+ "tikv-jemallocator",
+]
+
+[[package]]
 name = "swc_plugin"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4220,6 +4249,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,6 @@ dependencies = [
  "radix_fmt",
  "rustc-hash",
  "serde_json",
- "stylex_regex",
  "swc_core",
  "swc_ecma_parser",
  "xxhash-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,15 @@ serial_test = { version = "4.0.1" }
 stacker = "0.1.24"
 swc_compiler_base = { version = "62.0.0" }
 swc_config = { version = "6.0.0" }
+# The global allocator for the shipped `.node`. Selects mimalloc on every
+# target this repo publishes except `x86_64-unknown-linux-musl`, where it
+# deliberately keeps the system allocator: mimalloc segfaults on ARM64 musl
+# (microsoft/mimalloc#556) and the musl cross toolchains lack the C11 headers
+# its build needs. Depending on `mimalloc` directly would take mimalloc there
+# too, which is the configuration SWC found unshippable.
 swc_core = { version = "75.0.0" }
 swc_ecma_parser = { version = "43.0.0" }
+swc_malloc = { version = "1.2.5" }
 swc_sourcemap = { version = "10.0.2" }
 testing = "25.0.0"
 thiserror = "2.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,11 +107,14 @@ swc_compiler_base = { version = "62.0.0" }
 swc_config = { version = "6.0.0" }
 swc_core = { version = "75.0.0" }
 swc_ecma_parser = { version = "43.0.0" }
-# The global allocator for the shipped `.node`. Selects mimalloc on every target
-# this repo publishes except `x86_64-unknown-linux-musl`, where it deliberately
-# keeps the system allocator because mimalloc segfaults on ARM64 musl
-# (microsoft/mimalloc#556). Depending on `mimalloc` directly would take mimalloc
-# on musl too, which is the configuration SWC found unshippable.
+# The global allocator for the shipped `.node`. Keeps the system allocator on
+# *every* musl target -- `x86_64-unknown-linux-musl` is the one this repo
+# publishes -- because mimalloc segfaults on ARM64 musl (microsoft/mimalloc#556)
+# and jemalloc misbehaves against musl threads (jemalloc/jemalloc#1443).
+# Depending on `mimalloc` directly would take mimalloc on musl too, which is the
+# configuration SWC found unshippable. It also takes jemalloc rather than
+# mimalloc on `armv7-unknown-linux-gnueabihf`, which this repo does not publish
+# today: adding that target changes the allocator without a change here.
 swc_malloc = { version = "1.2.5" }
 swc_sourcemap = { version = "10.0.2" }
 testing = "25.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,14 +105,13 @@ serial_test = { version = "4.0.1" }
 stacker = "0.1.24"
 swc_compiler_base = { version = "62.0.0" }
 swc_config = { version = "6.0.0" }
-# The global allocator for the shipped `.node`. Selects mimalloc on every
-# target this repo publishes except `x86_64-unknown-linux-musl`, where it
-# deliberately keeps the system allocator: mimalloc segfaults on ARM64 musl
-# (microsoft/mimalloc#556) and the musl cross toolchains lack the C11 headers
-# its build needs. Depending on `mimalloc` directly would take mimalloc there
-# too, which is the configuration SWC found unshippable.
 swc_core = { version = "75.0.0" }
 swc_ecma_parser = { version = "43.0.0" }
+# The global allocator for the shipped `.node`. Selects mimalloc on every target
+# this repo publishes except `x86_64-unknown-linux-musl`, where it deliberately
+# keeps the system allocator because mimalloc segfaults on ARM64 musl
+# (microsoft/mimalloc#556). Depending on `mimalloc` directly would take mimalloc
+# on musl too, which is the configuration SWC found unshippable.
 swc_malloc = { version = "1.2.5" }
 swc_sourcemap = { version = "10.0.2" }
 testing = "25.0.0"

--- a/crates/postcss-value-parser/src/tests/cases.rs
+++ b/crates/postcss-value-parser/src/tests/cases.rs
@@ -29,7 +29,7 @@ pub(super) struct StressCase {
   pub output: &'static str,
 }
 
-/// 958 values: the differential harness's whole corpus, plus
+/// 960 values: the differential harness's whole corpus, plus
 /// malformed, truncated and degenerate inputs no author would write.
 pub(super) const PARSER_CASES: &[ParserCase] = &[
   ParserCase {
@@ -808,6 +808,11 @@ pub(super) const PARSER_CASES: &[ParserCase] = &[
     ast: "word \"purple\" 0..6",
   },
   ParserCase {
+    input: "rgb(0, {index}, 0)",
+    output: "rgb(0, {index}, 0)",
+    ast: "function \"rgb\" 0..18 before=\"\" after=\"\" nodes=5\n  word \"0\" 4..5\n  div \",\" 5..7 before=\"\" after=\" \"\n  word \"{index}\" 7..14\n  div \",\" 14..16 before=\"\" after=\" \"\n  word \"0\" 16..17",
+  },
+  ParserCase {
     input: "rgb(0,0,",
     output: "rgb(0,0,",
     ast: "function \"rgb\" 0..8 before=\"\" after=\"\" unclosed nodes=4\n  word \"0\" 4..5\n  div \",\" 5..6 before=\"\" after=\"\"\n  word \"0\" 6..7\n  div \",\" 7..8 before=\"\" after=\"\"",
@@ -1571,6 +1576,11 @@ pub(super) const PARSER_CASES: &[ParserCase] = &[
     input: "rgb(var(r), 0, 0)",
     output: "rgb(var(r), 0, 0)",
     ast: "function \"rgb\" 0..17 before=\"\" after=\"\" nodes=5\n  function \"var\" 4..10 before=\"\" after=\"\" nodes=1\n    word \"r\" 8..9\n  div \",\" 10..12 before=\"\" after=\" \"\n  word \"0\" 12..13\n  div \",\" 13..15 before=\"\" after=\" \"\n  word \"0\" 15..16",
+  },
+  ParserCase {
+    input: "rgb({index}, 0, 0)",
+    output: "rgb({index}, 0, 0)",
+    ast: "function \"rgb\" 0..18 before=\"\" after=\"\" nodes=5\n  word \"{index}\" 4..11\n  div \",\" 11..13 before=\"\" after=\" \"\n  word \"0\" 13..14\n  div \",\" 14..16 before=\"\" after=\" \"\n  word \"0\" 16..17",
   },
   ParserCase {
     input: "rgba( 1, 222,  33 , 0.5)",
@@ -4924,7 +4934,7 @@ pub(super) const OVERRIDE_CASES: &[OverrideCase] = &[
   },
 ];
 
-/// 682 words paired with their number/unit split, `None` standing for a
+/// 683 words paired with their number/unit split, `None` standing for a
 /// word that does not start with a number. Every word the cases above parse
 /// to, plus splits no parse would ever ask for.
 pub(super) const UNIT_CASES: &[(&str, Option<(&str, &str)>)] = &[
@@ -5114,6 +5124,7 @@ pub(super) const UNIT_CASES: &[(&str, Option<(&str, &str)>)] = &[
   ("#F7F5F6", None),
   ("black", None),
   ("purple", None),
+  ("{index}", None),
   ("r", None),
   ("g", None),
   ("----__hashed_var__1jqb1tb", None),

--- a/crates/postcss-value-parser/src/tests/cases.rs
+++ b/crates/postcss-value-parser/src/tests/cases.rs
@@ -808,9 +808,9 @@ pub(super) const PARSER_CASES: &[ParserCase] = &[
     ast: "word \"purple\" 0..6",
   },
   ParserCase {
-    input: "rgb(0, {index}, 0)",
-    output: "rgb(0, {index}, 0)",
-    ast: "function \"rgb\" 0..18 before=\"\" after=\"\" nodes=5\n  word \"0\" 4..5\n  div \",\" 5..7 before=\"\" after=\" \"\n  word \"{index}\" 7..14\n  div \",\" 14..16 before=\"\" after=\" \"\n  word \"0\" 16..17",
+    input: "rgb(0, {channel}, 0)",
+    output: "rgb(0, {channel}, 0)",
+    ast: "function \"rgb\" 0..20 before=\"\" after=\"\" nodes=5\n  word \"0\" 4..5\n  div \",\" 5..7 before=\"\" after=\" \"\n  word \"{channel}\" 7..16\n  div \",\" 16..18 before=\"\" after=\" \"\n  word \"0\" 18..19",
   },
   ParserCase {
     input: "rgb(0,0,",
@@ -1578,9 +1578,9 @@ pub(super) const PARSER_CASES: &[ParserCase] = &[
     ast: "function \"rgb\" 0..17 before=\"\" after=\"\" nodes=5\n  function \"var\" 4..10 before=\"\" after=\"\" nodes=1\n    word \"r\" 8..9\n  div \",\" 10..12 before=\"\" after=\" \"\n  word \"0\" 12..13\n  div \",\" 13..15 before=\"\" after=\" \"\n  word \"0\" 15..16",
   },
   ParserCase {
-    input: "rgb({index}, 0, 0)",
-    output: "rgb({index}, 0, 0)",
-    ast: "function \"rgb\" 0..18 before=\"\" after=\"\" nodes=5\n  word \"{index}\" 4..11\n  div \",\" 11..13 before=\"\" after=\" \"\n  word \"0\" 13..14\n  div \",\" 14..16 before=\"\" after=\" \"\n  word \"0\" 16..17",
+    input: "rgb({channel}, 0, 0)",
+    output: "rgb({channel}, 0, 0)",
+    ast: "function \"rgb\" 0..20 before=\"\" after=\"\" nodes=5\n  word \"{channel}\" 4..13\n  div \",\" 13..15 before=\"\" after=\" \"\n  word \"0\" 15..16\n  div \",\" 16..18 before=\"\" after=\" \"\n  word \"0\" 18..19",
   },
   ParserCase {
     input: "rgba( 1, 222,  33 , 0.5)",
@@ -5124,7 +5124,7 @@ pub(super) const UNIT_CASES: &[(&str, Option<(&str, &str)>)] = &[
   ("#F7F5F6", None),
   ("black", None),
   ("purple", None),
-  ("{index}", None),
+  ("{channel}", None),
   ("r", None),
   ("g", None),
   ("----__hashed_var__1jqb1tb", None),

--- a/crates/stylex-constants/src/constants/messages.rs
+++ b/crates/stylex-constants/src/constants/messages.rs
@@ -218,8 +218,6 @@ pub static VALUE_NOT_EXPRESSION: &str = "Style value must evaluate to a static e
 
 pub static EVAL_RESULT_EXPECTED: &str = "Expected a value from evaluation result.";
 
-pub static VAR_DECL_NAME_NOT_IDENT: &str = "Variable declarator name must be an identifier.";
-
 pub static VAR_DECL_INIT_REQUIRED: &str = "Variable declaration must have an initializer.";
 
 pub static KEY_VALUE_EXPECTED: &str = "Expected a key-value property in the object.";

--- a/crates/stylex-css/src/css/common.rs
+++ b/crates/stylex-css/src/css/common.rs
@@ -211,6 +211,16 @@ pub fn generate_css_rule(
 
 /// Calculates priority for compound pseudo selectors (e.g. `:hover::after`).
 fn get_compound_pseudo_priority(key: &str) -> Option<f64> {
+  // Both alternations in `PSEUDO_PART_REGEX` open with a colon, so a key
+  // without one cannot hold a pseudo part and the scan below can only come
+  // back empty. Asked first because the overwhelming majority of keys reaching
+  // here are plain property names -- `color`, `paddingBottom` -- and running a
+  // backtracking regex over each of them to learn nothing made this the
+  // single hottest leaf in a sampled profile of a large module.
+  if !key.contains(':') {
+    return None;
+  }
+
   let parts: Vec<&str> = PSEUDO_PART_REGEX
     .find_iter(key)
     .flatten()

--- a/crates/stylex-css/src/css/tests/common_test.rs
+++ b/crates/stylex-css/src/css/tests/common_test.rs
@@ -195,6 +195,7 @@ mod build_nested_css_rule_tests {
 #[cfg(test)]
 mod get_priority_tests {
   use crate::css::common::get_priority;
+  use stylex_regex::regex::PSEUDO_PART_REGEX;
 
   #[test]
   fn shorthand_of_shorthands_gets_1000() {
@@ -249,6 +250,39 @@ mod get_priority_tests {
   fn pseudo_class_focus() {
     let p = get_priority(":focus");
     assert!(p > 0.0);
+  }
+
+  /// The `contains(':')` guard in `get_compound_pseudo_priority` skips the scan
+  /// for a key that holds no colon, which is only sound while every alternation
+  /// of `PSEUDO_PART_REGEX` opens with one. An alternation added later that does
+  /// not -- an attribute selector, say -- would make the guard answer `None` for
+  /// keys it matches, and the generated CSS would reorder with nothing else
+  /// failing.
+  #[test]
+  fn every_pseudo_part_the_regex_matches_carries_a_colon() {
+    for key in [
+      ":hover:active",
+      "::before",
+      ":not(:hover)",
+      "::-webkit-scrollbar",
+      ":nth-child(2)::after",
+    ] {
+      for part in PSEUDO_PART_REGEX.find_iter(key).flatten() {
+        assert!(
+          part.as_str().starts_with(':'),
+          "{part:?} has no colon to guard on"
+        );
+      }
+    }
+  }
+
+  /// The other half of the premise: a key the guard refuses holds nothing the
+  /// scan would have found.
+  #[test]
+  fn a_key_without_a_colon_matches_no_pseudo_part() {
+    for key in ["color", "paddingBottom", "--custom-prop", "margin-top"] {
+      assert_eq!(PSEUDO_PART_REGEX.find_iter(key).flatten().count(), 0);
+    }
   }
 }
 

--- a/crates/stylex-regex/src/regex.rs
+++ b/crates/stylex-regex/src/regex.rs
@@ -21,11 +21,6 @@ pub static LENGTH_UNIT_TESTER_REGEX: Lazy<Regex> = Lazy::new(|| {
 pub static IS_CSS_VAR: Lazy<Regex> =
   Lazy::new(|| Regex::new(r#"^var\(--[a-zA-Z0-9-_]+\)$"#).expect("Is CSS var regex is valid"));
 
-// Improved: Using positive lookbehind to avoid capturing the prefix
-// This simplifies replacement from "$1-$2" to "-$1"
-pub static DASHIFY_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"(?<=^|[a-z])([A-Z])").expect("Dashify regex is valid"));
-
 pub static URL_REGEX: Lazy<Regex> = Lazy::new(|| {
   Regex::new(
         r"https?://(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)"

--- a/crates/stylex-regex/src/tests/regex_static_coverage_test.rs
+++ b/crates/stylex-regex/src/tests/regex_static_coverage_test.rs
@@ -3,10 +3,9 @@
 //! initialization.
 
 use crate::regex::{
-  ANCESTOR_SELECTOR, ANY_SIBLING_SELECTOR, CSS_VALUE_SPLIT_REGEX, DASHIFY_REGEX,
-  DESCENDANT_SELECTOR, IS_CSS_VAR, JSON_REGEX, LENGTH_UNIT_TESTER_REGEX, PSEUDO_PART_REGEX,
-  SIBLING_AFTER_SELECTOR, SIBLING_BEFORE_SELECTOR, STYLEX_CONSTS_IMPORT_REGEX, URL_REGEX,
-  VAR_EXTRACTION_REGEX,
+  ANCESTOR_SELECTOR, ANY_SIBLING_SELECTOR, CSS_VALUE_SPLIT_REGEX, DESCENDANT_SELECTOR, IS_CSS_VAR,
+  JSON_REGEX, LENGTH_UNIT_TESTER_REGEX, PSEUDO_PART_REGEX, SIBLING_AFTER_SELECTOR,
+  SIBLING_BEFORE_SELECTOR, STYLEX_CONSTS_IMPORT_REGEX, URL_REGEX, VAR_EXTRACTION_REGEX,
 };
 
 /// Value-splitting parsers should detect adjacency patterns.
@@ -34,7 +33,6 @@ fn core_cleanup_patterns_match() {
   assert!(!IS_CSS_VAR.is_match("var(--a:b)").unwrap());
   assert!(!IS_CSS_VAR.is_match("var(--a.b)").unwrap());
   assert!(!IS_CSS_VAR.is_match("var(--a[b)").unwrap());
-  assert!(DASHIFY_REGEX.is_match("fooBar").unwrap());
 }
 
 /// URL and JSON helper patterns should match their canonical content.

--- a/crates/stylex-rs-compiler/Cargo.toml
+++ b/crates/stylex-rs-compiler/Cargo.toml
@@ -27,6 +27,7 @@ swc_core = { workspace = true, features = [
   "ecma_utils",
 ] }
 swc_ecma_parser = { workspace = true, features = ["verify"] }
+swc_malloc.workspace = true
 swc_sourcemap.workspace = true
 
 indexmap.workspace = true

--- a/crates/stylex-rs-compiler/parity/corpus/harvested.json
+++ b/crates/stylex-rs-compiler/parity/corpus/harvested.json
@@ -219,6 +219,12 @@
       "origin": "crates/stylex-transform/tests/transform_stylex_create_test/absent_style_values.rs:466"
     },
     {
+      "id": "9cf14a20",
+      "property": "backgroundColor",
+      "value": "rgb(0, {index}, 0)",
+      "origin": "crates/stylex-transform/benches/transform_consumers_bench.rs:110"
+    },
+    {
       "id": "077eb7f1",
       "property": "backgroundColor",
       "value": "rgb(0,0,",
@@ -1531,6 +1537,12 @@
       "property": "color",
       "value": "rgb(var(r), 0, 0)",
       "origin": "crates/stylex-css/src/css/tests/unprefixed_custom_properties_test.rs:140"
+    },
+    {
+      "id": "2c26fd14",
+      "property": "color",
+      "value": "rgb({index}, 0, 0)",
+      "origin": "crates/stylex-transform/benches/transform_consumers_bench.rs:110"
     },
     {
       "id": "d31768cb",

--- a/crates/stylex-rs-compiler/parity/corpus/harvested.json
+++ b/crates/stylex-rs-compiler/parity/corpus/harvested.json
@@ -6,7 +6,7 @@
       "id": "1f8e27a3",
       "property": "--3abc",
       "value": "red",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:845"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:879"
     },
     {
       "id": "d3462dee",
@@ -18,7 +18,7 @@
       "id": "efa34d61",
       "property": "--customColor",
       "value": "#abcdef",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:464"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:498"
     },
     {
       "id": "59705c7e",
@@ -42,7 +42,7 @@
       "id": "13cd70db",
       "property": "--my-var",
       "value": "var(--token",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:742"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:776"
     },
     {
       "id": "3751a37e",
@@ -60,7 +60,7 @@
       "id": "5de7f712",
       "property": "--myVar",
       "value": "blue",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:457"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:491"
     },
     {
       "id": "c4881c49",
@@ -78,31 +78,31 @@
       "id": "e12893db",
       "property": "--xBg",
       "value": "#ff0000",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1277"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1311"
     },
     {
       "id": "754df154",
       "property": "--xBorder",
       "value": "solid",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1283"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1317"
     },
     {
       "id": "bfcaf933",
       "property": "--xCustom",
       "value": "10px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1271"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1305"
     },
     {
       "id": "209dd2f8",
       "property": "--xSomething",
       "value": "10px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1399"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1433"
     },
     {
       "id": "3e918449",
       "property": "--xVar",
       "value": "1px solid #000",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1405"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1439"
     },
     {
       "id": "66883a2d",
@@ -168,7 +168,7 @@
       "id": "81bd6d97",
       "property": "background",
       "value": "radial-gradient(circle, red, blue)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:687"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:721"
     },
     {
       "id": "c6cd1c8e",
@@ -219,10 +219,10 @@
       "origin": "crates/stylex-transform/tests/transform_stylex_create_test/absent_style_values.rs:466"
     },
     {
-      "id": "9cf14a20",
+      "id": "a9ff75ed",
       "property": "backgroundColor",
-      "value": "rgb(0, {index}, 0)",
-      "origin": "crates/stylex-transform/benches/transform_consumers_bench.rs:110"
+      "value": "rgb(0, {channel}, 0)",
+      "origin": "crates/stylex-transform/benches/transform_consumers_bench.rs:173"
     },
     {
       "id": "077eb7f1",
@@ -234,13 +234,13 @@
       "id": "835e815e",
       "property": "backgroundColor",
       "value": "rgb(from red r g b)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:594"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:628"
     },
     {
       "id": "800fc8ab",
       "property": "backgroundColor",
       "value": "rgba(from red r g b / 0.5)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:605"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:639"
     },
     {
       "id": "c90be70c",
@@ -312,7 +312,7 @@
       "id": "adda9c84",
       "property": "backgroundImage",
       "value": "linear-gradient(to right, rgb(from red r g b), blue)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:634"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:668"
     },
     {
       "id": "fe3892cd",
@@ -372,7 +372,7 @@
       "id": "5bd72342",
       "property": "backgroundImage",
       "value": "url(\"foo)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1326"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1360"
     },
     {
       "id": "0a403503",
@@ -582,7 +582,7 @@
       "id": "5137b4a8",
       "property": "border",
       "value": "1px solid red",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:489"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:523"
     },
     {
       "id": "009500e7",
@@ -1050,7 +1050,7 @@
       "id": "7ab6cb19",
       "property": "color",
       "value": "#ff0000",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:275"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:309"
     },
     {
       "id": "0b0c0199",
@@ -1092,7 +1092,7 @@
       "id": "16765d78",
       "property": "color",
       "value": "--Foo(1px)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1256"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1290"
     },
     {
       "id": "dd36ae0f",
@@ -1140,7 +1140,7 @@
       "id": "8864aad8",
       "property": "color",
       "value": "@",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:756"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:790"
     },
     {
       "id": "49f9fe96",
@@ -1254,7 +1254,7 @@
       "id": "ead947ae",
       "property": "color",
       "value": "color(from green srgb r g b)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:626"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:660"
     },
     {
       "id": "7ca6e277",
@@ -1278,43 +1278,43 @@
       "id": "7de88a19",
       "property": "color",
       "value": "hsl(0 0% 0%",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1332"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1366"
     },
     {
       "id": "b315d993",
       "property": "color",
       "value": "hsl(120, 100%, 50%)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:434"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:468"
     },
     {
       "id": "591ba0b3",
       "property": "color",
       "value": "hsla(120, 100%, 50%, 0.5)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:441"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:475"
     },
     {
       "id": "42f45060",
       "property": "color",
       "value": "hwb(194 0% 0%)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:712"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:746"
     },
     {
       "id": "d3d9e063",
       "property": "color",
       "value": "inherit",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:521"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:555"
     },
     {
       "id": "be48a0a3",
       "property": "color",
       "value": "lab(50% 40 59.5)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:696"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:730"
     },
     {
       "id": "30a60cae",
       "property": "color",
       "value": "lch(52.2% 72.2 50)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:703"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:737"
     },
     {
       "id": "f05f85c1",
@@ -1362,13 +1362,13 @@
       "id": "e7adc924",
       "property": "color",
       "value": "oklch(0.7   0.15   180)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:448"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:482"
     },
     {
       "id": "3858af24",
       "property": "color",
       "value": "oklch(0.7 0.15 180)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:427"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:461"
     },
     {
       "id": "2f99e89f",
@@ -1404,7 +1404,7 @@
       "id": "0c59ee8f",
       "property": "color",
       "value": "red",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:266"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:300"
     },
     {
       "id": "2106f042",
@@ -1422,7 +1422,7 @@
       "id": "688f2f99",
       "property": "color",
       "value": "red /* \" */",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1392"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1426"
     },
     {
       "id": "e8424e60",
@@ -1494,7 +1494,7 @@
       "id": "c005943e",
       "property": "color",
       "value": "rgb(   from red r g b   )",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:619"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:653"
     },
     {
       "id": "0d4994d9",
@@ -1512,25 +1512,25 @@
       "id": "32457dbb",
       "property": "color",
       "value": "rgb(255, 0, 0",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1298"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1332"
     },
     {
       "id": "b564acd6",
       "property": "color",
       "value": "rgb(255, 0, 0)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:574"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:608"
     },
     {
       "id": "3a76abbe",
       "property": "color",
       "value": "rgb(from   red   r g b)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:612"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:646"
     },
     {
       "id": "389020c6",
       "property": "color",
       "value": "rgb(from red r g b)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:833"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:867"
     },
     {
       "id": "7c9753ca",
@@ -1539,10 +1539,10 @@
       "origin": "crates/stylex-css/src/css/tests/unprefixed_custom_properties_test.rs:140"
     },
     {
-      "id": "2c26fd14",
+      "id": "5abc4a3f",
       "property": "color",
-      "value": "rgb({index}, 0, 0)",
-      "origin": "crates/stylex-transform/benches/transform_consumers_bench.rs:110"
+      "value": "rgb({channel}, 0, 0)",
+      "origin": "crates/stylex-transform/benches/transform_consumers_bench.rs:173"
     },
     {
       "id": "d31768cb",
@@ -1554,7 +1554,7 @@
       "id": "79628322",
       "property": "color",
       "value": "rgba(0, 0, 0, 0.5)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:582"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:616"
     },
     {
       "id": "c567fadc",
@@ -1566,7 +1566,7 @@
       "id": "4d5cae5a",
       "property": "color",
       "value": "transparent",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:282"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:316"
     },
     {
       "id": "d984a81c",
@@ -1698,7 +1698,7 @@
       "id": "b297e9c2",
       "property": "color",
       "value": "var(--token",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:729"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:763"
     },
     {
       "id": "c519cc8b",
@@ -1716,13 +1716,13 @@
       "id": "ee50973d",
       "property": "color",
       "value": "var(--xColor)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:551"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:585"
     },
     {
       "id": "19fa54f0",
       "property": "color",
       "value": "var(--xColor, red)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:558"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:592"
     },
     {
       "id": "e2dc14d5",
@@ -1842,7 +1842,7 @@
       "id": "f2efc7d0",
       "property": "content",
       "value": "\"rgb(from   red   r g b)\"",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:644"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:678"
     },
     {
       "id": "635710ca",
@@ -2004,25 +2004,25 @@
       "id": "00146ee8",
       "property": "display",
       "value": "flex",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:670"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:704"
     },
     {
       "id": "4c8c7c03",
       "property": "display",
       "value": "grid",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:677"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:711"
     },
     {
       "id": "9280d50d",
       "property": "display",
       "value": "initial",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:528"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:562"
     },
     {
       "id": "f1cf4cb1",
       "property": "display",
       "value": "none",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:535"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:569"
     },
     {
       "id": "45c94d3a",
@@ -2100,25 +2100,25 @@
       "id": "08db551c",
       "property": "fontFamily",
       "value": "\"Helvetica Neue",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1304"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1338"
     },
     {
       "id": "54e80d55",
       "property": "fontFamily",
       "value": "\"Helvetica Neue\", sans-serif",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1348"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1382"
     },
     {
       "id": "93834ccf",
       "property": "fontFamily",
       "value": "\"Helvetica Neue, sans-serif",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1317"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1351"
     },
     {
       "id": "b4bfbcc3",
       "property": "fontFamily",
       "value": "\"Helvetica \\\"Neue\", sans-serif",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1383"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1417"
     },
     {
       "id": "9a0ad6ed",
@@ -2262,19 +2262,19 @@
       "id": "b3f8b39f",
       "property": "fontFamily",
       "value": "'Helvetica Neue",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1310"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1344"
     },
     {
       "id": "19067393",
       "property": "fontFamily",
       "value": "'Helvetica Neue', sans-serif",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1360"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1394"
     },
     {
       "id": "efa3053e",
       "property": "fontFamily",
       "value": "'SF Pro Text', 'SF Pro Icons', Helvetica Neue', 'Helvetica', sans-serif",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1339"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1373"
     },
     {
       "id": "a59803fc",
@@ -2298,7 +2298,7 @@
       "id": "c6a18f41",
       "property": "fontFamily",
       "value": "-apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1370"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1404"
     },
     {
       "id": "5f49b4d0",
@@ -2460,7 +2460,7 @@
       "id": "d2ba4c08",
       "property": "fontSize",
       "value": "16px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:498"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:532"
     },
     {
       "id": "2d5bd35c",
@@ -2490,7 +2490,7 @@
       "id": "8feac7de",
       "property": "fontSize",
       "value": "32px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:505"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:539"
     },
     {
       "id": "f1b94ab1",
@@ -2508,7 +2508,7 @@
       "id": "036ce132",
       "property": "fontSize",
       "value": "clamp(1rem, 2vw, 3rem)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:721"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:755"
     },
     {
       "id": "269313b2",
@@ -2676,13 +2676,13 @@
       "id": "bcababff",
       "property": "height",
       "value": "/* c */ calc-size(auto, size * 0)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:807"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:841"
     },
     {
       "id": "aae7315a",
       "property": "height",
       "value": "/* unclosed",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:788"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:822"
     },
     {
       "id": "489328e2",
@@ -2706,7 +2706,7 @@
       "id": "fb1e7ba9",
       "property": "height",
       "value": "1px /* unclosed",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:788"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:822"
     },
     {
       "id": "8946f257",
@@ -2718,43 +2718,43 @@
       "id": "1892dd52",
       "property": "height",
       "value": "@",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:408"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:442"
     },
     {
       "id": "4b5a3aca",
       "property": "height",
       "value": "@ /* unclosed",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:788"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:822"
     },
     {
       "id": "45b0648d",
       "property": "height",
       "value": "CALC-SIZE(auto, round(up, size, 50px))",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:373"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:407"
     },
     {
       "id": "309a0774",
       "property": "height",
       "value": "[foo]",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:407"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:441"
     },
     {
       "id": "f0c8ed9c",
       "property": "height",
       "value": "calc-size( auto , size   *   0 )",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:352"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:386"
     },
     {
       "id": "629b27b4",
       "property": "height",
       "value": "calc-size(300px + 2rem, size / 2)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:361"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:395"
     },
     {
       "id": "1c7e9f79",
       "property": "height",
       "value": "calc-size(any, 300px * 1.5)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:359"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:393"
     },
     {
       "id": "9afe9df4",
@@ -2766,31 +2766,31 @@
       "id": "9fdd199b",
       "property": "height",
       "value": "calc-size(auto, size * 0) /* c */",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:803"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:837"
     },
     {
       "id": "f03ff7ad",
       "property": "height",
       "value": "calc-size(calc-size(max-content, size), size + 2rem)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:365"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:399"
     },
     {
       "id": "d83fb29d",
       "property": "height",
       "value": "calc-size(fit-content, size / 2)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:356"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:390"
     },
     {
       "id": "1e9d5b71",
       "property": "height",
       "value": "calc-size(var(--intrinsic-size), max(100px, size + 20px))",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:369"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:403"
     },
     {
       "id": "0672ffab",
       "property": "height",
       "value": "expected `{value}` to be rejected",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:793"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:827"
     },
     {
       "id": "cffdcdad",
@@ -2802,43 +2802,43 @@
       "id": "d69e140d",
       "property": "height",
       "value": "foo * bar",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:406"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:440"
     },
     {
       "id": "6b7b7cec",
       "property": "height",
       "value": "future-fn(\"a,   b\" * 2)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:391"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:425"
     },
     {
       "id": "adb3560e",
       "property": "height",
       "value": "future-fn(\"a\\\",   b\" * 2)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:401"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:435"
     },
     {
       "id": "6e16e210",
       "property": "height",
       "value": "future-fn(\"a\\\\\" * 2)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:405"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:439"
     },
     {
       "id": "3f14e317",
       "property": "height",
       "value": "future-fn(foo * 2)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:390"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:424"
     },
     {
       "id": "39f4abde",
       "property": "height",
       "value": "future-fn(foo /* a,   b */ * 2)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:393"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:427"
     },
     {
       "id": "b4973e5e",
       "property": "height",
       "value": "future-fn(foo/2 * @)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:396"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:430"
     },
     {
       "id": "8106f87e",
@@ -2952,7 +2952,7 @@
       "id": "b4212ffd",
       "property": "letterSpacing",
       "value": "-0.24px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:321"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:355"
     },
     {
       "id": "9ce253c8",
@@ -3060,7 +3060,7 @@
       "id": "ff3a5343",
       "property": "margin",
       "value": "0",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:312"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:346"
     },
     {
       "id": "9af84823",
@@ -3096,7 +3096,7 @@
       "id": "095d26cd",
       "property": "margin",
       "value": "10px   20px   30px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:661"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:695"
     },
     {
       "id": "09b36512",
@@ -3108,7 +3108,7 @@
       "id": "67f5f4cb",
       "property": "margin",
       "value": "10px 20px 30px 40px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:473"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:507"
     },
     {
       "id": "9849820b",
@@ -3132,7 +3132,7 @@
       "id": "670673ab",
       "property": "margin",
       "value": "2em",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:305"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:339"
     },
     {
       "id": "7826e219",
@@ -3150,7 +3150,7 @@
       "id": "8ee69eaa",
       "property": "margin",
       "value": "auto",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:542"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:576"
     },
     {
       "id": "f6e41149",
@@ -3228,7 +3228,7 @@
       "id": "d060198e",
       "property": "marginTop",
       "value": "-0.5px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:326"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:360"
     },
     {
       "id": "4a54ba9c",
@@ -3336,7 +3336,7 @@
       "id": "15379746",
       "property": "padding",
       "value": "5px 10px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:480"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:514"
     },
     {
       "id": "c28946e3",
@@ -3630,7 +3630,7 @@
       "id": "be4f0e8a",
       "property": "transform",
       "value": "rotate(45deg)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1248"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1282"
     },
     {
       "id": "8bc6eac6",
@@ -3660,31 +3660,31 @@
       "id": "61da571e",
       "property": "transform",
       "value": "rotateX(45deg)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1223"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1257"
     },
     {
       "id": "49409c2c",
       "property": "transform",
       "value": "scaleX(2)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1211"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1245"
     },
     {
       "id": "0a40fd70",
       "property": "transform",
       "value": "scaleY(0.5)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1217"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1251"
     },
     {
       "id": "6b2f1cb5",
       "property": "transform",
       "value": "skewX(10deg)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1229"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1263"
     },
     {
       "id": "68f15342",
       "property": "transform",
       "value": "skewY(5deg)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1235"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1269"
     },
     {
       "id": "c773c982",
@@ -3726,13 +3726,13 @@
       "id": "44df9ddb",
       "property": "transform",
       "value": "translateX(10px)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:567"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:601"
     },
     {
       "id": "0209bb89",
       "property": "transform",
       "value": "translateY(20px)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1205"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:1239"
     },
     {
       "id": "deb4e2fb",
@@ -4170,7 +4170,7 @@
       "id": "b419471c",
       "property": "width",
       "value": "100px",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:291"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:325"
     },
     {
       "id": "eaa22664",
@@ -4242,7 +4242,7 @@
       "id": "3504a257",
       "property": "width",
       "value": "50%",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:298"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:332"
     },
     {
       "id": "8bcaede1",
@@ -4332,7 +4332,7 @@
       "id": "44278134",
       "property": "width",
       "value": "calc(100% - 20px)",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:336"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:370"
     },
     {
       "id": "abea19ca",
@@ -4344,7 +4344,7 @@
       "id": "8087a358",
       "property": "width",
       "value": "calc(100% - calc(20px + 10px))",
-      "origin": "crates/stylex-css/src/css/tests/common_test.rs:343"
+      "origin": "crates/stylex-css/src/css/tests/common_test.rs:377"
     },
     {
       "id": "74d91699",

--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -9,10 +9,10 @@
 // cloned AST nodes. Swapping the allocator is the whole of the change and it
 // measures 1.09-1.15x end-to-end on this repo's two largest fixtures.
 //
-// `swc_malloc` rather than `mimalloc` directly: it resolves to mimalloc on
-// every target `.github/workflows/npm.yml` publishes except
-// `x86_64-unknown-linux-musl`, where the system allocator is kept on purpose
-// because mimalloc segfaults on ARM64 musl. The workspace manifest records why.
+// `swc_malloc` rather than `mimalloc` directly: it keeps the system allocator on
+// every musl target, and `.github/workflows/npm.yml` publishes one of them
+// (`x86_64-unknown-linux-musl`). The other six published targets get mimalloc.
+// The workspace manifest records why, and which target takes jemalloc instead.
 use swc_malloc as _;
 
 mod enums;

--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -11,8 +11,8 @@
 //
 // `swc_malloc` rather than `mimalloc` directly: it resolves to mimalloc on
 // every target `.github/workflows/npm.yml` publishes except
-// `x86_64-unknown-linux-musl`, where the system allocator is kept on purpose.
-// The workspace manifest records why.
+// `x86_64-unknown-linux-musl`, where the system allocator is kept on purpose
+// because mimalloc segfaults on ARM64 musl. The workspace manifest records why.
 use swc_malloc as _;
 
 mod enums;

--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -13,6 +13,10 @@
 // every musl target, and `.github/workflows/npm.yml` publishes one of them
 // (`x86_64-unknown-linux-musl`). The other six published targets get mimalloc.
 // The workspace manifest records why, and which target takes jemalloc instead.
+//
+// Reached through the `rlib` half of this crate's `crate-type` as well as the
+// `cdylib`, so anything that later depends on `stylex_compiler_rs` inherits
+// mimalloc rather than choosing it. Nothing does today.
 use swc_malloc as _;
 
 mod enums;

--- a/crates/stylex-rs-compiler/src/lib.rs
+++ b/crates/stylex-rs-compiler/src/lib.rs
@@ -1,5 +1,20 @@
 #![allow(deprecated)]
 
+// Sets this addon's global allocator. Linked for its `#[global_allocator]` and
+// nothing else, hence the `as _`.
+//
+// The transform is allocation-bound rather than compute-bound: a sampled
+// profile of a large module puts roughly 45% of samples in `malloc`/`free`,
+// because every folded style flows through short-lived `String`s, `Vec`s and
+// cloned AST nodes. Swapping the allocator is the whole of the change and it
+// measures 1.09-1.15x end-to-end on this repo's two largest fixtures.
+//
+// `swc_malloc` rather than `mimalloc` directly: it resolves to mimalloc on
+// every target `.github/workflows/npm.yml` publishes except
+// `x86_64-unknown-linux-musl`, where the system allocator is kept on purpose.
+// The workspace manifest records why.
+use swc_malloc as _;
+
 mod enums;
 mod structs;
 mod utils;

--- a/crates/stylex-transform/CONTEXT.md
+++ b/crates/stylex-transform/CONTEXT.md
@@ -774,6 +774,22 @@ zero sorts before every authored node, so comparing one answers a fact about its
 having been built.
 _Avoid_: generated node, dummy node, fake node
 
+**Candidate index**:
+Where the entries holding a given thing live, bucketed by a key that narrows to
+them, held beside the collection it indexes on the
+[state manager](#state-manager). The answer to "which recorded entry holds
+_this_?" -- which declarator a call initialises, which style variable it is
+bound to, which top-level expression it is, which import specifier binds a
+reference, whether a declarator at this position is already stored. Each of
+those was a walk of the whole collection comparing whole subtrees with
+`eq_ignore_span`, once per call the transform meets, which made the consumer
+phase quadratic in the number of calls a module makes. The key only narrows:
+equality still decides between the candidates it hands back, so the answer is
+the one the walk gave. What the key is depends on the question -- a structural
+hash for an expression, a source position for where something was written, a
+name for what a declarator binds.
+_Avoid_: lookup table, call map, bucket map
+
 **Key span index**:
 Where every style namespace key of the module's _own parsed source_ is written,
 collected in one walk and held beside that memoized source on the

--- a/crates/stylex-transform/CONTEXT.md
+++ b/crates/stylex-transform/CONTEXT.md
@@ -779,11 +779,12 @@ Where the entries holding a given thing live, bucketed by a key that narrows to
 them, held beside the collection it indexes on the
 [state manager](#state-manager). The answer to "which recorded entry holds
 _this_?" -- which declarator a call initialises, which style variable it is
-bound to, which top-level expression it is, which import specifier binds a
-reference, whether a declarator at this position is already stored. Each of
-those was a walk of the whole collection comparing whole subtrees with
-`eq_ignore_span`, once per call the transform meets, which made the consumer
-phase quadratic in the number of calls a module makes. The key only narrows:
+bound to, which top-level expression it is, which top-level expression a name
+binds, which import specifier binds a reference, whether a declarator at this
+position is already stored. Each of those was a walk of the whole collection
+comparing whole subtrees with `eq_ignore_span`, once per call the transform
+meets, which made the consumer phase quadratic in the number of calls a module
+makes. The key only narrows:
 equality still decides between the candidates it hands back, so the answer is
 the one the walk gave. What the key is depends on the question -- a structural
 hash for an expression, a source position for where something was written, a

--- a/crates/stylex-transform/Cargo.toml
+++ b/crates/stylex-transform/Cargo.toml
@@ -63,6 +63,10 @@ swc_core = { workspace = true, features = [
   "ecma_utils",
   "testing_transform",
 ] }
+# The benches stand in for the shipped `.node`, which runs mimalloc on every
+# published target but musl. Without this they measure the system allocator, and
+# an allocation-reducing change reads larger there than it does in production.
+swc_malloc.workspace = true
 testing.workspace = true
 
 [[bench]]

--- a/crates/stylex-transform/Cargo.toml
+++ b/crates/stylex-transform/Cargo.toml
@@ -87,6 +87,10 @@ name = "module_path_bench"
 
 [[bench]]
 harness = false
+name = "transform_consumers_bench"
+
+[[bench]]
+harness = false
 name = "transform_debug_bench"
 
 [lints]

--- a/crates/stylex-transform/benches/transform_consumers_bench.rs
+++ b/crates/stylex-transform/benches/transform_consumers_bench.rs
@@ -1,0 +1,267 @@
+//! What the consumer phase costs against the number of `stylex.*` calls a
+//! module makes, and -- the point of a series rather than one size -- whether
+//! that cost is linear in it.
+//!
+//! Every call the transform rewrites asks the state manager which recorded entry
+//! holds it: which declarator it initialises, which style variable it is bound
+//! to, which top-level expression it is. Answered by walking the collection and
+//! comparing whole `CallExpr` subtrees with `eq_ignore_span`, each of those runs
+//! once per call against every entry -- `O(calls x entries)`, which on a module
+//! of one component per `stylex.create` is genuinely quadratic in the file. They
+//! are now answered from keys, and a return to the old shape shows up here as a
+//! rising cost per component where a flat curve keeps it level.
+//!
+//! **Read the per-component cost, not the total.** Doubling the components
+//! doubles the work a linear transform does, so a total that doubles is the
+//! result being asserted; it is the total growing by *more* than the doubling
+//! that says a quadratic is back. What these three legs measured when this was
+//! written, as the leg's median divided by its components:
+//!
+//! ```text
+//!   components   walked    keyed
+//!           25   76.8 µs   65.9 µs
+//!          100   71.7 µs   65.7 µs
+//!          400   90.3 µs   67.7 µs
+//! ```
+//!
+//! The left column is the curve this file exists to catch: level to 100 and then
+//! climbing, because the quadratic term only overtakes the linear one once the
+//! collections are long enough. The right one stays flat. What is left in it is
+//! the fixed cost every transform pays, which is why it is not perfectly so.
+//!
+//! The legs stop at 400 because that is the smallest series that separates the
+//! two columns, and a larger one would cost every run more time to say what this
+//! one says. The effect keeps growing past it: measured outside this repository
+//! against generated modules of 375 to 3000 components, per-component cost went
+//! 83.5, 105.2, 146.9 and 220.3 µs walked against 70.7, 72.3, 79.8 and 81.9 µs
+//! keyed -- 2.7x on the whole transform at the top. Those files are not built
+//! here, so that pair is a development observation rather than a number a later
+//! reader can re-run; what *is* re-runnable is the three legs above.
+//!
+//! The module is generated rather than cut from a real file because the shape
+//! being measured is *many* calls: the repository's large fixture is one long
+//! array of `stylex.create` calls that declares almost nothing and reads almost
+//! nothing, so it exercises the producer half and asks these questions barely at
+//! all. Every component here declares its own styles and reads them from nine
+//! `stylex.props` sites, which is the ratio a component file has.
+//!
+//! What is timed is one `Program::apply` of the StyleX pass. Parsing is setup
+//! and the clone the pass consumes is batched out, so the number is the
+//! transform rather than a whole compile.
+//!
+//! **Every benchmark here runs inside `GLOBALS.set`**, for the reason
+//! `transform_debug_bench` states at length and `guidelines/PERFORMANCE.md`
+//! repeats: `into_pass` calls `Mark::new()`, which panics outside a `GLOBALS`
+//! scope, and the transform's panic boundary swallows it -- so a bench without
+//! one times a panic and its unwind and reports the swallowed path's regressions
+//! as improvements.
+
+use std::{
+  hint::black_box,
+  path::{Path, PathBuf},
+  rc::Rc,
+  sync::Arc,
+};
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use stylex_structures::stylex_options::ModuleResolution;
+use stylex_transform::StyleXTransform;
+use swc_core::{
+  common::{
+    FileName, GLOBALS, Globals, SourceMap, comments::SingleThreadedComments, input::StringInput,
+    sync::Lrc,
+  },
+  ecma::{
+    ast::{EsVersion, JSXAttr, JSXAttrName, JSXAttrValue, Program},
+    parser::{Parser, Syntax, TsSyntax, lexer::Lexer},
+    visit::{Visit, VisitWith},
+  },
+};
+
+/// The component counts measured.
+///
+/// Four times the size across the series, which is what separates a rising
+/// per-component cost from a level one. The header says why it stops at 400.
+const COMPONENT_COUNTS: [usize; 3] = [25, 100, 400];
+
+/// How many `stylex.props` sites each component reads its styles from.
+///
+/// The ratio that decides what this file measures: the lookups being timed are
+/// per *call*, and a component that declares one `create` and reads it once
+/// would spend most of its time in the producer half instead. Nine is what a
+/// moderately styled component element tree spells.
+const PROPS_PER_COMPONENT: usize = 9;
+
+/// The attribute a resolved `stylex.props` spread becomes, counted to prove the
+/// transform did the work rather than refusing it.
+const RESOLVED_ATTR: &str = "className";
+
+/// A module of `components` components, each declaring its own styles and
+/// reading them from [`PROPS_PER_COMPONENT`] sites.
+///
+/// Every component's styles are distinct, because identical `create` calls
+/// collapse onto one entry in the state manager's call map and would make the
+/// collections this benchmark is about far smaller than the file suggests.
+fn generated_source(components: usize) -> String {
+  let mut source = String::from("import * as stylex from '@stylexjs/stylex';\n\n");
+
+  for index in 0..components {
+    source.push_str(&format!(
+      "const styles{index} = stylex.create({{\n\
+       \x20 base: {{ color: 'rgb({index}, 0, 0)', paddingTop: {index} }},\n\
+       \x20 alt: {{ backgroundColor: 'rgb(0, {index}, 0)', marginBottom: {index} }},\n\
+       }});\n"
+    ));
+
+    source.push_str(&format!(
+      "export function Component{index}() {{\n  return (\n    <div>\n"
+    ));
+
+    for _ in 0..PROPS_PER_COMPONENT {
+      source.push_str(&format!(
+        "      <span {{...stylex.props(styles{index}.base, styles{index}.alt)}} />\n"
+      ));
+    }
+
+    source.push_str("    </div>\n  );\n}\n");
+  }
+
+  source
+}
+
+/// One size of the generated module: its path, and the parsed program.
+struct Module {
+  components: usize,
+  path: PathBuf,
+  program: Program,
+}
+
+fn build_module(components: usize) -> Module {
+  let source = generated_source(components);
+
+  // Named after the size, because the code frame's source map is process-global
+  // and keyed by file name: two sizes sharing one name would share one
+  // registered source. Nothing here writes the file -- production transforms
+  // resolve no positions, and the memoized module is what the path names.
+  let path = PathBuf::from(format!("/generated/components{components}.tsx"));
+  let program = parse(&FileName::Real(path.clone()), &source);
+
+  Module {
+    components,
+    path,
+    program,
+  }
+}
+
+fn parse(file_name: &FileName, source: &str) -> Program {
+  let cm: Lrc<SourceMap> = Default::default();
+  let fm = cm.new_source_file(Arc::new(file_name.clone()), source.to_owned());
+  let lexer = Lexer::new(
+    Syntax::Typescript(TsSyntax {
+      tsx: true,
+      ..Default::default()
+    }),
+    EsVersion::EsNext,
+    StringInput::from(&*fm),
+    None,
+  );
+  let mut parser = Parser::new_from(lexer);
+
+  match parser.parse_program() {
+    Ok(program) => program,
+    Err(error) => panic!("Failed to parse {}: {:#?}", file_name, error),
+  }
+}
+
+/// The transform under measurement, configured as a production build configures
+/// it. `dev` is off: it turns on the position lookup, which is several times the
+/// whole production transform and is what `transform_debug_bench` measures.
+fn transform(path: &Path, program: Program) -> Program {
+  let comments = Rc::new(SingleThreadedComments::default());
+
+  let pass = StyleXTransform::test(comments)
+    .with_filename(FileName::Real(path.to_path_buf()))
+    .with_dev(false)
+    .with_treeshake_compensation(true)
+    .with_unstable_module_resolution(ModuleResolution::haste(None))
+    .with_enable_minified_keys(false)
+    .with_runtime_injection()
+    .into_pass();
+
+  program.apply(pass)
+}
+
+/// Counts the `className` attributes a resolved `stylex.props` spread leaves
+/// behind.
+///
+/// Keyed on a string-valued attribute, because a spread the transform could not
+/// resolve stays a spread of a runtime call and leaves none: this counts
+/// resolutions, not elements.
+#[derive(Default)]
+struct ResolvedPropsCounter {
+  resolved: usize,
+}
+
+impl Visit for ResolvedPropsCounter {
+  fn visit_jsx_attr(&mut self, attr: &JSXAttr) {
+    if matches!(&attr.name, JSXAttrName::Ident(name) if name.sym.as_ref() == RESOLVED_ATTR)
+      && matches!(&attr.value, Some(JSXAttrValue::Str(_)))
+    {
+      self.resolved += 1;
+    }
+
+    attr.visit_children_with(self);
+  }
+}
+
+/// Panics unless the transform resolved every `stylex.props` site in the module.
+///
+/// A refusal, a deopt and a swallowed panic are all fast, and a curve that
+/// flattens because the work stopped happening is indistinguishable from a win.
+/// The props sites are what asks the lookups being timed, so they are what has
+/// to have happened.
+fn assert_resolves_every_props_site(module: &Module) {
+  let mut counter = ResolvedPropsCounter::default();
+
+  transform(&module.path, module.program.clone()).visit_with(&mut counter);
+
+  let expected = module.components * PROPS_PER_COMPONENT;
+
+  assert_eq!(
+    counter.resolved, expected,
+    "a {}-component module resolved {} of its {expected} `stylex.props` sites -- the benchmark \
+     below would be timing a refusal rather than the transform",
+    module.components, counter.resolved
+  );
+}
+
+fn consumer_phase_benchmarks(c: &mut Criterion) {
+  let globals = Globals::default();
+
+  GLOBALS.set(&globals, || {
+    let modules: Vec<Module> = COMPONENT_COUNTS.into_iter().map(build_module).collect();
+
+    for module in &modules {
+      assert_resolves_every_props_site(module);
+    }
+
+    let mut group = c.benchmark_group("TransformConsumers");
+
+    for module in &modules {
+      // Batched because `apply` consumes the program: the clone is setup, not
+      // work under measurement.
+      group.bench_function(format!("components/{}", module.components), |b| {
+        b.iter_batched(
+          || module.program.clone(),
+          |program| black_box(transform(black_box(&module.path), program)),
+          BatchSize::SmallInput,
+        )
+      });
+    }
+
+    group.finish();
+  });
+}
+
+criterion_group!(benches, consumer_phase_benchmarks);
+criterion_main!(benches);

--- a/crates/stylex-transform/benches/transform_consumers_bench.rs
+++ b/crates/stylex-transform/benches/transform_consumers_bench.rs
@@ -14,29 +14,45 @@
 //! **Read the per-component cost, not the total.** Doubling the components
 //! doubles the work a linear transform does, so a total that doubles is the
 //! result being asserted; it is the total growing by *more* than the doubling
-//! that says a quadratic is back. What these three legs measured when this was
-//! written, as the leg's median divided by its components:
+//! that says a quadratic is back. What these legs measured when this was
+//! written, as the leg's median divided by its components. `walked` is the same
+//! file run against the commit before the keys, so the two columns differ in the
+//! lookups alone:
 //!
 //! ```text
-//!   components   walked    keyed
-//!           25   76.8 µs   65.9 µs
-//!          100   71.7 µs   65.7 µs
-//!          400   90.3 µs   67.7 µs
+//!   components   walked    keyed     identical styles   walked    keyed
+//!           25   54.3 µs   51.9 µs                 25   47.4 µs   45.2 µs
+//!          100   60.6 µs   56.0 µs                100   50.8 µs   46.1 µs
+//!          400   78.9 µs   59.1 µs                400   68.5 µs   51.0 µs
 //! ```
 //!
-//! The left column is the curve this file exists to catch: level to 100 and then
-//! climbing, because the quadratic term only overtakes the linear one once the
-//! collections are long enough. The right one stays flat. What is left in it is
-//! the fixed cost every transform pays, which is why it is not perfectly so.
+//! The `walked` columns are the curve this file exists to catch: level to 100
+//! and then climbing, because the quadratic term only overtakes the linear one
+//! once the collections are long enough. The `keyed` ones stay near flat. What
+//! is left in them is the fixed cost every transform pays -- parsing aside, the
+//! producer half that turns each style object into CSS -- which is why they are
+//! not perfectly so, and why the whole transform gains 1.3x at 400 rather than
+//! the multiple the lookups themselves do.
 //!
-//! The legs stop at 400 because that is the smallest series that separates the
-//! two columns, and a larger one would cost every run more time to say what this
-//! one says. The effect keeps growing past it: measured outside this repository
-//! against generated modules of 375 to 3000 components, per-component cost went
-//! 83.5, 105.2, 146.9 and 220.3 µs walked against 70.7, 72.3, 79.8 and 81.9 µs
-//! keyed -- 2.7x on the whole transform at the top. Those files are not built
-//! here, so that pair is a development observation rather than a number a later
-//! reader can re-run; what *is* re-runnable is the three legs above.
+//! [`assert_cost_per_component_stays_flat`] reads that curve for you, so a
+//! regression fails the run instead of waiting in a criterion report for a human
+//! to open it.
+//!
+//! Both shapes are measured because they load the keys differently: see
+//! [`Styles`]. The legs stop at 400 because that is the smallest series that
+//! separates the columns, and a larger one would cost every run more time to say
+//! what this one says. The effect keeps growing past it: measured outside this
+//! repository against generated modules of 375 to 3000 components, per-component
+//! cost went 83.5, 105.2, 146.9 and 220.3 µs walked against 70.7, 72.3, 79.8 and
+//! 81.9 µs keyed -- 2.7x on the whole transform at the top. Those files are not
+//! built here, and that pair predates the allocator below, so it is a
+//! development observation rather than a number a later reader can re-run; what
+//! *is* re-runnable is the legs above.
+//!
+//! Every number here was taken with the benches linking the same allocator the
+//! shipped `.node` does. A run under the system allocator reads slower
+//! throughout and reports an allocation-reducing change as a larger win than
+//! consumers get.
 //!
 //! The module is generated rather than cut from a real file because the shape
 //! being measured is *many* calls: the repository's large fixture is one long
@@ -56,11 +72,16 @@
 //! one times a panic and its unwind and reports the swallowed path's regressions
 //! as improvements.
 
+// Same allocator the `.node` links, so a malloc-bound measurement here is the
+// one consumers get. Linked for its `#[global_allocator]` and nothing else.
+use swc_malloc as _;
+
 use std::{
   hint::black_box,
   path::{Path, PathBuf},
   rc::Rc,
   sync::Arc,
+  time::{Duration, Instant},
 };
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -96,20 +117,62 @@ const PROPS_PER_COMPONENT: usize = 9;
 /// transform did the work rather than refusing it.
 const RESOLVED_ATTR: &str = "className";
 
+/// How a generated module spells the styles of its components.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Styles {
+  /// Every component's `create` call reads differently, so each lands in a
+  /// bucket of its own. What a component file writes, and the shape the keyed
+  /// lookups are claimed to be linear in.
+  Distinct,
+  /// Every component's `create` call reads the same, so all of them share one
+  /// bucket. The shape a key cannot narrow, which real code does write and which
+  /// the `structurally_identical_calls` fixtures pin the *output* of.
+  ///
+  /// Measured because narrowing to a bucket of N leaves the confirm to decide
+  /// between N, where the walk this replaced stopped at the first entry -- every
+  /// one of them matches. Confirming the whole bucket to learn what its first
+  /// entry already said cost 1.7x the walk here before `earliest_confirmed`
+  /// learned to stop at the first entry of a bucket nothing has moved.
+  Identical,
+}
+
+impl Styles {
+  /// What the component at `index` names its colour channel.
+  ///
+  /// The index is what separates one component's `create` call from another's,
+  /// so dropping it is the whole of what collapses the module onto one bucket.
+  fn channel(self, index: usize) -> String {
+    match self {
+      Styles::Distinct => index.to_string(),
+      Styles::Identical => String::from("0"),
+    }
+  }
+
+  /// The name of the leg this shape measures.
+  fn leg(self) -> &'static str {
+    match self {
+      Styles::Distinct => "components",
+      Styles::Identical => "identicalStyles",
+    }
+  }
+}
+
 /// A module of `components` components, each declaring its own styles and
 /// reading them from [`PROPS_PER_COMPONENT`] sites.
 ///
-/// Every component's styles are distinct, because identical `create` calls
-/// collapse onto one entry in the state manager's call map and would make the
-/// collections this benchmark is about far smaller than the file suggests.
-fn generated_source(components: usize) -> String {
+/// Each component still declares and reads a style variable of its own whatever
+/// `styles` says, so the number of lookups is the same across the two shapes and
+/// only the number of buckets they answer from differs.
+fn generated_source(components: usize, styles: Styles) -> String {
   let mut source = String::from("import * as stylex from '@stylexjs/stylex';\n\n");
 
   for index in 0..components {
+    let channel = styles.channel(index);
+
     source.push_str(&format!(
       "const styles{index} = stylex.create({{\n\
-       \x20 base: {{ color: 'rgb({index}, 0, 0)', paddingTop: {index} }},\n\
-       \x20 alt: {{ backgroundColor: 'rgb(0, {index}, 0)', marginBottom: {index} }},\n\
+       \x20 base: {{ color: 'rgb({channel}, 0, 0)', paddingTop: {channel} }},\n\
+       \x20 alt: {{ backgroundColor: 'rgb(0, {channel}, 0)', marginBottom: {channel} }},\n\
        }});\n"
     ));
 
@@ -132,22 +195,25 @@ fn generated_source(components: usize) -> String {
 /// One size of the generated module: its path, and the parsed program.
 struct Module {
   components: usize,
+  styles: Styles,
   path: PathBuf,
   program: Program,
 }
 
-fn build_module(components: usize) -> Module {
-  let source = generated_source(components);
+fn build_module(components: usize, styles: Styles) -> Module {
+  let source = generated_source(components, styles);
 
-  // Named after the size, because the code frame's source map is process-global
-  // and keyed by file name: two sizes sharing one name would share one
-  // registered source. Nothing here writes the file -- production transforms
-  // resolve no positions, and the memoized module is what the path names.
-  let path = PathBuf::from(format!("/generated/components{components}.tsx"));
+  // Named after the size and the shape, because the code frame's source map is
+  // process-global and keyed by file name: two modules sharing one name would
+  // share one registered source. Nothing here writes the file -- production
+  // transforms resolve no positions, and the memoized module is what the path
+  // names.
+  let path = PathBuf::from(format!("/generated/{}{components}.tsx", styles.leg()));
   let program = parse(&FileName::Real(path.clone()), &source);
 
   Module {
     components,
+    styles,
     path,
     program,
   }
@@ -235,28 +301,120 @@ fn assert_resolves_every_props_site(module: &Module) {
   );
 }
 
+/// How many times each leg is transformed to price it.
+///
+/// The cheapest run of the several is what is compared, because a run can only
+/// be made *slower* by something outside the transform -- a scheduler, a
+/// competing process, a page fault -- so the minimum is the closest a wall clock
+/// gets to the work itself.
+const PRICING_RUNS: usize = 7;
+
+/// How much the per-component cost may rise across the series before the rise is
+/// called a regression.
+///
+/// Set from what both sides measure through [`cost_per_component`], not from the
+/// criterion medians in the header. Over three runs of each, the commit before
+/// the keys rose 1.43x to 1.57x, and this one rises 1.05x to 1.17x. The bound
+/// sits between them with about a tenth of headroom on each side, which the
+/// cheapest of [`PRICING_RUNS`] runs is stable enough to keep: the widest spread
+/// seen on either side of it was 0.06x.
+///
+/// Below the whole cost of the walk, because most of what a leg spends is the
+/// producer half that both share. What is being bounded is the rise across the
+/// series, not the distance between the two implementations.
+const MAX_PER_COMPONENT_RISE: f64 = 1.30;
+
+/// What one component of `module` costs to transform, in seconds.
+fn cost_per_component(module: &Module) -> f64 {
+  let mut cheapest = Duration::MAX;
+
+  for _ in 0..PRICING_RUNS {
+    let program = module.program.clone();
+    let started = Instant::now();
+
+    black_box(transform(&module.path, program));
+
+    cheapest = cheapest.min(started.elapsed());
+  }
+
+  cheapest.as_secs_f64() / module.components as f64
+}
+
+/// Panics unless the transform costs about the same per component at every size.
+///
+/// The claim the whole file exists for. A linear transform spends a flat amount
+/// per component whatever the module holds, so the largest leg may not cost
+/// [`MAX_PER_COMPONENT_RISE`] times the smallest one per component; a quadratic
+/// one climbs, because the lookups it makes per call grow with the collections
+/// they walk.
+///
+/// Each shape against itself, because the two start from different fixed costs:
+/// what is being asserted is that a shape stays level as it grows, not that the
+/// shapes cost alike. Only the smallest and largest leg of each shape is priced,
+/// so this adds four legs of [`PRICING_RUNS`] transforms -- about a third of a
+/// second -- to the run.
+///
+/// Outside the timed region, so criterion measures the transform rather than
+/// this.
+fn assert_cost_per_component_stays_flat(modules: &[Module]) {
+  for styles in [Styles::Distinct, Styles::Identical] {
+    let mut legs = modules.iter().filter(|module| module.styles == styles);
+
+    let (Some(smallest), Some(largest)) = (legs.next(), legs.next_back()) else {
+      continue;
+    };
+
+    let rise = cost_per_component(largest) / cost_per_component(smallest);
+
+    assert!(
+      rise < MAX_PER_COMPONENT_RISE,
+      "{} cost rose {rise:.2}x per component from {} components to {} -- a linear \
+       transform keeps that flat, so a lookup is walking again",
+      styles.leg(),
+      smallest.components,
+      largest.components
+    );
+  }
+}
+
 fn consumer_phase_benchmarks(c: &mut Criterion) {
   let globals = Globals::default();
 
   GLOBALS.set(&globals, || {
-    let modules: Vec<Module> = COMPONENT_COUNTS.into_iter().map(build_module).collect();
+    let modules: Vec<Module> = [Styles::Distinct, Styles::Identical]
+      .into_iter()
+      .flat_map(|styles| {
+        COMPONENT_COUNTS
+          .into_iter()
+          .map(move |components| build_module(components, styles))
+      })
+      .collect();
 
+    // A full extra transform of every leg, the largest included, before
+    // anything is measured. Deliberate: what it buys is the guarantee that the
+    // numbers below price the transform rather than a refusal, and it costs
+    // startup time only.
     for module in &modules {
       assert_resolves_every_props_site(module);
     }
+
+    assert_cost_per_component_stays_flat(&modules);
 
     let mut group = c.benchmark_group("TransformConsumers");
 
     for module in &modules {
       // Batched because `apply` consumes the program: the clone is setup, not
       // work under measurement.
-      group.bench_function(format!("components/{}", module.components), |b| {
-        b.iter_batched(
-          || module.program.clone(),
-          |program| black_box(transform(black_box(&module.path), program)),
-          BatchSize::SmallInput,
-        )
-      });
+      group.bench_function(
+        format!("{}/{}", module.styles.leg(), module.components),
+        |b| {
+          b.iter_batched(
+            || module.program.clone(),
+            |program| black_box(transform(black_box(&module.path), program)),
+            BatchSize::SmallInput,
+          )
+        },
+      );
     }
 
     group.finish();

--- a/crates/stylex-transform/docs/adr/0005-the-memo-key-is-a-whole-subtree-hash.md
+++ b/crates/stylex-transform/docs/adr/0005-the-memo-key-is-a-whole-subtree-hash.md
@@ -54,8 +54,8 @@ collapses to nothing, which reads exactly like a win. `key_fallback_benchmarks`
 now asserts which arm each leg takes before timing it, so the figure above
 cannot quietly stop being about the boundary.
 
-**Its width was load-bearing and too narrow.** Ten things key off a hash of an
-expression, and they do not agree about how much the hash has to mean:
+**Its width was load-bearing and too narrow.** Eleven things key off a hash of
+an expression, and they do not agree about how much the hash has to mean:
 
 - the evaluator's `seen` memo returns a cached fold on a **hash hit alone**;
 - `InsertionSlot::BeforeDecl` splices a declaration's style metadata on a
@@ -64,13 +64,14 @@ expression, and they do not agree about how much the hash has to mean:
   twice over, once keyed by `compute_cache_key` and once by
   `compute_key_span_cache_key`;
 - the JSX-spread replacement map, the queued-decl dedup, the callee index behind
-  `is_member_callee`, and the three `CandidateIndex`es that pin a call to its
-  declarator, to its style variable and to its top-level expression, narrow a
-  bucket by hash and then confirm with `eq_ignore_span`;
+  `is_member_callee`, and three of the state manager's six `CandidateIndex`es --
+  the ones that pin a call to its declarator, to its style variable and to its
+  top-level expression -- narrow a bucket by hash and then confirm with
+  `eq_ignore_span`;
 - `all_call_expressions` confirms on read too, but a collision can evict the
   wrong entry when a call is replaced.
 
-So for four of the ten the key _is_ the equality test. At 64 bits and ten
+So for four of the eleven the key _is_ the equality test. At 64 bits and ten
 thousand distinct expressions in a file that is a collision every `1e-12` files,
 and they fail with different volumes: a wrong folded value or a misplaced
 injection is silent, while a wrong cached span is **directly visible in the

--- a/crates/stylex-transform/docs/adr/0005-the-memo-key-is-a-whole-subtree-hash.md
+++ b/crates/stylex-transform/docs/adr/0005-the-memo-key-is-a-whole-subtree-hash.md
@@ -64,7 +64,7 @@ expression, and they do not agree about how much the hash has to mean:
   twice over, once keyed by `compute_cache_key` and once by
   `compute_key_span_cache_key`;
 - the JSX-spread replacement map, the queued-decl dedup, the callee index behind
-  `is_member_callee`, and the three `StructuralIndex`es that pin a call to its
+  `is_member_callee`, and the three `CandidateIndex`es that pin a call to its
   declarator, to its style variable and to its top-level expression, narrow a
   bucket by hash and then confirm with `eq_ignore_span`;
 - `all_call_expressions` confirms on read too, but a collision can evict the

--- a/crates/stylex-transform/docs/adr/0005-the-memo-key-is-a-whole-subtree-hash.md
+++ b/crates/stylex-transform/docs/adr/0005-the-memo-key-is-a-whole-subtree-hash.md
@@ -54,7 +54,7 @@ collapses to nothing, which reads exactly like a win. `key_fallback_benchmarks`
 now asserts which arm each leg takes before timing it, so the figure above
 cannot quietly stop being about the boundary.
 
-**Its width was load-bearing and too narrow.** Seven things key off a hash of an
+**Its width was load-bearing and too narrow.** Ten things key off a hash of an
 expression, and they do not agree about how much the hash has to mean:
 
 - the evaluator's `seen` memo returns a cached fold on a **hash hit alone**;
@@ -63,13 +63,14 @@ expression, and they do not agree about how much the hash has to mean:
 - the code-frame `span_cache` returns a cached span on a **hash hit alone** —
   twice over, once keyed by `compute_cache_key` and once by
   `compute_key_span_cache_key`;
-- the JSX-spread replacement map, the queued-decl dedup and the callee index
-  behind `is_member_callee` narrow a bucket by hash and then confirm with
-  `eq_ignore_span`;
+- the JSX-spread replacement map, the queued-decl dedup, the callee index behind
+  `is_member_callee`, and the three `StructuralIndex`es that pin a call to its
+  declarator, to its style variable and to its top-level expression, narrow a
+  bucket by hash and then confirm with `eq_ignore_span`;
 - `all_call_expressions` confirms on read too, but a collision can evict the
   wrong entry when a call is replaced.
 
-So for four of the seven the key _is_ the equality test. At 64 bits and ten
+So for four of the ten the key _is_ the equality test. At 64 bits and ten
 thousand distinct expressions in a file that is a collision every `1e-12` files,
 and they fail with different volumes: a wrong folded value or a misplaced
 injection is silent, while a wrong cached span is **directly visible in the
@@ -77,8 +78,9 @@ output** as a style annotated with another style's `file:line`. All four are now
 **128 bits**, which puts them past `1e-31`.
 
 The span cache arrived at this decision late — it was missed on the first count
-of consumers and found in review, which is why this section says seven rather
-than five. It keys a _positional_ hash rather than the structural one, because it
+of consumers and found in review, which took the count from five to seven; the
+three that pin a call to what holds it came later still. It keys a _positional_
+hash rather than the structural one, because it
 caches "where was this written" and two identical expressions at different
 positions must not share an entry. That is why it has its own key derivation and
 did not come along for free.
@@ -98,12 +100,13 @@ It cost **+49% on the key and +5.8% on a whole production transform** of the
 400-`create` corpus file (26.0 ms to 27.5 ms, 25 runs each), and paying that
 forever to remove a failure that arrives once per `1e4` years is the wrong trade.
 
-**Confirm the hit with `eq_ignore_span` instead of widening.** What the other two
-consumers do. Rejected for the evaluator's memo: a confirm costs a subtree
-compare on _every hit_ — the same order as the walk just paid — and `seen` would
-have to hold a deep clone of every memoized expression to have something to
-compare against. It remains the right answer for a consumer whose hits are rare;
-`InsertionSlot::BeforeDecl` would qualify, and is covered by the width instead.
+**Confirm the hit with `eq_ignore_span` instead of widening.** What the
+confirming consumers do. Rejected for the evaluator's memo: a confirm costs a
+subtree compare on _every hit_ — the same order as the walk just paid — and
+`seen` would have to hold a deep clone of every memoized expression to have
+something to compare against. It remains the right answer for a consumer whose
+hits are rare; `InsertionSlot::BeforeDecl` would qualify, and is covered by the
+width instead.
 
 **xxh3, taken 128 bits wide.** What shipped. A single pass emits 128 bits, and it
 is enough faster than SipHash that the wider key is also the _cheaper_ one:

--- a/crates/stylex-transform/docs/adr/0005-the-memo-key-is-a-whole-subtree-hash.md
+++ b/crates/stylex-transform/docs/adr/0005-the-memo-key-is-a-whole-subtree-hash.md
@@ -63,8 +63,9 @@ expression, and they do not agree about how much the hash has to mean:
 - the code-frame `span_cache` returns a cached span on a **hash hit alone** —
   twice over, once keyed by `compute_cache_key` and once by
   `compute_key_span_cache_key`;
-- the JSX-spread replacement map and the queued-decl dedup narrow a bucket by
-  hash and then confirm with `eq_ignore_span`;
+- the JSX-spread replacement map, the queued-decl dedup and the callee index
+  behind `is_member_callee` narrow a bucket by hash and then confirm with
+  `eq_ignore_span`;
 - `all_call_expressions` confirms on read too, but a collision can evict the
   wrong entry when a call is replaced.
 

--- a/crates/stylex-transform/src/shared/structures/candidate_index.rs
+++ b/crates/stylex-transform/src/shared/structures/candidate_index.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap;
 /// Where the entries holding a given thing live, bucketed by a key that narrows
 /// to them.
 ///
-/// Five of the state manager's questions have the same shape: "which recorded
+/// Six of the state manager's questions have the same shape: "which recorded
 /// entry holds *this*?", asked once per `stylex.*` call or per identifier
 /// reference the transform meets. Answered by walking the whole collection and
 /// comparing whole subtrees with `eq_ignore_span`, each of those runs once per

--- a/crates/stylex-transform/src/shared/structures/candidate_index.rs
+++ b/crates/stylex-transform/src/shared/structures/candidate_index.rs
@@ -22,11 +22,15 @@ use rustc_hash::FxHashMap;
 ///
 /// **The key narrows and equality still decides.** Callers confirm the
 /// candidates this hands back, which is the shape `adr/0005` calls "narrow a
-/// bucket by hash and then confirm" and what keeps every answer the one the walk
-/// gave: a hit alone would make these consumers ones for which the key *is* the
-/// equality test, and would refuse a match the walk made whenever
-/// `EQ_IGNORE_SPAN_IGNORE_CTXT` is in scope, since a structural key hashes an
-/// identifier's `SyntaxContext` and `eq_ignore_span` there does not.
+/// bucket by hash and then confirm". Confirmation removes false positives -- a
+/// hit alone would make these consumers ones for which the key *is* the
+/// equality test. It cannot remove false negatives: a bucket miss is final, so
+/// the key must never be *stricter* than the equality that confirms it. It is
+/// stricter in three places today, all unreachable: `Ident::optional` and the
+/// `raw` of `Str`/`Number`/`BigInt` are hashed but not compared, and under
+/// `EQ_IGNORE_SPAN_IGNORE_CTXT` -- which nothing sets -- an identifier's
+/// `SyntaxContext` would join them. Anything that sets that flag has to change
+/// the key.
 #[derive(Clone, Debug)]
 pub(crate) struct CandidateIndex<K, H> {
   buckets: FxHashMap<K, Vec<H>>,
@@ -56,6 +60,10 @@ impl<K: Eq + Hash, H: PartialEq> CandidateIndex<K, H> {
 
   /// Drops the record that the entry at `handle` holds what `key` narrows to,
   /// forgetting the bucket once nothing is left in it.
+  ///
+  /// Removing the emptied bucket is for [`Self::candidates`]' `is_empty()`
+  /// short-circuit alone, never for correctness: an empty bucket and an absent
+  /// key both answer with nothing.
   pub(crate) fn forget(&mut self, key: &K, handle: &H) {
     let Some(bucket) = self.buckets.get_mut(key) else {
       return;

--- a/crates/stylex-transform/src/shared/structures/candidate_index.rs
+++ b/crates/stylex-transform/src/shared/structures/candidate_index.rs
@@ -1,0 +1,103 @@
+use std::hash::Hash;
+
+use rustc_hash::FxHashMap;
+
+/// Where the entries holding a given thing live, bucketed by a key that narrows
+/// to them.
+///
+/// Five of the state manager's questions have the same shape: "which recorded
+/// entry holds *this*?", asked once per `stylex.*` call or per identifier
+/// reference the transform meets. Answered by walking the whole collection and
+/// comparing whole subtrees with `eq_ignore_span`, each of those runs once per
+/// question against every entry -- quadratic in the size of the module, and on a
+/// 1,500-component JSX module the largest single cost in the transform.
+///
+/// `K` is what narrows: a structural hash where the question is about an
+/// expression, a source position where it is about where something was written,
+/// a name where it is about what a declarator binds. `H` is how an entry is
+/// addressed in the collection beside it -- a position for a `Vec`, a name for a
+/// map. The index holds no entry itself, so it cannot disagree with one about
+/// its contents, only about where it is, which is what the confirmation below
+/// settles.
+///
+/// **The key narrows and equality still decides.** Callers confirm the
+/// candidates this hands back, which is the shape `adr/0005` calls "narrow a
+/// bucket by hash and then confirm" and what keeps every answer the one the walk
+/// gave: a hit alone would make these consumers ones for which the key *is* the
+/// equality test, and would refuse a match the walk made whenever
+/// `EQ_IGNORE_SPAN_IGNORE_CTXT` is in scope, since a structural key hashes an
+/// identifier's `SyntaxContext` and `eq_ignore_span` there does not.
+#[derive(Clone, Debug)]
+pub(crate) struct CandidateIndex<K, H> {
+  buckets: FxHashMap<K, Vec<H>>,
+}
+
+impl<K, H> Default for CandidateIndex<K, H> {
+  fn default() -> Self {
+    Self {
+      buckets: FxHashMap::default(),
+    }
+  }
+}
+
+impl<K: Eq + Hash, H: PartialEq> CandidateIndex<K, H> {
+  /// Records that the entry at `handle` holds what `key` narrows to.
+  ///
+  /// Recording one that is already there is a no-op rather than a second bucket
+  /// entry, so a collection filled twice -- which the discovery cycle does --
+  /// indexes each entry once.
+  pub(crate) fn record(&mut self, key: K, handle: H) {
+    let bucket = self.buckets.entry(key).or_default();
+
+    if !bucket.contains(&handle) {
+      bucket.push(handle);
+    }
+  }
+
+  /// Drops the record that the entry at `handle` holds what `key` narrows to,
+  /// forgetting the bucket once nothing is left in it.
+  pub(crate) fn forget(&mut self, key: &K, handle: &H) {
+    let Some(bucket) = self.buckets.get_mut(key) else {
+      return;
+    };
+
+    bucket.retain(|candidate| candidate != handle);
+
+    if bucket.is_empty() {
+      self.buckets.remove(key);
+    }
+  }
+
+  /// Moves the entry at `handle` from the key it was recorded under to the one
+  /// it now belongs to, either of which may be absent.
+  ///
+  /// The one way an entry's key changes, and the reason it is a method rather
+  /// than a pair of calls at four sites: the order matters. Forgetting first
+  /// means an entry replaced by something under the *same* key keeps its record
+  /// instead of losing it to the forget that would otherwise follow.
+  pub(crate) fn move_entry(&mut self, replaced: Option<K>, recorded: Option<K>, handle: H) {
+    if let Some(replaced) = replaced {
+      self.forget(&replaced, &handle);
+    }
+
+    if let Some(recorded) = recorded {
+      self.record(recorded, handle);
+    }
+  }
+
+  /// The entries that may hold what `key_of` describes -- the candidates the
+  /// caller confirms.
+  ///
+  /// The key is computed only when there is something to look it up in, because
+  /// computing a structural one walks the whole expression. A module that
+  /// records nothing of the kind this index holds -- every style in one
+  /// top-level array is the common shape -- then answers for free, where hashing
+  /// a style object first would cost more than the scan this replaces did.
+  pub(crate) fn candidates(&self, key_of: impl FnOnce() -> K) -> &[H] {
+    if self.buckets.is_empty() {
+      return &[];
+    }
+
+    self.buckets.get(&key_of()).map_or(&[], Vec::as_slice)
+  }
+}

--- a/crates/stylex-transform/src/shared/structures/mod.rs
+++ b/crates/stylex-transform/src/shared/structures/mod.rs
@@ -1,4 +1,5 @@
 // Kept locally (depend on StateManager, functions, or utils)
+pub(crate) mod candidate_index;
 pub mod evaluate_result;
 pub mod functions;
 pub(crate) mod key_span_index;

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -1,5 +1,6 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::OnceCell;
+use std::collections::hash_map::Entry;
 use std::{option::Option, path::Path, rc::Rc, sync::Arc};
 use stylex_macros::{stylex_panic, stylex_unimplemented};
 
@@ -59,7 +60,9 @@ use stylex_structures::{
   style_vars_to_keep::StyleVarsToKeep, top_level_expression::TopLevelExpression,
 };
 use stylex_types::enums::data_structures::injectable_style::InjectableStyleKind;
-use stylex_utils::hash::{stable_hash_unspanned, stable_hash_unspanned_call};
+use stylex_utils::hash::{
+  stable_hash_unspanned, stable_hash_unspanned_call, stable_hash_unspanned_member,
+};
 
 use super::{
   key_span_index::{KeySpanIndex, ModuleBase},
@@ -291,36 +294,90 @@ impl ModuleSourceState {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CallExpressionState {
   all_call_expressions: FxHashMap<u128, Callee>,
+  /// How many entries of [`Self::all_call_expressions`] have a member
+  /// expression for a callee, counted per structural key of that member.
+  ///
+  /// This is an index over the callees, and the whole of what
+  /// [`Self::is_member_callee`] needs. Without it that question was answered by
+  /// scanning every call in the module and comparing whole `MemberExpr`
+  /// subtrees with `eq_ignore_span`. It is asked once per member expression the
+  /// evaluator visits, so the scan made the consumer phase quadratic in the
+  /// number of calls a module makes: on a 1,500-component JSX module it grew
+  /// 3.6x for every doubling of the input and reached 41% of total compile
+  /// time.
+  ///
+  /// Counted rather than held as a set because the map collapses structurally
+  /// equal calls onto one entry while two *different* calls can still share a
+  /// callee — `a.b(1)` and `a.b(2)`. A plain set would drop `a.b` when either
+  /// one of them is replaced, and `is_member_callee` would start answering
+  /// `false` for a callee that is still live.
+  ///
+  /// Keyed by the same 128-bit structural hash that keys the map itself, so a
+  /// collision was already able to conflate two calls before this existed; the
+  /// index widens nothing.
+  callee_member_keys: FxHashMap<u128, u32>,
 }
 
 impl CallExpressionState {
   fn add_call_expression(&mut self, call_expr: &CallExpr) {
-    self.all_call_expressions.insert(
-      stable_hash_unspanned_call(call_expr),
-      call_expr.callee.clone(),
-    );
+    let key = stable_hash_unspanned_call(call_expr);
+    let callee = call_expr.callee.clone();
+    let member_key = Self::callee_member_key(&callee);
+
+    // `insert` overwrites, so an existing entry's callee leaves the map here
+    // and its count has to go with it.
+    if let Some(replaced) = self.all_call_expressions.insert(key, callee) {
+      self.release_member_key(Self::callee_member_key(&replaced));
+    }
+
+    if let Some(member_key) = member_key {
+      *self.callee_member_keys.entry(member_key).or_default() += 1;
+    }
   }
 
   fn is_member_callee(&self, member: &MemberExpr) -> bool {
     self
-      .all_call_expressions
-      .values()
-      .any(|call_expr_callee| match call_expr_callee {
-        Callee::Expr(callee) => match callee.as_ref() {
-          Expr::Member(call_member) => call_member.eq_ignore_span(member),
-          _ => false,
-        },
-        _ => false,
-      })
+      .callee_member_keys
+      .contains_key(&stable_hash_unspanned_member(member))
   }
 
   fn replace_call_expression(&mut self, call: &CallExpr, ast: &Expr) {
-    self
+    if let Some(removed) = self
       .all_call_expressions
-      .remove(&stable_hash_unspanned_call(call));
+      .remove(&stable_hash_unspanned_call(call))
+    {
+      self.release_member_key(Self::callee_member_key(&removed));
+    }
 
     if let Some(call_expr) = ast.as_call() {
       self.add_call_expression(call_expr);
+    }
+  }
+
+  /// The structural key of `callee`, where the callee is a member expression.
+  fn callee_member_key(callee: &Callee) -> Option<u128> {
+    match callee {
+      Callee::Expr(expr) => match expr.as_ref() {
+        Expr::Member(member) => Some(stable_hash_unspanned_member(member)),
+        _ => None,
+      },
+      _ => None,
+    }
+  }
+
+  /// Drop one reference to `key`, forgetting it once nothing holds it.
+  fn release_member_key(&mut self, key: Option<u128>) {
+    let Some(key) = key else {
+      return;
+    };
+
+    if let Entry::Occupied(mut occupied) = self.callee_member_keys.entry(key) {
+      match occupied.get_mut() {
+        1 => {
+          occupied.remove();
+        },
+        count => *count -= 1,
+      }
     }
   }
 }

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -766,16 +766,24 @@ pub struct StateManager {
   /// the second where the walk this replaces found it.
   /// Shared rather than copied -- see [`Self::declaration_call_index`].
   top_level_name_index: Rc<CandidateIndex<Atom, usize>>,
-  /// How many entries of [`Self::top_level_expressions`] are an array literal.
+  /// Where each entry of [`Self::top_level_expressions`] that is an array
+  /// literal was written.
   ///
-  /// A count rather than a walk, because the question every `stylex.create`
-  /// asks of that list -- does the module hold *any* top-level array -- does not
-  /// read the call, so re-walking the list per call was O(creates x declarators)
-  /// for one module-constant bit.
+  /// The whole of what [`Self::holds_call_in_top_level_array`] needs. A module
+  /// writes a handful of top-level arrays and can write thousands of calls, so
+  /// asking the arrays is not the walk of every top-level expression that
+  /// question used to cost, once per `stylex.create`.
   ///
-  /// A count rather than a flag, because [`Self::set_top_level_expr`] can
-  /// replace an array with something else and a flag could not be lowered.
-  top_level_array_count: usize,
+  /// Spans rather than the expressions, because the question is whether a call
+  /// sits *inside* one, and a span answers that by containment -- the same O(1)
+  /// test `is_bound_create_expr` uses, and for the same reason: a single
+  /// top-level array holding every style in a module is an idiomatic shape, so
+  /// walking its elements would be quadratic in the styles it holds.
+  ///
+  /// A list rather than a count, because [`Self::set_top_level_expr`] can
+  /// replace an array with something else, and because a count cannot say which
+  /// call an array holds.
+  top_level_array_spans: Vec<Span>,
   /// Spans of the calls that initialise a top-level declarator bound to a
   /// pattern rather than a name — `export const { foo } = stylex.create(…);`.
   /// [`Self::top_level_expressions`] is keyed by the exported name and so has
@@ -974,7 +982,7 @@ impl StateManager {
       top_level_expressions: vec![],
       top_level_call_index: Rc::default(),
       top_level_name_index: Rc::default(),
-      top_level_array_count: 0,
+      top_level_array_spans: vec![],
       pattern_bound_top_level_calls: FxHashSet::default(),
       call_expressions: CallExpressionState::default(),
       jsx_spread_attr_exprs_map: FxHashMap::default(),
@@ -1299,8 +1307,8 @@ impl StateManager {
       Rc::make_mut(&mut self.top_level_name_index).record(name.clone(), position);
     }
 
-    if matches!(expression.1, Expr::Array(_)) {
-      self.top_level_array_count += 1;
+    if let Expr::Array(array) = &expression.1 {
+      self.top_level_array_spans.push(array.span);
     }
 
     self.top_level_expressions.push(expression);
@@ -1317,17 +1325,27 @@ impl StateManager {
     // its initializer before it.
     let recorded = call_key_of(Some(&expr));
     let replaced = std::mem::replace(&mut entry.1, expr);
-    // Read while the entry is still borrowed, because the count below is a
-    // field of the same state manager.
-    let records_array = matches!(entry.1, Expr::Array(_));
+    // Read while the entry is still borrowed, because the list below is a field
+    // of the same state manager.
+    let records_array = match &entry.1 {
+      Expr::Array(array) => Some(array.span),
+      _ => None,
+    };
 
-    // Exact rather than approximate: an entry that stops being an array lowers
-    // the count, which is what keeps [`Self::holds_top_level_array`] the answer
-    // the walk gave.
-    self.top_level_array_count = self
-      .top_level_array_count
-      .saturating_sub(usize::from(matches!(replaced, Expr::Array(_))))
-      + usize::from(records_array);
+    // An entry that stops being an array leaves the list, which is what keeps
+    // [`Self::holds_call_in_top_level_array`] the answer the walk gave.
+    if let Expr::Array(array) = &replaced
+      && let Some(position) = self
+        .top_level_array_spans
+        .iter()
+        .position(|recorded| *recorded == array.span)
+    {
+      self.top_level_array_spans.remove(position);
+    }
+
+    if let Some(span) = records_array {
+      self.top_level_array_spans.push(span);
+    }
 
     // The name an entry binds does not change with its expression, so only the
     // call index needs repairing here.
@@ -2109,20 +2127,36 @@ impl StateManager {
     self.find_top_level_expr(call).is_some() || self.top_level_expressions.iter().any(binds_call)
   }
 
-  /// Whether any recorded top-level expression is an array literal.
+  /// Whether a recorded top-level array literal holds `call`.
   ///
-  /// Answered from [`Self::top_level_array_count`], which is why it takes no
-  /// call: the question does not read one.
-  pub(crate) fn holds_top_level_array(&self) -> bool {
-    let found = self.top_level_array_count > 0;
+  /// The shape a name cannot find: `export const styles = [stylex.create(…)];`
+  /// writes the call at program level, and the recorded entry is the array
+  /// rather than the call, so no key answers for it.
+  ///
+  /// Containment decides, not the mere presence of an array. A call written
+  /// inside a function is not at program level because the module also holds an
+  /// array somewhere else, and `is_bound_create_expr` reads the same shape the
+  /// same way.
+  ///
+  /// A span-less call is held by nothing. Such a call is synthesized rather than
+  /// parsed, so no recorded array can be where it was written, and a dummy span
+  /// would otherwise be read as position zero.
+  pub(crate) fn holds_call_in_top_level_array(&self, call: &CallExpr) -> bool {
+    if call.span.is_dummy() {
+      return false;
+    }
+
+    let found = self
+      .top_level_array_spans
+      .iter()
+      .any(|array| array.contains(call.span));
 
     debug_assert_eq!(
       found,
-      self
-        .top_level_expressions
-        .iter()
-        .any(|recorded| matches!(recorded.1, Expr::Array(_))),
-      "`top_level_array_count` disagrees with `top_level_expressions`; something \
+      self.top_level_expressions.iter().any(|recorded| {
+        matches!(&recorded.1, Expr::Array(array) if array.span.contains(call.span))
+      }),
+      "`top_level_array_spans` disagrees with `top_level_expressions`; something \
        changed the list without going through `push_top_level_expression` or \
        `set_top_level_expr`"
     );

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -302,17 +302,18 @@ pub(crate) struct CallExpressionState {
   ///
   /// The whole of what [`Self::is_member_callee`] needs. Without it that
   /// question was answered by walking every call in the module and comparing
-  /// whole `MemberExpr` subtrees, once per member expression the evaluator
-  /// visits -- which made the consumer phase quadratic in the number of calls
-  /// a module makes. On a 1,500-component JSX module it grew 3.6x for every
-  /// doubling of the input and reached 41% of total compile time.
+  /// whole `MemberExpr` subtrees, which is `O(calls)` for each ask.
   ///
-  /// That pair, and the percentage below it, were taken while this was written.
-  /// The benches used the system allocator then. The figures are smaller under
-  /// the allocator the shipped `.node` links, which is what
-  /// `transform_consumers_bench` measures now: there the lookups this index
-  /// serves are 25% of a 400-component transform. Read all three as the shape of
-  /// the cost, not as a figure to compare a later run against.
+  /// **The ask is cold, so the bound is a guard rather than a win.** Counted
+  /// over the whole transform suite, the question is asked 2,261 times, and the
+  /// largest module that asks it at all holds 85 calls. Four generated modules
+  /// -- 1,500 components of JSX, the same with a folded method call in every
+  /// style value, the producer-heavy fixture, and 7.3 MB of one top-level array
+  /// -- never ask it once, and restoring the walk moves none of them outside
+  /// measurement noise. An earlier note here put the walk at 41% of compile time
+  /// on a large JSX module; that is not reproducible from this repository and
+  /// has been removed rather than repeated. What the index buys is that a module
+  /// which does ask, and holds many calls, cannot pay `O(calls)` for it.
   ///
   /// A bucket of members rather than a bare key, because the key narrows and
   /// [`EqIgnoreSpan`] still decides: this is the shape
@@ -331,10 +332,13 @@ pub(crate) struct CallExpressionState {
   /// Counted per distinct member rather than held one-per-call, because a
   /// module's calls overwhelmingly share a handful of callee shapes: every
   /// `stylex.create(...)` in a file spells the same `stylex.create`. Holding a
-  /// clone per call made the bucket as long as the call list -- 15,000 copies
-  /// of one member on a large module, and an allocation for each -- which cost
-  /// 12.7% on a producer-heavy fixture and is the whole reason the count is
-  /// here. The count is still needed for the reason a set would not do: two
+  /// clone per call made the bucket as long as the call list -- one copy of the
+  /// same member per call, and an allocation for each. Restoring that shape
+  /// costs 1.12x on a 1,500-component JSX module (84.6 ms against 94.4 ms) and
+  /// 2.08x on 7.3 MB of one top-level array (1.26 s against 2.63 s), which is
+  /// the whole reason the count is here. Unlike the bound above, this is paid on
+  /// every call a module makes rather than on an ask that may never come.
+  /// The count is still needed for the reason a set would not do: two
   /// *different* calls can share a callee -- `a.b(1)` and `a.b(2)` -- and
   /// forgetting `a.b` when either is replaced would leave
   /// [`Self::is_member_callee`] answering `false` for a callee still live.
@@ -751,10 +755,9 @@ pub struct StateManager {
   ///
   /// Only calls, where the list holds expressions of every shape, because a key
   /// costs a walk of the expression it describes and a top-level expression can
-  /// be a whole module's styles in one array. Keying those too cost about 50 ms
-  /// on a 7.3 MB file to serve one lookup [`Self::top_level_name_index`]
-  /// answers without a walk at all -- measured under the system allocator, for
-  /// the reason the `callee_members` comment gives.
+  /// be a whole module's styles in one array. Keying those too costs about 60 ms
+  /// on 7.3 MB of one such array -- 1.26 s against 1.32 s -- to serve one lookup
+  /// [`Self::top_level_name_index`] answers without a walk at all.
   /// Shared rather than copied -- see [`Self::declaration_call_index`].
   top_level_call_index: Rc<CandidateIndex<u128, usize>>,
   /// Positions in [`Self::top_level_expressions`] of the entries bound to each

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -2011,9 +2011,22 @@ impl StateManager {
           .get(position)
           .is_some_and(|recorded| recorded.1.eq_ignore_span(expr))
       },
-    )?;
+    );
 
-    self.top_level_expressions.get(position)
+    // The scan must not consult the index: it is the independent answer the
+    // index is checked against.
+    debug_assert_eq!(
+      position.is_some(),
+      self
+        .top_level_expressions
+        .iter()
+        .any(|recorded| { recorded.2.as_ref() == Some(name) && recorded.1.eq_ignore_span(expr) }),
+      "`top_level_name_index` disagrees with `top_level_expressions` about \
+       `{name}`; something grew the list without going through \
+       `push_top_level_expression`"
+    );
+
+    self.top_level_expressions.get(position?)
   }
 
   /// The style variable bound to `name`, if its declarator reads as
@@ -2149,9 +2162,12 @@ impl StateManager {
   /// Name of the style variable `call` initialises.
   ///
   /// Unordered, unlike the two lookups above: [`Self::style_vars`] is a map, so
-  /// the walk this replaces had no order to preserve either.
+  /// the walk this replaces had no order to preserve either. Nothing turns on
+  /// which of a bucket's names comes first, because at most one of them can
+  /// confirm: the moment a style variable's initializer is rewritten,
+  /// [`Self::set_style_var_init`] moves it off this call's key.
   fn find_style_var_name(&self, call: &CallExpr) -> Option<String> {
-    self
+    let found = self
       .style_var_call_index
       .candidates(|| stable_hash_unspanned_call(call))
       .iter()
@@ -2159,7 +2175,18 @@ impl StateManager {
         matches!(self.style_vars.get(*name).and_then(|decl| decl.init.as_deref()),
           Some(Expr::Call(recorded)) if recorded.eq_ignore_span(call))
       })
-      .cloned()
+      .cloned();
+
+    debug_assert_eq!(
+      found.is_some(),
+      self.style_vars.values().any(|decl| {
+        matches!(decl.init.as_deref(), Some(Expr::Call(recorded)) if recorded.eq_ignore_span(call))
+      }),
+      "`style_var_call_index` disagrees with `style_vars`; something changed the \
+       map without going through `insert_style_var` or `set_style_var_init`"
+    );
+
+    found
   }
 
   pub(crate) fn register_styles(

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -307,6 +307,13 @@ pub(crate) struct CallExpressionState {
   /// a module makes. On a 1,500-component JSX module it grew 3.6x for every
   /// doubling of the input and reached 41% of total compile time.
   ///
+  /// That pair, and the percentage below it, were taken while this was written.
+  /// The benches used the system allocator then. The figures are smaller under
+  /// the allocator the shipped `.node` links, which is what
+  /// `transform_consumers_bench` measures now: there the lookups this index
+  /// serves are 25% of a 400-component transform. Read all three as the shape of
+  /// the cost, not as a figure to compare a later run against.
+  ///
   /// A bucket of members rather than a bare key, because the key narrows and
   /// [`EqIgnoreSpan`] still decides: this is the shape
   /// `adr/0005` calls "narrow a bucket by hash and then confirm", and it is
@@ -314,11 +321,12 @@ pub(crate) struct CallExpressionState {
   /// alone would make this a fifth consumer for which the key *is* the equality
   /// test, which is a decision that ADR owns rather than this index.
   ///
-  /// Confirming is also what keeps the answer right under
-  /// `EQ_IGNORE_SPAN_IGNORE_CTXT`: the key hashes an identifier's
-  /// `SyntaxContext` while `eq_ignore_span` ignores it inside that scope, so
-  /// the key alone would refuse a match the walk made. Nothing sets that flag
-  /// today; confirming means nothing has to remember this if something does.
+  /// Confirming settles collisions, not context. Under
+  /// `EQ_IGNORE_SPAN_IGNORE_CTXT` the key would be *stricter* than the equality
+  /// below it -- the key hashes an identifier's `SyntaxContext` while
+  /// `eq_ignore_span` ignores it inside that scope -- and a bucket miss is
+  /// final, so confirming could not recover the match the walk made. Nothing
+  /// sets that flag today.
   ///
   /// Counted per distinct member rather than held one-per-call, because a
   /// module's calls overwhelmingly share a handful of callee shapes: every
@@ -724,7 +732,8 @@ pub struct StateManager {
   /// costs a walk of the expression it describes and a top-level expression can
   /// be a whole module's styles in one array. Keying those too cost about 50 ms
   /// on a 7.3 MB file to serve one lookup [`Self::top_level_name_index`]
-  /// answers without a walk at all.
+  /// answers without a walk at all -- measured under the system allocator, for
+  /// the reason the `callee_members` comment gives.
   /// Shared rather than copied -- see [`Self::declaration_call_index`].
   top_level_call_index: Rc<CandidateIndex<u128, usize>>,
   /// Positions in [`Self::top_level_expressions`] of the entries bound to each
@@ -1198,6 +1207,12 @@ impl StateManager {
   /// `spacing` unbound here -- so a reference spelled that way names something
   /// else, or nothing at all, and resolving it to the import it was aliased away
   /// from is not a resolution the language allows.
+  ///
+  /// The `Id` key carries a `SyntaxContext`, which is what makes this
+  /// scope-aware -- and what makes it stricter than the `eq_ignore_span` that
+  /// confirms it under `EQ_IGNORE_SPAN_IGNORE_CTXT`. A bucket miss is final, so
+  /// anything that sets that flag has to key this differently rather than lean
+  /// on the confirm. Nothing sets it today.
   pub(crate) fn import_binding(&self, ident: &Ident) -> Option<(&ImportDecl, &ImportSpecifier)> {
     let found = self
       .top_import_index

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -317,12 +317,17 @@ pub(crate) struct CallExpressionState {
   /// the key alone would refuse a match the walk made. Nothing sets that flag
   /// today; confirming means nothing has to remember this if something does.
   ///
-  /// Held as a list rather than a set because the map collapses structurally
-  /// equal calls onto one entry while two *different* calls can still share a
-  /// callee -- `a.b(1)` and `a.b(2)`. Dropping `a.b` when either one of them is
-  /// replaced would leave [`Self::is_member_callee`] answering `false` for a
-  /// callee that is still live.
-  callee_members: FxHashMap<u128, Vec<MemberExpr>>,
+  /// Counted per distinct member rather than held one-per-call, because a
+  /// module's calls overwhelmingly share a handful of callee shapes: every
+  /// `stylex.create(...)` in a file spells the same `stylex.create`. Holding a
+  /// clone per call made the bucket as long as the call list -- 15,000 copies
+  /// of one member on a large module, and an allocation for each -- which cost
+  /// 12.7% on a producer-heavy fixture and is the whole reason the count is
+  /// here. The count is still needed for the reason a set would not do: two
+  /// *different* calls can share a callee -- `a.b(1)` and `a.b(2)` -- and
+  /// forgetting `a.b` when either is replaced would leave
+  /// [`Self::is_member_callee`] answering `false` for a callee still live.
+  callee_members: FxHashMap<u128, Vec<(MemberExpr, u32)>>,
 }
 
 impl CallExpressionState {
@@ -340,11 +345,18 @@ impl CallExpressionState {
     }
 
     if let Some(member) = member {
-      self
+      let bucket = self
         .callee_members
         .entry(stable_hash_unspanned_member(&member))
-        .or_default()
-        .push(member);
+        .or_default();
+
+      match bucket
+        .iter_mut()
+        .find(|(candidate, _)| candidate.eq_ignore_span(&member))
+      {
+        Some((_, count)) => *count += 1,
+        None => bucket.push((member, 1)),
+      }
     }
   }
 
@@ -355,7 +367,7 @@ impl CallExpressionState {
       .is_some_and(|bucket| {
         bucket
           .iter()
-          .any(|candidate| candidate.eq_ignore_span(member))
+          .any(|(candidate, _)| candidate.eq_ignore_span(member))
       })
   }
 
@@ -398,9 +410,14 @@ impl CallExpressionState {
 
     if let Some(position) = bucket
       .iter()
-      .position(|candidate| candidate.eq_ignore_span(member))
+      .position(|(candidate, _)| candidate.eq_ignore_span(member))
     {
-      bucket.remove(position);
+      match &mut bucket[position].1 {
+        1 => {
+          bucket.remove(position);
+        },
+        count => *count -= 1,
+      }
     }
 
     if bucket.is_empty() {

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -415,11 +415,14 @@ impl CallExpressionState {
       .iter()
       .position(|(candidate, _)| candidate.eq_ignore_span(member))
     {
-      match &mut bucket[position].1 {
-        1 => {
+      // The last call that holds a member drops it from the bucket. Any other
+      // one only decrements the count that keeps it alive for the calls left.
+      match bucket.get_mut(position) {
+        Some((_, 1)) => {
           bucket.remove(position);
         },
-        count => *count -= 1,
+        Some((_, count)) => *count -= 1,
+        None => {},
       }
     }
 
@@ -645,18 +648,18 @@ pub struct StateManager {
   /// because `declarations` is append-only -- nothing removes, reorders or
   /// truncates it, and the in-place edits reach `init` rather than `name`, so a
   /// recorded position stays the position of the same binding.
-  pub(crate) declaration_index: FxHashMap<Id, usize>,
+  declaration_index: FxHashMap<Id, usize>,
   /// Positions in [`Self::declarations`] of the declarators initialised by a
   /// given call, so pinning a call to its declarator is a hash probe rather
   /// than a walk of every declarator in the module comparing whole call
   /// subtrees. Maintained by [`Self::push_declaration`] and
   /// [`Self::set_declaration_init`], which are the only writers of the list and
   /// of a declarator's initializer.
-  pub(crate) declaration_call_index: CandidateIndex<u128, usize>,
+  declaration_call_index: CandidateIndex<u128, usize>,
   /// Positions in [`Self::declarations`] of the declarators written at a given
   /// source position, which is what [`Self::holds_declaration`] narrows on.
   /// Maintained by [`Self::push_declaration`], the only writer of the list.
-  pub(crate) declaration_span_index: CandidateIndex<Span, usize>,
+  declaration_span_index: CandidateIndex<Span, usize>,
   /// Bindings rebound after their declaration — an assignment, update,
   /// destructuring or loop target. The reference implementation's constant
   /// violations, probed as its own step of the reference-resolution chain.
@@ -712,7 +715,7 @@ pub struct StateManager {
   /// be a whole module's styles in one array. Keying those too cost about 50 ms
   /// on a 7.3 MB file to serve one lookup [`Self::top_level_name_index`]
   /// answers without a walk at all.
-  pub(crate) top_level_call_index: CandidateIndex<u128, usize>,
+  top_level_call_index: CandidateIndex<u128, usize>,
   /// Positions in [`Self::top_level_expressions`] of the entries bound to each
   /// name. Maintained by [`Self::push_top_level_expression`].
   ///
@@ -720,7 +723,7 @@ pub struct StateManager {
   /// permits redeclaration: `var styles = …; var styles = …;` records two
   /// entries under one name, and keeping only the first would answer `None` for
   /// the second where the walk this replaces found it.
-  pub(crate) top_level_name_index: CandidateIndex<Atom, usize>,
+  top_level_name_index: CandidateIndex<Atom, usize>,
   /// Spans of the calls that initialise a top-level declarator bound to a
   /// pattern rather than a name — `export const { foo } = stylex.create(…);`.
   /// [`Self::top_level_expressions`] is keyed by the exported name and so has
@@ -796,7 +799,7 @@ pub struct StateManager {
   /// call. Maintained by [`Self::insert_style_var`] and
   /// [`Self::set_style_var_init`], for the reason
   /// [`Self::declaration_call_index`] is.
-  pub(crate) style_var_call_index: CandidateIndex<u128, String>,
+  style_var_call_index: CandidateIndex<u128, String>,
 
   /// Map of local identifier -> imported name for `@stylexjs/atoms` imports.
   /// The key includes `SyntaxContext`, so shadowed bindings with the same symbol
@@ -859,7 +862,7 @@ pub struct StateManager {
   /// Keyed by the local binding's `Id` and confirmed with `eq_ignore_span` on
   /// read, for the reason [`Self::declaration_call_index`] is: the key narrows
   /// and equality decides.
-  pub(crate) top_import_index: CandidateIndex<Id, (usize, usize)>,
+  top_import_index: CandidateIndex<Id, (usize, usize)>,
   pub(crate) named_exports: FxHashSet<NamedExport>,
 
   pub cycle: TransformationCycle,
@@ -930,6 +933,22 @@ impl StateManager {
       other_injected_css_rules: IndexMap::new(),
 
       cycle: TransformationCycle::Discover,
+    }
+  }
+
+  /// A state manager that holds `options` and exports under `export_id`, which
+  /// is the whole of what a transformer unit test sets on one.
+  ///
+  /// A constructor rather than the `StateManager { .., ..default() }` literal
+  /// those tests wrote, because that form names every field and so needs every
+  /// field visible -- the indexes included, which only the writers beside them
+  /// may touch.
+  #[cfg(test)]
+  pub(crate) fn for_test(export_id: Option<&str>, options: StyleXStateOptions) -> Self {
+    Self {
+      export_id: export_id.map(str::to_string),
+      options,
+      ..Self::default()
     }
   }
 
@@ -1119,13 +1138,14 @@ impl StateManager {
       return;
     };
 
+    // Keyed before the move, because reading the initializer back from the list
+    // needs an index operator, which panics where a stale position gets here.
+    let recorded = call_key_of(Some(&init));
     let replaced = declarator.init.replace(Box::new(init));
 
-    self.declaration_call_index.move_entry(
-      call_key_of(replaced.as_deref()),
-      call_key_of(self.declarations[position].init.as_deref()),
-      position,
-    );
+    self
+      .declaration_call_index
+      .move_entry(call_key_of(replaced.as_deref()), recorded, position);
   }
 
   /// Appends an import declaration and records where each name it binds went.
@@ -1227,30 +1247,32 @@ impl StateManager {
   /// Replaces the expression recorded at `position`, keeping the call index in
   /// step. See [`Self::set_declaration_init`] for why it is the one way.
   pub(crate) fn set_top_level_expr(&mut self, position: usize, expr: Expr) {
-    let Some(recorded) = self.top_level_expressions.get_mut(position) else {
+    let Some(entry) = self.top_level_expressions.get_mut(position) else {
       return;
     };
 
-    let replaced = std::mem::replace(&mut recorded.1, expr);
+    // Keyed before the move, for the reason [`Self::set_declaration_init`] keys
+    // its initializer before it.
+    let recorded = call_key_of(Some(&expr));
+    let replaced = std::mem::replace(&mut entry.1, expr);
 
     // The name an entry binds does not change with its expression, so only the
     // call index needs repairing here.
-    self.top_level_call_index.move_entry(
-      call_key_of(Some(&replaced)),
-      call_key_of(Some(&self.top_level_expressions[position].1)),
-      position,
-    );
+    self
+      .top_level_call_index
+      .move_entry(call_key_of(Some(&replaced)), recorded, position);
   }
 
   /// Records the declarator `name` is bound by, and the call it is initialised
   /// by. The one way [`Self::style_vars`] grows, for the reason
   /// [`Self::push_declaration`] is the one way `declarations` does.
   pub(crate) fn insert_style_var(&mut self, name: String, declarator: VarDeclarator) {
+    let recorded = call_key_of(declarator.init.as_deref());
     let replaced = self.style_vars.insert(name.clone(), declarator);
 
     self.style_var_call_index.move_entry(
       call_key_of(replaced.as_ref().and_then(|decl| decl.init.as_deref())),
-      call_key_of(self.style_vars[&name].init.as_deref()),
+      recorded,
       name,
     );
   }
@@ -1263,13 +1285,12 @@ impl StateManager {
       return;
     };
 
+    let recorded = call_key_of(Some(&init));
     let replaced = declarator.init.replace(Box::new(init));
 
-    self.style_var_call_index.move_entry(
-      call_key_of(replaced.as_deref()),
-      call_key_of(self.style_vars[&name].init.as_deref()),
-      name,
-    );
+    self
+      .style_var_call_index
+      .move_entry(call_key_of(replaced.as_deref()), recorded, name);
   }
 
   /// The declarator binding `ident`, by hash probe rather than by scan.
@@ -1280,8 +1301,9 @@ impl StateManager {
       .and_then(|position| self.declarations.get(*position));
 
     // The index and the list have to agree, and only [`Self::push_declaration`]
-    // keeps them agreeing. The field is `pub(crate)`, so nothing in the type
-    // system stops a future caller pushing straight to it and leaving the
+    // keeps them agreeing. The index is private, so nothing can write it without
+    // the writer, but the list beside it is `pub(crate)`: nothing in the type
+    // system stops a future caller pushing straight to that and leaving the
     // binding it added invisible here -- which is what three test builders did
     // the day the index was added. Checking the answer against the scan it
     // replaced turns that back into a loud test failure rather than a reference

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -344,30 +344,35 @@ pub(crate) struct CallExpressionState {
 impl CallExpressionState {
   fn add_call_expression(&mut self, call_expr: &CallExpr) {
     let key = stable_hash_unspanned_call(call_expr);
-    let callee = call_expr.callee.clone();
-    let member = Self::callee_member(&callee).cloned();
 
     // `insert` overwrites, so an existing entry's callee leaves the map here
     // and its bucket entry has to go with it.
-    if let Some(replaced) = self.all_call_expressions.insert(key, callee)
+    if let Some(replaced) = self
+      .all_call_expressions
+      .insert(key, call_expr.callee.clone())
       && let Some(replaced) = Self::callee_member(&replaced)
     {
       self.release_member(replaced);
     }
 
-    if let Some(member) = member {
-      let bucket = self
-        .callee_members
-        .entry(stable_hash_unspanned_member(&member))
-        .or_default();
+    // Borrowed from the argument rather than from the clone above, so a member
+    // is copied only where the bucket has no entry to count -- which a module's
+    // handful of distinct callee shapes makes the rare case.
+    let Some(member) = Self::callee_member(&call_expr.callee) else {
+      return;
+    };
 
-      match bucket
-        .iter_mut()
-        .find(|(candidate, _)| candidate.eq_ignore_span(&member))
-      {
-        Some((_, count)) => *count += 1,
-        None => bucket.push((member, 1)),
-      }
+    let bucket = self
+      .callee_members
+      .entry(stable_hash_unspanned_member(member))
+      .or_default();
+
+    match bucket
+      .iter_mut()
+      .find(|(candidate, _)| candidate.eq_ignore_span(member))
+    {
+      Some((_, count)) => *count += 1,
+      None => bucket.push((member.clone(), 1)),
     }
   }
 
@@ -506,7 +511,23 @@ fn call_key_of(expr: Option<&Expr>) -> Option<u128> {
 /// the order its entries were recorded, and moving one re-records it at the
 /// back, so only the minimum is reliably the one a walk in source order would
 /// have reached first.
+///
+/// A bucket nothing has moved is still in recording order. There the first
+/// entry that confirms *is* the minimum, so that case stops at it, as the walk
+/// this replaces stopped at its first match.
+///
+/// That case matters. A module of structurally identical calls puts all of them
+/// in one bucket, and every one of them confirms. To confirm the rest costs more
+/// than the walk did. The check is cheap: it compares integers, where a
+/// confirmation compares whole subtrees.
 fn earliest_confirmed(candidates: &[usize], confirm: impl Fn(usize) -> bool) -> Option<usize> {
+  if candidates.is_sorted() {
+    return candidates
+      .iter()
+      .copied()
+      .find(|position| confirm(*position));
+  }
+
   candidates
     .iter()
     .copied()
@@ -745,6 +766,16 @@ pub struct StateManager {
   /// the second where the walk this replaces found it.
   /// Shared rather than copied -- see [`Self::declaration_call_index`].
   top_level_name_index: Rc<CandidateIndex<Atom, usize>>,
+  /// How many entries of [`Self::top_level_expressions`] are an array literal.
+  ///
+  /// A count rather than a walk, because the question every `stylex.create`
+  /// asks of that list -- does the module hold *any* top-level array -- does not
+  /// read the call, so re-walking the list per call was O(creates x declarators)
+  /// for one module-constant bit.
+  ///
+  /// A count rather than a flag, because [`Self::set_top_level_expr`] can
+  /// replace an array with something else and a flag could not be lowered.
+  top_level_array_count: usize,
   /// Spans of the calls that initialise a top-level declarator bound to a
   /// pattern rather than a name — `export const { foo } = stylex.create(…);`.
   /// [`Self::top_level_expressions`] is keyed by the exported name and so has
@@ -943,6 +974,7 @@ impl StateManager {
       top_level_expressions: vec![],
       top_level_call_index: Rc::default(),
       top_level_name_index: Rc::default(),
+      top_level_array_count: 0,
       pattern_bound_top_level_calls: FxHashSet::default(),
       call_expressions: CallExpressionState::default(),
       jsx_spread_attr_exprs_map: FxHashMap::default(),
@@ -1267,6 +1299,10 @@ impl StateManager {
       Rc::make_mut(&mut self.top_level_name_index).record(name.clone(), position);
     }
 
+    if matches!(expression.1, Expr::Array(_)) {
+      self.top_level_array_count += 1;
+    }
+
     self.top_level_expressions.push(expression);
   }
 
@@ -1281,6 +1317,17 @@ impl StateManager {
     // its initializer before it.
     let recorded = call_key_of(Some(&expr));
     let replaced = std::mem::replace(&mut entry.1, expr);
+    // Read while the entry is still borrowed, because the count below is a
+    // field of the same state manager.
+    let records_array = matches!(entry.1, Expr::Array(_));
+
+    // Exact rather than approximate: an entry that stops being an array lowers
+    // the count, which is what keeps [`Self::holds_top_level_array`] the answer
+    // the walk gave.
+    self.top_level_array_count = self
+      .top_level_array_count
+      .saturating_sub(usize::from(matches!(replaced, Expr::Array(_))))
+      + usize::from(records_array);
 
     // The name an entry binds does not change with its expression, so only the
     // call index needs repairing here.
@@ -2060,6 +2107,27 @@ impl StateManager {
     binds_call: impl Fn(&TopLevelExpression) -> bool,
   ) -> bool {
     self.find_top_level_expr(call).is_some() || self.top_level_expressions.iter().any(binds_call)
+  }
+
+  /// Whether any recorded top-level expression is an array literal.
+  ///
+  /// Answered from [`Self::top_level_array_count`], which is why it takes no
+  /// call: the question does not read one.
+  pub(crate) fn holds_top_level_array(&self) -> bool {
+    let found = self.top_level_array_count > 0;
+
+    debug_assert_eq!(
+      found,
+      self
+        .top_level_expressions
+        .iter()
+        .any(|recorded| matches!(recorded.1, Expr::Array(_))),
+      "`top_level_array_count` disagrees with `top_level_expressions`; something \
+       changed the list without going through `push_top_level_expression` or \
+       `set_top_level_expr`"
+    );
+
+    found
   }
 
   /// Find the top level expression recorded from *this* call node, matched by

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -479,6 +479,30 @@ impl CacheState {
   }
 }
 
+/// The structural key of `expr` where it is a call, and nothing where it is
+/// anything else -- what the call indexes are keyed by, spelled once for the
+/// four places that move an entry between keys.
+fn call_key_of(expr: Option<&Expr>) -> Option<u128> {
+  match expr {
+    Some(Expr::Call(call)) => Some(stable_hash_unspanned_call(call)),
+    _ => None,
+  }
+}
+
+/// The earliest of `candidates` that `confirm` accepts.
+///
+/// The earliest rather than the first the bucket holds: a bucket is filled in
+/// the order its entries were recorded, and moving one re-records it at the
+/// back, so only the minimum is reliably the one a walk in source order would
+/// have reached first.
+fn earliest_confirmed(candidates: &[usize], confirm: impl Fn(usize) -> bool) -> Option<usize> {
+  candidates
+    .iter()
+    .copied()
+    .filter(|position| confirm(*position))
+    .min()
+}
+
 /// Where the module's hoisted `class` and `function` declarations are, keyed by
 /// the binding each one declares.
 ///
@@ -507,30 +531,6 @@ impl CacheState {
 /// First writer wins, which is the answer the deduplicating push it replaces
 /// gave, and it is the first spelling of a name whose position a
 /// used-before-declaration diagnostic is about.
-/// The structural key of `expr` where it is a call, and nothing where it is
-/// anything else -- what the call indexes are keyed by, spelled once for the
-/// four places that move an entry between keys.
-fn call_key_of(expr: Option<&Expr>) -> Option<u128> {
-  match expr {
-    Some(Expr::Call(call)) => Some(stable_hash_unspanned_call(call)),
-    _ => None,
-  }
-}
-
-/// The earliest of `candidates` that `confirm` accepts.
-///
-/// The earliest rather than the first the bucket holds: a bucket is filled in
-/// the order its entries were recorded, and moving one re-records it at the
-/// back, so only the minimum is reliably the one a walk in source order would
-/// have reached first.
-fn earliest_confirmed(candidates: &[usize], confirm: impl Fn(usize) -> bool) -> Option<usize> {
-  candidates
-    .iter()
-    .copied()
-    .filter(|position| confirm(*position))
-    .min()
-}
-
 #[derive(Clone, Debug, Default)]
 pub(crate) struct DeclarationState {
   class_names: FxHashMap<Id, Span>,

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -648,18 +648,28 @@ pub struct StateManager {
   /// because `declarations` is append-only -- nothing removes, reorders or
   /// truncates it, and the in-place edits reach `init` rather than `name`, so a
   /// recorded position stays the position of the same binding.
-  declaration_index: FxHashMap<Id, usize>,
+  ///
+  /// Shared rather than copied -- see [`Self::declaration_call_index`].
+  declaration_index: Rc<FxHashMap<Id, usize>>,
   /// Positions in [`Self::declarations`] of the declarators initialised by a
   /// given call, so pinning a call to its declarator is a hash probe rather
   /// than a walk of every declarator in the module comparing whole call
   /// subtrees. Maintained by [`Self::push_declaration`] and
   /// [`Self::set_declaration_init`], which are the only writers of the list and
   /// of a declarator's initializer.
-  declaration_call_index: CandidateIndex<u128, usize>,
+  ///
+  /// Behind an `Rc` for the reason [`Self::binding_reassignments`] is: a dynamic
+  /// style's callback clones the whole state manager once per invocation, and
+  /// six deep-copied maps on that path is what the note there exists to prevent.
+  /// Copy-on-write rather than read-only, because these are still written after
+  /// the pre-scan -- the copy happens only where a clone records something, and
+  /// a clone made to fold a callback body records nothing.
+  declaration_call_index: Rc<CandidateIndex<u128, usize>>,
   /// Positions in [`Self::declarations`] of the declarators written at a given
   /// source position, which is what [`Self::holds_declaration`] narrows on.
   /// Maintained by [`Self::push_declaration`], the only writer of the list.
-  declaration_span_index: CandidateIndex<Span, usize>,
+  /// Shared rather than copied -- see [`Self::declaration_call_index`].
+  declaration_span_index: Rc<CandidateIndex<Span, usize>>,
   /// Bindings rebound after their declaration — an assignment, update,
   /// destructuring or loop target. The reference implementation's constant
   /// violations, probed as its own step of the reference-resolution chain.
@@ -715,7 +725,8 @@ pub struct StateManager {
   /// be a whole module's styles in one array. Keying those too cost about 50 ms
   /// on a 7.3 MB file to serve one lookup [`Self::top_level_name_index`]
   /// answers without a walk at all.
-  top_level_call_index: CandidateIndex<u128, usize>,
+  /// Shared rather than copied -- see [`Self::declaration_call_index`].
+  top_level_call_index: Rc<CandidateIndex<u128, usize>>,
   /// Positions in [`Self::top_level_expressions`] of the entries bound to each
   /// name. Maintained by [`Self::push_top_level_expression`].
   ///
@@ -723,7 +734,8 @@ pub struct StateManager {
   /// permits redeclaration: `var styles = …; var styles = …;` records two
   /// entries under one name, and keeping only the first would answer `None` for
   /// the second where the walk this replaces found it.
-  top_level_name_index: CandidateIndex<Atom, usize>,
+  /// Shared rather than copied -- see [`Self::declaration_call_index`].
+  top_level_name_index: Rc<CandidateIndex<Atom, usize>>,
   /// Spans of the calls that initialise a top-level declarator bound to a
   /// pattern rather than a name — `export const { foo } = stylex.create(…);`.
   /// [`Self::top_level_expressions`] is keyed by the exported name and so has
@@ -799,7 +811,8 @@ pub struct StateManager {
   /// call. Maintained by [`Self::insert_style_var`] and
   /// [`Self::set_style_var_init`], for the reason
   /// [`Self::declaration_call_index`] is.
-  style_var_call_index: CandidateIndex<u128, String>,
+  /// Shared rather than copied -- see [`Self::declaration_call_index`].
+  style_var_call_index: Rc<CandidateIndex<u128, String>>,
 
   /// Map of local identifier -> imported name for `@stylexjs/atoms` imports.
   /// The key includes `SyntaxContext`, so shadowed bindings with the same symbol
@@ -862,7 +875,8 @@ pub struct StateManager {
   /// Keyed by the local binding's `Id` and confirmed with `eq_ignore_span` on
   /// read, for the reason [`Self::declaration_call_index`] is: the key narrows
   /// and equality decides.
-  top_import_index: CandidateIndex<Id, (usize, usize)>,
+  /// Shared rather than copied -- see [`Self::declaration_call_index`].
+  top_import_index: Rc<CandidateIndex<Id, (usize, usize)>>,
   pub(crate) named_exports: FxHashSet<NamedExport>,
 
   pub cycle: TransformationCycle,
@@ -888,7 +902,7 @@ impl StateManager {
       local_rebinding_scopes: FxHashMap::default(),
       style_map: FxHashMap::default(),
       style_vars: FxHashMap::default(),
-      style_var_call_index: CandidateIndex::default(),
+      style_var_call_index: Rc::default(),
       atom_imports: FxHashMap::default(),
       dynamic_style_namespaces: FxHashMap::default(),
       style_vars_to_keep: IndexSet::default(),
@@ -905,21 +919,21 @@ impl StateManager {
       module_source: ModuleSourceState::default(),
 
       top_imports: vec![],
-      top_import_index: CandidateIndex::default(),
+      top_import_index: Rc::default(),
       named_exports: FxHashSet::default(),
 
       declarations: vec![],
-      declaration_index: FxHashMap::default(),
-      declaration_call_index: CandidateIndex::default(),
-      declaration_span_index: CandidateIndex::default(),
+      declaration_index: Rc::default(),
+      declaration_call_index: Rc::default(),
+      declaration_span_index: Rc::default(),
       declarations_state: DeclarationState::default(),
       binding_reassignments: Rc::default(),
       binding_mutations: Rc::default(),
       binding_deep_mutations: Rc::default(),
       declared_bindings: Rc::default(),
       top_level_expressions: vec![],
-      top_level_call_index: CandidateIndex::default(),
-      top_level_name_index: CandidateIndex::default(),
+      top_level_call_index: Rc::default(),
+      top_level_name_index: Rc::default(),
       pattern_bound_top_level_calls: FxHashSet::default(),
       call_expressions: CallExpressionState::default(),
       jsx_spread_attr_exprs_map: FxHashMap::default(),
@@ -1069,21 +1083,17 @@ impl StateManager {
     let position = self.declarations.len();
 
     if let Pat::Ident(binding) = &declarator.name {
-      self
-        .declaration_index
+      Rc::make_mut(&mut self.declaration_index)
         .entry(binding.id.to_id())
         .or_insert(position);
     }
 
     if let Some(Expr::Call(call)) = declarator.init.as_deref() {
-      self
-        .declaration_call_index
+      Rc::make_mut(&mut self.declaration_call_index)
         .record(stable_hash_unspanned_call(call), position);
     }
 
-    self
-      .declaration_span_index
-      .record(declarator.span, position);
+    Rc::make_mut(&mut self.declaration_span_index).record(declarator.span, position);
 
     self.declarations.push(declarator);
   }
@@ -1143,9 +1153,11 @@ impl StateManager {
     let recorded = call_key_of(Some(&init));
     let replaced = declarator.init.replace(Box::new(init));
 
-    self
-      .declaration_call_index
-      .move_entry(call_key_of(replaced.as_deref()), recorded, position);
+    Rc::make_mut(&mut self.declaration_call_index).move_entry(
+      call_key_of(replaced.as_deref()),
+      recorded,
+      position,
+    );
   }
 
   /// Appends an import declaration and records where each name it binds went.
@@ -1156,7 +1168,7 @@ impl StateManager {
     let position = self.top_imports.len();
 
     for (specifier_position, specifier) in import.specifiers.iter().enumerate() {
-      self.top_import_index.record(
+      Rc::make_mut(&mut self.top_import_index).record(
         local_binding_of(specifier).to_id(),
         (position, specifier_position),
       );
@@ -1232,13 +1244,12 @@ impl StateManager {
     let position = self.top_level_expressions.len();
 
     if let Expr::Call(call) = &expression.1 {
-      self
-        .top_level_call_index
+      Rc::make_mut(&mut self.top_level_call_index)
         .record(stable_hash_unspanned_call(call), position);
     }
 
     if let Some(name) = &expression.2 {
-      self.top_level_name_index.record(name.clone(), position);
+      Rc::make_mut(&mut self.top_level_name_index).record(name.clone(), position);
     }
 
     self.top_level_expressions.push(expression);
@@ -1258,9 +1269,11 @@ impl StateManager {
 
     // The name an entry binds does not change with its expression, so only the
     // call index needs repairing here.
-    self
-      .top_level_call_index
-      .move_entry(call_key_of(Some(&replaced)), recorded, position);
+    Rc::make_mut(&mut self.top_level_call_index).move_entry(
+      call_key_of(Some(&replaced)),
+      recorded,
+      position,
+    );
   }
 
   /// Records the declarator `name` is bound by, and the call it is initialised
@@ -1270,7 +1283,7 @@ impl StateManager {
     let recorded = call_key_of(declarator.init.as_deref());
     let replaced = self.style_vars.insert(name.clone(), declarator);
 
-    self.style_var_call_index.move_entry(
+    Rc::make_mut(&mut self.style_var_call_index).move_entry(
       call_key_of(replaced.as_ref().and_then(|decl| decl.init.as_deref())),
       recorded,
       name,
@@ -1288,9 +1301,11 @@ impl StateManager {
     let recorded = call_key_of(Some(&init));
     let replaced = declarator.init.replace(Box::new(init));
 
-    self
-      .style_var_call_index
-      .move_entry(call_key_of(replaced.as_deref()), recorded, name);
+    Rc::make_mut(&mut self.style_var_call_index).move_entry(
+      call_key_of(replaced.as_deref()),
+      recorded,
+      name,
+    );
   }
 
   /// The declarator binding `ident`, by hash probe rather than by scan.

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -25,12 +25,15 @@ use swc_core::{
   },
 };
 
-use crate::shared::utils::js::check_declaration::{DeclarationType, declares_ident};
+use crate::shared::utils::js::check_declaration::DeclarationType;
 use crate::shared::{
   structures::types::InjectableStylesMap,
   utils::{
     ast::{convertors::create_number_expr, helpers::namespace_name_from_member_prop},
-    common::{extract_filename_from_path, extract_filename_with_ext_from_path, extract_path},
+    common::{
+      extract_filename_from_path, extract_filename_with_ext_from_path, extract_path,
+      local_binding_of,
+    },
     validators::{is_attrs_call, is_props_call},
   },
 };
@@ -54,7 +57,6 @@ use stylex_enums::{
   counter_mode::CounterMode,
   import_path_resolution::ImportPathResolution,
   style_vars_to_keep::{NonNullProp, NonNullProps},
-  top_level_expression::TopLevelExpressionKind,
 };
 use stylex_structures::{
   style_vars_to_keep::StyleVarsToKeep, top_level_expression::TopLevelExpression,
@@ -65,6 +67,7 @@ use stylex_utils::hash::{
 };
 
 use super::{
+  candidate_index::CandidateIndex,
   key_span_index::{KeySpanIndex, ModuleBase},
   seen_value::SeenValue,
   types::{InjectImportIdents, SeenModuleSource, StylesObjectMap},
@@ -476,39 +479,85 @@ impl CacheState {
   }
 }
 
+/// Where the module's hoisted `class` and `function` declarations are, keyed by
+/// the binding each one declares.
+///
+/// A map rather than the two lists it replaces, because both questions asked of
+/// it -- does this reference name one of them, and where was it written -- are
+/// questions about a single binding, and a list answers them by walking every
+/// declaration the module holds once per reference. That is quadratic in a
+/// module of many components, and it bought nothing: the order of the lists was
+/// never read.
+///
+/// Keyed by the full `Id`, so a reference resolves to the binding its own
+/// `SyntaxContext` names rather than to whichever declaration happens to spell
+/// the same symbol first. That is what the rest of the state manager keys on --
+/// [`StateManager::declaration_index`] and the pre-scan's binding sets -- and it
+/// is the scope-aware answer, where matching the symbol alone would resolve a
+/// shadowed name to the declaration shadowing it.
+///
+/// The key *is* the equality test here, unlike the indexes that narrow and then
+/// confirm, and that is sound because an `Id` is the whole of what identifies a
+/// binding. It differs from `Ident::eq_ignore_span` in two ways that cannot
+/// separate two declarations: the `optional` flag, which a `class` or `function`
+/// declaration name never carries, and `EQ_IGNORE_SPAN_IGNORE_CTXT`, under which
+/// the comparison would stop being scope-aware and resolve a shadowed name to
+/// the declaration shadowing it -- the bug this keying exists to avoid.
+///
+/// First writer wins, which is the answer the deduplicating push it replaces
+/// gave, and it is the first spelling of a name whose position a
+/// used-before-declaration diagnostic is about.
+/// The structural key of `expr` where it is a call, and nothing where it is
+/// anything else -- what the call indexes are keyed by, spelled once for the
+/// four places that move an entry between keys.
+fn call_key_of(expr: Option<&Expr>) -> Option<u128> {
+  match expr {
+    Some(Expr::Call(call)) => Some(stable_hash_unspanned_call(call)),
+    _ => None,
+  }
+}
+
+/// The earliest of `candidates` that `confirm` accepts.
+///
+/// The earliest rather than the first the bucket holds: a bucket is filled in
+/// the order its entries were recorded, and moving one re-records it at the
+/// back, so only the minimum is reliably the one a walk in source order would
+/// have reached first.
+fn earliest_confirmed(candidates: &[usize], confirm: impl Fn(usize) -> bool) -> Option<usize> {
+  candidates
+    .iter()
+    .copied()
+    .filter(|position| confirm(*position))
+    .min()
+}
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct DeclarationState {
-  class_name_declarations: Vec<Ident>,
-  function_name_declarations: Vec<Ident>,
+  class_names: FxHashMap<Id, Span>,
+  function_names: FxHashMap<Id, Span>,
 }
 
 impl DeclarationState {
   fn add_class_name_declaration(&mut self, ident: Ident) {
-    if !self
-      .class_name_declarations
-      .iter()
-      .any(|existing| existing.eq_ignore_span(&ident))
-    {
-      self.class_name_declarations.push(ident);
-    }
+    self.class_names.entry(ident.to_id()).or_insert(ident.span);
   }
 
   fn add_function_name_declaration(&mut self, ident: Ident) {
-    if !self
-      .function_name_declarations
-      .iter()
-      .any(|existing| existing.eq_ignore_span(&ident))
-    {
-      self.function_name_declarations.push(ident);
-    }
+    self
+      .function_names
+      .entry(ident.to_id())
+      .or_insert(ident.span);
   }
 
-  fn class_name_declarations(&self) -> &[Ident] {
-    &self.class_name_declarations
+  /// Where the hoisted `class` binding `ident` names was declared, if one was.
+  fn class_name_declaration(&self, ident: &Ident) -> Option<Span> {
+    self.class_names.get(&ident.to_id()).copied()
   }
 
-  fn function_name_declarations(&self) -> &[Ident] {
-    &self.function_name_declarations
+  /// Where the hoisted `function` binding `ident` names was declared, if one
+  /// was.
+  fn function_name_declaration(&self, ident: &Ident) -> Option<Span> {
+    self.function_names.get(&ident.to_id()).copied()
   }
 }
 
@@ -597,6 +646,17 @@ pub struct StateManager {
   /// truncates it, and the in-place edits reach `init` rather than `name`, so a
   /// recorded position stays the position of the same binding.
   pub(crate) declaration_index: FxHashMap<Id, usize>,
+  /// Positions in [`Self::declarations`] of the declarators initialised by a
+  /// given call, so pinning a call to its declarator is a hash probe rather
+  /// than a walk of every declarator in the module comparing whole call
+  /// subtrees. Maintained by [`Self::push_declaration`] and
+  /// [`Self::set_declaration_init`], which are the only writers of the list and
+  /// of a declarator's initializer.
+  pub(crate) declaration_call_index: CandidateIndex<u128, usize>,
+  /// Positions in [`Self::declarations`] of the declarators written at a given
+  /// source position, which is what [`Self::holds_declaration`] narrows on.
+  /// Maintained by [`Self::push_declaration`], the only writer of the list.
+  pub(crate) declaration_span_index: CandidateIndex<Span, usize>,
   /// Bindings rebound after their declaration — an assignment, update,
   /// destructuring or loop target. The reference implementation's constant
   /// violations, probed as its own step of the reference-resolution chain.
@@ -642,6 +702,25 @@ pub struct StateManager {
   /// Shared rather than copied -- see [`Self::binding_reassignments`].
   pub(crate) declared_bindings: Rc<FxHashSet<Id>>,
   pub(crate) top_level_expressions: Vec<TopLevelExpression>,
+  /// Positions in [`Self::top_level_expressions`] of the entries that *are* a
+  /// given call. Maintained by [`Self::push_top_level_expression`] and
+  /// [`Self::set_top_level_expr`], for the reason
+  /// [`Self::declaration_call_index`] is.
+  ///
+  /// Only calls, where the list holds expressions of every shape, because a key
+  /// costs a walk of the expression it describes and a top-level expression can
+  /// be a whole module's styles in one array. Keying those too cost about 50 ms
+  /// on a 7.3 MB file to serve one lookup [`Self::top_level_name_index`]
+  /// answers without a walk at all.
+  pub(crate) top_level_call_index: CandidateIndex<u128, usize>,
+  /// Positions in [`Self::top_level_expressions`] of the entries bound to each
+  /// name. Maintained by [`Self::push_top_level_expression`].
+  ///
+  /// Every position a name binds rather than only the first, because `var`
+  /// permits redeclaration: `var styles = …; var styles = …;` records two
+  /// entries under one name, and keeping only the first would answer `None` for
+  /// the second where the walk this replaces found it.
+  pub(crate) top_level_name_index: CandidateIndex<Atom, usize>,
   /// Spans of the calls that initialise a top-level declarator bound to a
   /// pattern rather than a name — `export const { foo } = stylex.create(…);`.
   /// [`Self::top_level_expressions`] is keyed by the exported name and so has
@@ -713,6 +792,11 @@ pub struct StateManager {
   // `stylex.create` calls
   pub(crate) style_map: FxHashMap<String, Rc<StylesObjectMap>>,
   pub(crate) style_vars: FxHashMap<String, VarDeclarator>,
+  /// Names in [`Self::style_vars`] whose declarator is initialised by a given
+  /// call. Maintained by [`Self::insert_style_var`] and
+  /// [`Self::set_style_var_init`], for the reason
+  /// [`Self::declaration_call_index`] is.
+  pub(crate) style_var_call_index: CandidateIndex<u128, String>,
 
   /// Map of local identifier -> imported name for `@stylexjs/atoms` imports.
   /// The key includes `SyntaxContext`, so shadowed bindings with the same symbol
@@ -766,6 +850,16 @@ pub struct StateManager {
 
   pub(crate) other_injected_css_rules: InjectableStylesMap,
   pub(crate) top_imports: Vec<ImportDecl>,
+  /// Where in [`Self::top_imports`] the specifier binding each imported name
+  /// sits, as the import's position and the specifier's within it, so resolving
+  /// a reference to its import is a probe rather than a walk of every specifier
+  /// the module imports. Maintained by [`Self::push_top_import`], the only
+  /// writer of the list.
+  ///
+  /// Keyed by the local binding's `Id` and confirmed with `eq_ignore_span` on
+  /// read, for the reason [`Self::declaration_call_index`] is: the key narrows
+  /// and equality decides.
+  pub(crate) top_import_index: CandidateIndex<Id, (usize, usize)>,
   pub(crate) named_exports: FxHashSet<NamedExport>,
 
   pub cycle: TransformationCycle,
@@ -791,6 +885,7 @@ impl StateManager {
       local_rebinding_scopes: FxHashMap::default(),
       style_map: FxHashMap::default(),
       style_vars: FxHashMap::default(),
+      style_var_call_index: CandidateIndex::default(),
       atom_imports: FxHashMap::default(),
       dynamic_style_namespaces: FxHashMap::default(),
       style_vars_to_keep: IndexSet::default(),
@@ -807,16 +902,21 @@ impl StateManager {
       module_source: ModuleSourceState::default(),
 
       top_imports: vec![],
+      top_import_index: CandidateIndex::default(),
       named_exports: FxHashSet::default(),
 
       declarations: vec![],
       declaration_index: FxHashMap::default(),
+      declaration_call_index: CandidateIndex::default(),
+      declaration_span_index: CandidateIndex::default(),
       declarations_state: DeclarationState::default(),
       binding_reassignments: Rc::default(),
       binding_mutations: Rc::default(),
       binding_deep_mutations: Rc::default(),
       declared_bindings: Rc::default(),
       top_level_expressions: vec![],
+      top_level_call_index: CandidateIndex::default(),
+      top_level_name_index: CandidateIndex::default(),
       pattern_bound_top_level_calls: FxHashSet::default(),
       call_expressions: CallExpressionState::default(),
       jsx_spread_attr_exprs_map: FxHashMap::default(),
@@ -914,11 +1014,11 @@ impl StateManager {
   /// for by cloning both lists on the path every dynamic style's parameter
   /// takes.
   pub(crate) fn declared_as(&self, ident: &Ident) -> Option<DeclarationType> {
-    if declares_ident(self.class_name_declarations(), ident) {
+    if self.class_name_declaration(ident).is_some() {
       return Some(DeclarationType::Class);
     }
 
-    if declares_ident(self.function_name_declarations(), ident) {
+    if self.function_name_declaration(ident).is_some() {
       return Some(DeclarationType::Function);
     }
 
@@ -947,14 +1047,229 @@ impl StateManager {
   /// the binding it added invisible to [`Self::declaration_of`], which is what
   /// the three test builders that did so discovered.
   pub(crate) fn push_declaration(&mut self, declarator: VarDeclarator) {
+    let position = self.declarations.len();
+
     if let Pat::Ident(binding) = &declarator.name {
       self
         .declaration_index
         .entry(binding.id.to_id())
-        .or_insert(self.declarations.len());
+        .or_insert(position);
     }
 
+    if let Some(Expr::Call(call)) = declarator.init.as_deref() {
+      self
+        .declaration_call_index
+        .record(stable_hash_unspanned_call(call), position);
+    }
+
+    self
+      .declaration_span_index
+      .record(declarator.span, position);
+
     self.declarations.push(declarator);
+  }
+
+  /// Whether a declarator written at `declarator`'s position and reading the
+  /// same is already recorded -- the question the discovery cycle asks before
+  /// storing one.
+  ///
+  /// Position decides first and content second, which is the order the walk
+  /// this replaces used: the same declaration seen on more than one discovery
+  /// pass carries the same span and is stored once, while two declarations that
+  /// merely read alike, `var m = f(); var m = f();`, stay two entries, as a
+  /// lookup that pins a call to its declarator by span needs them to be.
+  ///
+  /// The span narrows and `eq_ignore_span` still decides, which is what settles
+  /// the synthesized declarators that share `DUMMY_SP`. Every caller runs over
+  /// the parsed module, where a span is a real position and so narrows to at
+  /// most a handful.
+  pub(crate) fn holds_declaration(&self, declarator: &VarDeclarator) -> bool {
+    let found = self
+      .declaration_span_index
+      .candidates(|| declarator.span)
+      .iter()
+      .any(|position| {
+        self
+          .declarations
+          .get(*position)
+          .is_some_and(|recorded| recorded.eq_ignore_span(declarator))
+      });
+
+    debug_assert_eq!(
+      found,
+      self.declarations.iter().any(|recorded| {
+        recorded.span == declarator.span && recorded.eq_ignore_span(declarator)
+      }),
+      "`declaration_span_index` disagrees with `declarations`; something grew \
+       the list without going through `push_declaration`"
+    );
+
+    found
+  }
+
+  /// Replaces the initializer of the declarator at `position`, keeping the call
+  /// index beside it in step.
+  ///
+  /// The one way a recorded declarator's initializer changes, because the index
+  /// is keyed by that initializer: replacing it in place leaves the declarator
+  /// findable under the call it no longer holds, and unfindable under the one it
+  /// now does.
+  pub(crate) fn set_declaration_init(&mut self, position: usize, init: Expr) {
+    let Some(declarator) = self.declarations.get_mut(position) else {
+      return;
+    };
+
+    let replaced = declarator.init.replace(Box::new(init));
+
+    self.declaration_call_index.move_entry(
+      call_key_of(replaced.as_deref()),
+      call_key_of(self.declarations[position].init.as_deref()),
+      position,
+    );
+  }
+
+  /// Appends an import declaration and records where each name it binds went.
+  ///
+  /// Every caller that grows [`Self::top_imports`] goes through here, for the
+  /// reason [`Self::push_declaration`] exists.
+  pub(crate) fn push_top_import(&mut self, import: ImportDecl) {
+    let position = self.top_imports.len();
+
+    for (specifier_position, specifier) in import.specifiers.iter().enumerate() {
+      self.top_import_index.record(
+        local_binding_of(specifier).to_id(),
+        (position, specifier_position),
+      );
+    }
+
+    self.top_imports.push(import);
+  }
+
+  /// The import declaration and the specifier that bind `ident`, earliest
+  /// first.
+  ///
+  /// The two travel together because the caller that asks *whether* an import
+  /// binds a reference immediately asks *which specifier* did -- a named
+  /// specifier resolves to a theme reference where a default one is refused. A
+  /// second search for the specifier could come back empty and leave the caller
+  /// holding an unanswerable case.
+  ///
+  /// The binding, not the name: a reference and an import specifier are the
+  /// same thing only when their `SyntaxContext` agrees too. Matching on the
+  /// symbol alone resolved a *shadowing* binding -- an arrow parameter carries a
+  /// context of its own -- to the import it shadows, so a dynamic style whose
+  /// parameter is named after an imported theme answered a confident `ThemeRef`
+  /// and aborted the build (#1266).
+  ///
+  /// The local binding is the only name asked about. A specifier's *imported*
+  /// name binds nothing in this module -- `import { spacing as sp }` leaves
+  /// `spacing` unbound here -- so a reference spelled that way names something
+  /// else, or nothing at all, and resolving it to the import it was aliased away
+  /// from is not a resolution the language allows.
+  pub(crate) fn import_binding(&self, ident: &Ident) -> Option<(&ImportDecl, &ImportSpecifier)> {
+    let found = self
+      .top_import_index
+      .candidates(|| ident.to_id())
+      .iter()
+      .filter(|(import, specifier)| {
+        self
+          .specifier_at(*import, *specifier)
+          .is_some_and(|specifier| local_binding_of(specifier).eq_ignore_span(ident))
+      })
+      .min()
+      .and_then(|(import, specifier)| {
+        Some((
+          self.top_imports.get(*import)?,
+          self.specifier_at(*import, *specifier)?,
+        ))
+      });
+
+    debug_assert_eq!(
+      found.is_some(),
+      self.top_imports.iter().any(|import| {
+        import
+          .specifiers
+          .iter()
+          .any(|specifier| local_binding_of(specifier).eq_ignore_span(ident))
+      }),
+      "`top_import_index` disagrees with `top_imports` about `{}`; something \
+       grew the list without going through `push_top_import`",
+      ident.sym
+    );
+
+    found
+  }
+
+  fn specifier_at(&self, import: usize, specifier: usize) -> Option<&ImportSpecifier> {
+    self.top_imports.get(import)?.specifiers.get(specifier)
+  }
+
+  /// Appends a top-level expression and records the call it is, if it is one.
+  ///
+  /// Every caller that grows [`Self::top_level_expressions`] goes through here,
+  /// for the reason [`Self::push_declaration`] exists.
+  pub(crate) fn push_top_level_expression(&mut self, expression: TopLevelExpression) {
+    let position = self.top_level_expressions.len();
+
+    if let Expr::Call(call) = &expression.1 {
+      self
+        .top_level_call_index
+        .record(stable_hash_unspanned_call(call), position);
+    }
+
+    if let Some(name) = &expression.2 {
+      self.top_level_name_index.record(name.clone(), position);
+    }
+
+    self.top_level_expressions.push(expression);
+  }
+
+  /// Replaces the expression recorded at `position`, keeping the call index in
+  /// step. See [`Self::set_declaration_init`] for why it is the one way.
+  pub(crate) fn set_top_level_expr(&mut self, position: usize, expr: Expr) {
+    let Some(recorded) = self.top_level_expressions.get_mut(position) else {
+      return;
+    };
+
+    let replaced = std::mem::replace(&mut recorded.1, expr);
+
+    // The name an entry binds does not change with its expression, so only the
+    // call index needs repairing here.
+    self.top_level_call_index.move_entry(
+      call_key_of(Some(&replaced)),
+      call_key_of(Some(&self.top_level_expressions[position].1)),
+      position,
+    );
+  }
+
+  /// Records the declarator `name` is bound by, and the call it is initialised
+  /// by. The one way [`Self::style_vars`] grows, for the reason
+  /// [`Self::push_declaration`] is the one way `declarations` does.
+  pub(crate) fn insert_style_var(&mut self, name: String, declarator: VarDeclarator) {
+    let replaced = self.style_vars.insert(name.clone(), declarator);
+
+    self.style_var_call_index.move_entry(
+      call_key_of(replaced.as_ref().and_then(|decl| decl.init.as_deref())),
+      call_key_of(self.style_vars[&name].init.as_deref()),
+      name,
+    );
+  }
+
+  /// Replaces the initializer of the declarator bound to `name`, keeping the
+  /// call index in step. See [`Self::set_declaration_init`] for why it is the
+  /// one way.
+  pub(crate) fn set_style_var_init(&mut self, name: String, init: Expr) {
+    let Some(declarator) = self.style_vars.get_mut(&name) else {
+      return;
+    };
+
+    let replaced = declarator.init.replace(Box::new(init));
+
+    self.style_var_call_index.move_entry(
+      call_key_of(replaced.as_deref()),
+      call_key_of(self.style_vars[&name].init.as_deref()),
+      name,
+    );
   }
 
   /// The declarator binding `ident`, by hash probe rather than by scan.
@@ -1028,12 +1343,15 @@ impl StateManager {
     self.declarations_state.add_function_name_declaration(ident);
   }
 
-  pub(crate) fn class_name_declarations(&self) -> &[Ident] {
-    self.declarations_state.class_name_declarations()
+  /// Where the hoisted `class` binding `ident` names was declared, if one was.
+  pub(crate) fn class_name_declaration(&self, ident: &Ident) -> Option<Span> {
+    self.declarations_state.class_name_declaration(ident)
   }
 
-  pub(crate) fn function_name_declarations(&self) -> &[Ident] {
-    self.declarations_state.function_name_declarations()
+  /// Where the hoisted `function` binding `ident` names was declared, if one
+  /// was.
+  pub(crate) fn function_name_declaration(&self, ident: &Ident) -> Option<Span> {
+    self.declarations_state.function_name_declaration(ident)
   }
 
   pub(crate) fn has_import_paths(&self) -> bool {
@@ -1578,17 +1896,105 @@ impl StateManager {
     }
   }
 
-  pub(crate) fn find_top_level_expr(
+  /// The recorded top-level expression that *is* `call`, earliest first.
+  ///
+  /// Answered from [`Self::top_level_call_index`]: the key narrows to the
+  /// entries that may be this call and `eq_ignore_span` decides between them,
+  /// which is the answer the walk over every recorded expression gave.
+  pub(crate) fn find_top_level_expr(&self, call: &CallExpr) -> Option<&TopLevelExpression> {
+    let found = self
+      .find_top_level_expr_index(call)
+      .and_then(|position| self.top_level_expressions.get(position));
+
+    debug_assert_eq!(
+      found.is_some(),
+      self
+        .top_level_expressions
+        .iter()
+        .any(|tpe| matches!(tpe.1, Expr::Call(ref recorded) if recorded.eq_ignore_span(call))),
+      "`top_level_call_index` disagrees with `top_level_expressions`; something \
+       changed the list without going through `push_top_level_expression` or \
+       `set_top_level_expr`"
+    );
+
+    found
+  }
+
+  /// Position of the earliest recorded top-level expression that is `call`.
+  fn find_top_level_expr_index(&self, call: &CallExpr) -> Option<usize> {
+    earliest_confirmed(
+      self
+        .top_level_call_index
+        .candidates(|| stable_hash_unspanned_call(call)),
+      |position| {
+        matches!(self.top_level_expressions.get(position),
+          Some(TopLevelExpression(_, Expr::Call(recorded), _)) if recorded.eq_ignore_span(call))
+      },
+    )
+  }
+
+  /// The recorded top-level expression bound to `name`, if it reads as `expr`
+  /// does.
+  ///
+  /// Found by the name it binds rather than by the expression it holds, which is
+  /// what a walk of every recorded expression comparing whole subtrees used to
+  /// decide. The name is the sharper question of the two, and the walk conflated
+  /// two things it separates: where two declarators hold structurally identical
+  /// initializers, the walk answered with whichever came first, so a
+  /// `const styles = create({…})` beside an *exported* declarator spelling the
+  /// same styles read the export's kind and skipped a pruning that was its own
+  /// to do. Every position a name binds is a candidate, because `var` permits
+  /// redeclaration, and `eq_ignore_span` still confirms -- so an entry whose
+  /// expression has moved on since answers `None` as the walk did.
+  pub(crate) fn find_top_level_expr_named(
+    &self,
+    name: &Atom,
+    expr: &Expr,
+  ) -> Option<&TopLevelExpression> {
+    let position = earliest_confirmed(
+      self.top_level_name_index.candidates(|| name.clone()),
+      |position| {
+        self
+          .top_level_expressions
+          .get(position)
+          .is_some_and(|recorded| recorded.1.eq_ignore_span(expr))
+      },
+    )?;
+
+    self.top_level_expressions.get(position)
+  }
+
+  /// The style variable bound to `name`, if its declarator reads as
+  /// `declarator` does.
+  ///
+  /// [`Self::style_vars`] is keyed by the name its declarator binds, so the
+  /// entry that can equal `declarator` is the one under `declarator`'s own name
+  /// -- which is what turns the walk of every style variable in the module into
+  /// a probe. `eq_ignore_span` still decides, so a name rebound to something
+  /// else answers `None` as the walk did.
+  pub(crate) fn matching_style_var(&self, declarator: &VarDeclarator) -> Option<&VarDeclarator> {
+    let name = declarator.name.as_ident()?;
+
+    self
+      .style_vars
+      .get(name.sym.as_str())
+      .filter(|recorded| declarator.eq_ignore_span(recorded))
+  }
+
+  /// Whether the module records `call` at program level, either as a top-level
+  /// expression of its own or inside one that `binds_call` recognises.
+  ///
+  /// The two are asked together because the answer is a yes or a no rather than
+  /// an entry: `binds_call` covers the shapes that *hold* a call without being
+  /// it -- an array literal of styles, a member access on the call -- and no
+  /// key can find those, so they stay a walk. It is a cheap one, and it only
+  /// runs when the indexed lookup has already missed.
+  pub(crate) fn has_top_level_expr(
     &self,
     call: &CallExpr,
-    extended_predicate_fn: impl Fn(&TopLevelExpression) -> bool,
-    kind: Option<TopLevelExpressionKind>,
-  ) -> Option<&TopLevelExpression> {
-    self.top_level_expressions.iter().find(|tpe| {
-      kind.is_none_or(|kind| tpe.0 == kind)
-        && (matches!(tpe.1, Expr::Call(ref c) if c.eq_ignore_span(call))
-          || extended_predicate_fn(tpe))
-    })
+    binds_call: impl Fn(&TopLevelExpression) -> bool,
+  ) -> bool {
+    self.find_top_level_expr(call).is_some() || self.top_level_expressions.iter().any(binds_call)
   }
 
   /// Find the top level expression recorded from *this* call node, matched by
@@ -1650,13 +2056,58 @@ impl StateManager {
       .get(self.find_call_declaration_index_by_span(call)?)
   }
 
+  /// The declarator `call` initialises, earliest first.
+  ///
+  /// Answered from [`Self::declaration_call_index`] rather than by walking every
+  /// declarator the module holds and comparing whole call subtrees. Asked once
+  /// per `stylex.*` call, that walk was the largest single cost in the
+  /// transform of a module of many components -- and the calls it answers `None`
+  /// for, every `stylex.props` site among them, were the ones that paid for the
+  /// whole of it.
   pub(crate) fn find_call_declaration(&self, call: &CallExpr) -> Option<&VarDeclarator> {
-    self.declarations.iter().find(|decl| {
-      decl
-        .init
-        .as_ref()
-        .is_some_and(|expr| matches!(**expr, Expr::Call(ref c) if c.eq_ignore_span(call)))
-    })
+    let found = self
+      .find_call_declaration_index(call)
+      .and_then(|position| self.declarations.get(position));
+
+    debug_assert_eq!(
+      found.is_some(),
+      self.declarations.iter().any(|decl| {
+        matches!(decl.init.as_deref(), Some(Expr::Call(recorded)) if recorded.eq_ignore_span(call))
+      }),
+      "`declaration_call_index` disagrees with `declarations`; something changed \
+       the list without going through `push_declaration` or `set_declaration_init`"
+    );
+
+    found
+  }
+
+  /// Position of the earliest declarator `call` initialises.
+  fn find_call_declaration_index(&self, call: &CallExpr) -> Option<usize> {
+    earliest_confirmed(
+      self
+        .declaration_call_index
+        .candidates(|| stable_hash_unspanned_call(call)),
+      |position| {
+        matches!(self.declarations.get(position).and_then(|decl| decl.init.as_deref()),
+          Some(Expr::Call(recorded)) if recorded.eq_ignore_span(call))
+      },
+    )
+  }
+
+  /// Name of the style variable `call` initialises.
+  ///
+  /// Unordered, unlike the two lookups above: [`Self::style_vars`] is a map, so
+  /// the walk this replaces had no order to preserve either.
+  fn find_style_var_name(&self, call: &CallExpr) -> Option<String> {
+    self
+      .style_var_call_index
+      .candidates(|| stable_hash_unspanned_call(call))
+      .iter()
+      .find(|name| {
+        matches!(self.style_vars.get(*name).and_then(|decl| decl.init.as_deref()),
+          Some(Expr::Call(recorded)) if recorded.eq_ignore_span(call))
+      })
+      .cloned()
   }
 
   pub(crate) fn register_styles(
@@ -1802,26 +2253,16 @@ impl StateManager {
   }
 
   fn update_references(&mut self, call: &CallExpr, ast: &Expr, _fallback_ast: Option<&Expr>) {
-    if let Some(item) = self.declarations.iter_mut().find(|decl| {
-      decl.init.as_ref().is_some_and(|expr| {
-        matches!(**expr, Expr::Call(ref existing_call) if existing_call.eq_ignore_span(call))
-      })
-    }) {
-      item.init = Some(Box::new(ast.clone()));
+    if let Some(position) = self.find_call_declaration_index(call) {
+      self.set_declaration_init(position, ast.clone());
     }
 
-    if let Some((_, item)) = self.style_vars.iter_mut().find(|(_, decl)| {
-      decl.init.as_ref().is_some_and(|expr| {
-        matches!(**expr, Expr::Call(ref existing_call) if existing_call.eq_ignore_span(call))
-      })
-    }) {
-      item.init = Some(Box::new(ast.clone()));
+    if let Some(name) = self.find_style_var_name(call) {
+      self.set_style_var_init(name, ast.clone());
     }
 
-    if let Some(top_level_expr) = self.top_level_expressions.iter_mut().find(
-      |TopLevelExpression(_, expr, _)| matches!(expr, Expr::Call(c) if c.eq_ignore_span(call)),
-    ) {
-      top_level_expr.1 = ast.clone();
+    if let Some(position) = self.find_top_level_expr_index(call) {
+      self.set_top_level_expr(position, ast.clone());
     }
 
     self.call_expressions.replace_call_expression(call, ast);

--- a/crates/stylex-transform/src/shared/structures/state_manager.rs
+++ b/crates/stylex-transform/src/shared/structures/state_manager.rs
@@ -294,59 +294,78 @@ impl ModuleSourceState {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CallExpressionState {
   all_call_expressions: FxHashMap<u128, Callee>,
-  /// How many entries of [`Self::all_call_expressions`] have a member
-  /// expression for a callee, counted per structural key of that member.
+  /// The member expressions that are the callee of some entry of
+  /// [`Self::all_call_expressions`], bucketed by their structural key.
   ///
-  /// This is an index over the callees, and the whole of what
-  /// [`Self::is_member_callee`] needs. Without it that question was answered by
-  /// scanning every call in the module and comparing whole `MemberExpr`
-  /// subtrees with `eq_ignore_span`. It is asked once per member expression the
-  /// evaluator visits, so the scan made the consumer phase quadratic in the
-  /// number of calls a module makes: on a 1,500-component JSX module it grew
-  /// 3.6x for every doubling of the input and reached 41% of total compile
-  /// time.
+  /// The whole of what [`Self::is_member_callee`] needs. Without it that
+  /// question was answered by walking every call in the module and comparing
+  /// whole `MemberExpr` subtrees, once per member expression the evaluator
+  /// visits -- which made the consumer phase quadratic in the number of calls
+  /// a module makes. On a 1,500-component JSX module it grew 3.6x for every
+  /// doubling of the input and reached 41% of total compile time.
   ///
-  /// Counted rather than held as a set because the map collapses structurally
+  /// A bucket of members rather than a bare key, because the key narrows and
+  /// [`EqIgnoreSpan`] still decides: this is the shape
+  /// `adr/0005` calls "narrow a bucket by hash and then confirm", and it is
+  /// what keeps the answer the same one the walk gave. Answering on a hash hit
+  /// alone would make this a fifth consumer for which the key *is* the equality
+  /// test, which is a decision that ADR owns rather than this index.
+  ///
+  /// Confirming is also what keeps the answer right under
+  /// `EQ_IGNORE_SPAN_IGNORE_CTXT`: the key hashes an identifier's
+  /// `SyntaxContext` while `eq_ignore_span` ignores it inside that scope, so
+  /// the key alone would refuse a match the walk made. Nothing sets that flag
+  /// today; confirming means nothing has to remember this if something does.
+  ///
+  /// Held as a list rather than a set because the map collapses structurally
   /// equal calls onto one entry while two *different* calls can still share a
-  /// callee — `a.b(1)` and `a.b(2)`. A plain set would drop `a.b` when either
-  /// one of them is replaced, and `is_member_callee` would start answering
-  /// `false` for a callee that is still live.
-  ///
-  /// Keyed by the same 128-bit structural hash that keys the map itself, so a
-  /// collision was already able to conflate two calls before this existed; the
-  /// index widens nothing.
-  callee_member_keys: FxHashMap<u128, u32>,
+  /// callee -- `a.b(1)` and `a.b(2)`. Dropping `a.b` when either one of them is
+  /// replaced would leave [`Self::is_member_callee`] answering `false` for a
+  /// callee that is still live.
+  callee_members: FxHashMap<u128, Vec<MemberExpr>>,
 }
 
 impl CallExpressionState {
   fn add_call_expression(&mut self, call_expr: &CallExpr) {
     let key = stable_hash_unspanned_call(call_expr);
     let callee = call_expr.callee.clone();
-    let member_key = Self::callee_member_key(&callee);
+    let member = Self::callee_member(&callee).cloned();
 
     // `insert` overwrites, so an existing entry's callee leaves the map here
-    // and its count has to go with it.
-    if let Some(replaced) = self.all_call_expressions.insert(key, callee) {
-      self.release_member_key(Self::callee_member_key(&replaced));
+    // and its bucket entry has to go with it.
+    if let Some(replaced) = self.all_call_expressions.insert(key, callee)
+      && let Some(replaced) = Self::callee_member(&replaced)
+    {
+      self.release_member(replaced);
     }
 
-    if let Some(member_key) = member_key {
-      *self.callee_member_keys.entry(member_key).or_default() += 1;
+    if let Some(member) = member {
+      self
+        .callee_members
+        .entry(stable_hash_unspanned_member(&member))
+        .or_default()
+        .push(member);
     }
   }
 
   fn is_member_callee(&self, member: &MemberExpr) -> bool {
     self
-      .callee_member_keys
-      .contains_key(&stable_hash_unspanned_member(member))
+      .callee_members
+      .get(&stable_hash_unspanned_member(member))
+      .is_some_and(|bucket| {
+        bucket
+          .iter()
+          .any(|candidate| candidate.eq_ignore_span(member))
+      })
   }
 
   fn replace_call_expression(&mut self, call: &CallExpr, ast: &Expr) {
     if let Some(removed) = self
       .all_call_expressions
       .remove(&stable_hash_unspanned_call(call))
+      && let Some(removed) = Self::callee_member(&removed)
     {
-      self.release_member_key(Self::callee_member_key(&removed));
+      self.release_member(removed);
     }
 
     if let Some(call_expr) = ast.as_call() {
@@ -354,30 +373,38 @@ impl CallExpressionState {
     }
   }
 
-  /// The structural key of `callee`, where the callee is a member expression.
-  fn callee_member_key(callee: &Callee) -> Option<u128> {
+  /// The member expression `callee` is, where it is one.
+  fn callee_member(callee: &Callee) -> Option<&MemberExpr> {
     match callee {
       Callee::Expr(expr) => match expr.as_ref() {
-        Expr::Member(member) => Some(stable_hash_unspanned_member(member)),
+        Expr::Member(member) => Some(member),
         _ => None,
       },
       _ => None,
     }
   }
 
-  /// Drop one reference to `key`, forgetting it once nothing holds it.
-  fn release_member_key(&mut self, key: Option<u128>) {
-    let Some(key) = key else {
+  /// Drops one occurrence of `member` from its bucket, forgetting the bucket
+  /// once nothing holds it.
+  fn release_member(&mut self, member: &MemberExpr) {
+    let Entry::Occupied(mut occupied) = self
+      .callee_members
+      .entry(stable_hash_unspanned_member(member))
+    else {
       return;
     };
 
-    if let Entry::Occupied(mut occupied) = self.callee_member_keys.entry(key) {
-      match occupied.get_mut() {
-        1 => {
-          occupied.remove();
-        },
-        count => *count -= 1,
-      }
+    let bucket = occupied.get_mut();
+
+    if let Some(position) = bucket
+      .iter()
+      .position(|candidate| candidate.eq_ignore_span(member))
+    {
+      bucket.remove(position);
+    }
+
+    if bucket.is_empty() {
+      occupied.remove();
     }
   }
 }

--- a/crates/stylex-transform/src/shared/structures/tests/candidate_index_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/candidate_index_test.rs
@@ -110,6 +110,34 @@ mod candidate_index {
     assert_eq!(index.candidates(|| OTHER_KEY), [1]);
   }
 
+  /// The bucket `forget` removed has to come back, not stay gone: a declarator
+  /// whose initializer is replaced and then replaced with the call it first held
+  /// takes exactly this path.
+  /// `a_handle_can_be_recorded_again_after_being_forgotten` re-records under a
+  /// *different* key, so it never exercises it.
+  #[test]
+  fn a_key_whose_bucket_was_removed_can_be_recorded_under_again() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, 1usize);
+    index.forget(&KEY, &1);
+    index.record(KEY, 1);
+
+    assert_eq!(index.candidates(|| KEY), [1]);
+  }
+
+  /// `set_declaration_init` produces this shape whenever a non-call initializer
+  /// is replaced by a call: a key to leave that never held the handle.
+  #[test]
+  fn moving_an_entry_that_was_never_under_the_key_it_leaves_still_joins_the_new_one() {
+    let mut index = CandidateIndex::default();
+
+    index.record(OTHER_KEY, 2usize);
+    index.move_entry(Some(KEY), Some(OTHER_KEY), 1usize);
+
+    assert_eq!(index.candidates(|| OTHER_KEY), [2, 1]);
+  }
+
   #[test]
   fn computes_no_key_while_the_index_holds_nothing() {
     let index: CandidateIndex<u128, usize> = CandidateIndex::default();

--- a/crates/stylex-transform/src/shared/structures/tests/candidate_index_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/candidate_index_test.rs
@@ -1,0 +1,240 @@
+#[cfg(test)]
+mod candidate_index {
+  use std::cell::Cell;
+
+  use crate::shared::structures::candidate_index::CandidateIndex;
+
+  /// A key the tests can spell without building an expression, since the index
+  /// never derives one itself.
+  const KEY: u128 = 0x1234_5678_9abc_def0_1234_5678_9abc_def0;
+  const OTHER_KEY: u128 = 1;
+
+  #[test]
+  fn hands_back_nothing_before_anything_is_recorded() {
+    let index: CandidateIndex<u128, usize> = CandidateIndex::default();
+
+    assert!(index.candidates(|| KEY).is_empty());
+  }
+
+  #[test]
+  fn hands_back_the_handles_recorded_under_a_key() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, 7usize);
+    index.record(KEY, 9);
+
+    assert_eq!(index.candidates(|| KEY), [7, 9]);
+  }
+
+  #[test]
+  fn keeps_the_order_handles_were_recorded_in() {
+    let mut index = CandidateIndex::default();
+
+    for handle in [9usize, 3, 5] {
+      index.record(KEY, handle);
+    }
+
+    assert_eq!(index.candidates(|| KEY), [9, 3, 5]);
+  }
+
+  #[test]
+  fn records_a_handle_once_however_often_it_is_offered() {
+    let mut index = CandidateIndex::default();
+
+    for _ in 0..100 {
+      index.record(KEY, 4usize);
+    }
+
+    assert_eq!(index.candidates(|| KEY), [4]);
+  }
+
+  #[test]
+  fn keeps_keys_apart() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, 1usize);
+    index.record(OTHER_KEY, 2);
+
+    assert_eq!(index.candidates(|| KEY), [1]);
+    assert_eq!(index.candidates(|| OTHER_KEY), [2]);
+  }
+
+  #[test]
+  fn forgetting_drops_only_the_handle_named() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, 1usize);
+    index.record(KEY, 2);
+    index.forget(&KEY, &1);
+
+    assert_eq!(index.candidates(|| KEY), [2]);
+  }
+
+  #[test]
+  fn forgetting_the_last_handle_empties_the_index() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, 1usize);
+    index.forget(&KEY, &1);
+
+    // Not merely absent from its bucket: an index that kept an empty bucket
+    // would stop answering for free, which is the whole of what the empty case
+    // buys.
+    assert!(
+      index
+        .candidates(|| panic!("an empty index must not compute a key"))
+        .is_empty()
+    );
+  }
+
+  #[test]
+  fn forgetting_what_was_never_recorded_changes_nothing() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, 1usize);
+    index.forget(&KEY, &2);
+    index.forget(&OTHER_KEY, &1);
+
+    assert_eq!(index.candidates(|| KEY), [1]);
+  }
+
+  #[test]
+  fn a_handle_can_be_recorded_again_after_being_forgotten() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, 1usize);
+    index.forget(&KEY, &1);
+    index.record(OTHER_KEY, 1);
+
+    assert!(index.candidates(|| KEY).is_empty());
+    assert_eq!(index.candidates(|| OTHER_KEY), [1]);
+  }
+
+  #[test]
+  fn computes_no_key_while_the_index_holds_nothing() {
+    let index: CandidateIndex<u128, usize> = CandidateIndex::default();
+    let computed = Cell::new(0);
+
+    index.candidates(|| {
+      computed.set(computed.get() + 1);
+      KEY
+    });
+
+    assert_eq!(computed.get(), 0);
+  }
+
+  #[test]
+  fn computes_the_key_once_when_the_index_holds_something() {
+    let mut index = CandidateIndex::default();
+    let computed = Cell::new(0);
+
+    index.record(OTHER_KEY, 1usize);
+    index.candidates(|| {
+      computed.set(computed.get() + 1);
+      KEY
+    });
+
+    assert_eq!(computed.get(), 1);
+  }
+
+  #[test]
+  fn holds_a_name_as_readily_as_a_position() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, String::from("styles"));
+    index.record(KEY, String::from("other"));
+    index.forget(&KEY, &String::from("styles"));
+
+    assert_eq!(index.candidates(|| KEY), [String::from("other")]);
+  }
+
+  /// A key that is not a hash at all, which is what the declaration and
+  /// top-level-name indexes are keyed by.
+  #[test]
+  fn narrows_on_a_key_that_is_not_a_hash() {
+    let mut index: CandidateIndex<&str, usize> = CandidateIndex::default();
+
+    index.record("styles", 0);
+    index.record("styles", 4);
+    index.record("theme", 1);
+
+    assert_eq!(index.candidates(|| "styles"), [0, 4]);
+    assert_eq!(index.candidates(|| "theme"), [1]);
+    assert!(index.candidates(|| "absent").is_empty());
+  }
+
+  #[test]
+  fn moving_an_entry_forgets_the_key_it_left_and_records_the_one_it_joined() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, 1usize);
+    index.move_entry(Some(KEY), Some(OTHER_KEY), 1);
+
+    assert!(index.candidates(|| KEY).is_empty());
+    assert_eq!(index.candidates(|| OTHER_KEY), [1]);
+  }
+
+  /// The ordering the method exists to encode: forgetting runs first, so an
+  /// entry that moves to the key it already held keeps its record.
+  #[test]
+  fn moving_an_entry_to_the_key_it_already_held_keeps_it() {
+    let mut index = CandidateIndex::default();
+
+    index.record(KEY, 1usize);
+    index.move_entry(Some(KEY), Some(KEY), 1);
+
+    assert_eq!(index.candidates(|| KEY), [1]);
+  }
+
+  #[test]
+  fn moving_an_entry_from_or_to_nothing_touches_only_the_side_given() {
+    let mut index = CandidateIndex::default();
+
+    // An entry that had no key joins one.
+    index.move_entry(None, Some(KEY), 1usize);
+    assert_eq!(index.candidates(|| KEY), [1]);
+
+    // And one that gains no key leaves the one it had.
+    index.move_entry(Some(KEY), None, 1);
+    assert!(index.candidates(|| KEY).is_empty());
+
+    // Neither side is a no-op rather than a panic.
+    index.move_entry(None, None, 1);
+    assert!(index.candidates(|| KEY).is_empty());
+  }
+
+  /// Far past any module, to show the bucket that answers is the one the key
+  /// names rather than a walk of everything recorded.
+  #[test]
+  fn stays_exact_across_a_hundred_thousand_keys() {
+    let mut index = CandidateIndex::default();
+
+    for handle in 0..100_000u128 {
+      index.record(handle, handle as usize);
+    }
+
+    assert_eq!(index.candidates(|| 0), [0]);
+    assert_eq!(index.candidates(|| 99_999), [99_999]);
+    assert!(index.candidates(|| 100_000).is_empty());
+  }
+
+  /// One key that every entry shares -- the worst a collision or a module of
+  /// identical calls can do. The index still answers, and still answers with
+  /// everything, because narrowing is all it promises: equality is the caller's.
+  #[test]
+  fn a_bucket_every_handle_shares_still_hands_back_all_of_them() {
+    let mut index = CandidateIndex::default();
+
+    for handle in 0..1_000usize {
+      index.record(KEY, handle);
+    }
+
+    assert_eq!(index.candidates(|| KEY).len(), 1_000);
+
+    for handle in 0..1_000usize {
+      index.forget(&KEY, &handle);
+    }
+
+    assert!(index.candidates(|| KEY).is_empty());
+  }
+}

--- a/crates/stylex-transform/src/shared/structures/tests/mod.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/mod.rs
@@ -1,3 +1,4 @@
+mod candidate_index_test;
 mod flatten_raw_style_objects_test;
 mod gen_css_test;
 mod get_canonical_file_path_test;

--- a/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
@@ -454,10 +454,7 @@ mod state_manager {
       .push(var_declarator("second", Expr::Call(second.clone())));
 
     assert_eq!(
-      state
-        .find_call_declaration_by_span(&second)
-        .and_then(|decl| decl.name.as_ident())
-        .map(|ident| ident.sym.as_str()),
+      bound_name(state.find_call_declaration_by_span(&second)),
       Some("second")
     );
     assert!(
@@ -560,6 +557,22 @@ mod state_manager {
     }
   }
 
+  /// A call that carries both content and a position, so the two lookups can be
+  /// asked about the same node.
+  fn call_of_at(name: &str, argument: &str, span: Span) -> CallExpr {
+    CallExpr {
+      span,
+      ..call_of(name, argument)
+    }
+  }
+
+  /// The name a found declarator binds, for assertions that only care about it.
+  fn bound_name(declarator: Option<&VarDeclarator>) -> Option<&str> {
+    declarator
+      .and_then(|decl| decl.name.as_ident())
+      .map(|ident| ident.sym.as_str())
+  }
+
   fn declarator_at(name: &str, span: Span, init: Expr) -> VarDeclarator {
     VarDeclarator {
       span,
@@ -579,10 +592,7 @@ mod state_manager {
     state.push_declaration(var_declarator("plain", string_expr("no call here")));
 
     assert_eq!(
-      state
-        .find_call_declaration(&second)
-        .and_then(|decl| decl.name.as_ident())
-        .map(|ident| ident.sym.as_str()),
+      bound_name(state.find_call_declaration(&second)),
       Some("second")
     );
     assert!(
@@ -604,11 +614,87 @@ mod state_manager {
     // Two declarators can hold structurally equal calls, and the walk this
     // replaced answered with whichever came first in the module.
     assert_eq!(
-      state
-        .find_call_declaration(&call)
-        .and_then(|decl| decl.name.as_ident())
-        .map(|ident| ident.sym.as_str()),
+      bound_name(state.find_call_declaration(&call)),
       Some("earlier")
+    );
+  }
+
+  /// The two lookups answer different questions and must keep disagreeing.
+  ///
+  /// `find_call_declaration` is keyed on what a call *is*, so two calls that
+  /// differ only in position collapse onto the earliest declarator holding one.
+  /// `find_call_declaration_by_span` is keyed on where a call was *written*, so
+  /// the same pair resolves to one declarator each. Routing either through the
+  /// other would look like a tidy-up and would silently break whichever
+  /// question it stopped answering.
+  #[test]
+  fn a_call_is_found_by_content_collapsed_and_by_position_apart() {
+    let mut state = StateManager::default();
+
+    let earlier = call_of_at("create", "shared", span_at(1, 10));
+    let later = call_of_at("create", "shared", span_at(20, 30));
+
+    state.push_declaration(var_declarator("earlier", Expr::Call(earlier.clone())));
+    state.push_declaration(var_declarator("later", Expr::Call(later.clone())));
+
+    for call in [&earlier, &later] {
+      assert_eq!(
+        bound_name(state.find_call_declaration(call)),
+        Some("earlier")
+      );
+    }
+
+    assert_eq!(
+      bound_name(state.find_call_declaration_by_span(&earlier)),
+      Some("earlier")
+    );
+    assert_eq!(
+      bound_name(state.find_call_declaration_by_span(&later)),
+      Some("later")
+    );
+  }
+
+  /// The same disagreement at a width no hand-written module reaches, so the
+  /// index answering from a bucket and the walk answering from a position are
+  /// both exercised past the point where a linear fallback would be visible.
+  #[test]
+  fn content_and_position_keep_disagreeing_across_five_thousand_equal_calls() {
+    const DECLARATORS: usize = 5_000;
+
+    let mut state = StateManager::default();
+
+    let calls: Vec<CallExpr> = (0..DECLARATORS)
+      .map(|index| {
+        let start = (index as u32 + 1) * 100;
+        call_of_at("create", "shared", span_at(start, start + 10))
+      })
+      .collect();
+
+    for (index, call) in calls.iter().enumerate() {
+      state.push_declaration(var_declarator(
+        &format!("styles{index}"),
+        Expr::Call(call.clone()),
+      ));
+    }
+
+    for index in [0usize, 1, 2_499, DECLARATORS - 1] {
+      assert_eq!(
+        bound_name(state.find_call_declaration(&calls[index])),
+        Some("styles0"),
+        "content lookup at {index}"
+      );
+      assert_eq!(
+        bound_name(state.find_call_declaration_by_span(&calls[index])),
+        Some(format!("styles{index}").as_str()),
+        "positional lookup at {index}"
+      );
+    }
+
+    // A position no declarator was written at is not the last one seen.
+    assert!(
+      state
+        .find_call_declaration_by_span(&call_of_at("create", "shared", span_at(7, 8)))
+        .is_none()
     );
   }
 
@@ -1035,10 +1121,7 @@ mod state_manager {
 
     for index in [0usize, 1, 4_999, 9_998, 9_999] {
       assert_eq!(
-        state
-          .find_call_declaration(&calls[index])
-          .and_then(|decl| decl.name.as_ident())
-          .map(|ident| ident.sym.as_str()),
+        bound_name(state.find_call_declaration(&calls[index])),
         Some(format!("styles{index}").as_str())
       );
       assert_eq!(

--- a/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
@@ -2,12 +2,13 @@
 mod state_manager {
   use rustc_hash::FxHashSet;
   use swc_core::{
-    common::{BytePos, DUMMY_SP, Span, SyntaxContext},
+    atoms::Atom,
+    common::{BytePos, DUMMY_SP, EqIgnoreSpan, Span, SyntaxContext},
     ecma::ast::{
-      AssignPatProp, BindingIdent, CallExpr, Callee, Decl, Expr, ExprStmt, Ident, IdentName,
-      ImportDecl, ImportPhase, Lit, MemberExpr, MemberProp, Module, ModuleDecl, ModuleItem,
-      ObjectLit, ObjectPat, ObjectPatProp, Pat, Prop, PropName, PropOrSpread, Stmt, Str, VarDecl,
-      VarDeclKind, VarDeclarator,
+      ArrayLit, AssignPatProp, BindingIdent, CallExpr, Callee, Decl, Expr, ExprOrSpread, ExprStmt,
+      Ident, IdentName, ImportDecl, ImportNamedSpecifier, ImportPhase, ImportSpecifier, Lit,
+      MemberExpr, MemberProp, Module, ModuleDecl, ModuleItem, ObjectLit, ObjectPat, ObjectPatProp,
+      Pat, Prop, PropName, PropOrSpread, Stmt, Str, VarDecl, VarDeclKind, VarDeclarator,
     },
   };
 
@@ -15,6 +16,7 @@ mod state_manager {
     DeclId, InsertionSlot, StateManager, build_decl_use_graph, compute_live_set,
     flush_pending_insertions,
   };
+  use crate::shared::utils::js::check_declaration::DeclarationType;
   use stylex_enums::top_level_expression::TopLevelExpressionKind;
   use stylex_structures::ceiling::Ceiling;
   use stylex_structures::evaluation_depth::MAX_EVALUATION_DEPTH;
@@ -541,5 +543,708 @@ mod state_manager {
         );
       }
     }
+  }
+
+  /// A call carrying `argument`, so two calls can differ in content rather than
+  /// only in position.
+  fn call_of(name: &str, argument: &str) -> CallExpr {
+    CallExpr {
+      span: DUMMY_SP,
+      ctxt: SyntaxContext::empty(),
+      callee: Callee::Expr(Box::new(ident_expr(name))),
+      args: vec![ExprOrSpread {
+        spread: None,
+        expr: Box::new(string_expr(argument)),
+      }],
+      type_args: None,
+    }
+  }
+
+  fn declarator_at(name: &str, span: Span, init: Expr) -> VarDeclarator {
+    VarDeclarator {
+      span,
+      ..var_declarator(name, init)
+    }
+  }
+
+  #[test]
+  fn find_call_declaration_pins_the_declarator_that_call_initialises() {
+    let mut state = StateManager::default();
+
+    let first = call_of("create", "first");
+    let second = call_of("create", "second");
+
+    state.push_declaration(var_declarator("first", Expr::Call(first)));
+    state.push_declaration(var_declarator("second", Expr::Call(second.clone())));
+    state.push_declaration(var_declarator("plain", string_expr("no call here")));
+
+    assert_eq!(
+      state
+        .find_call_declaration(&second)
+        .and_then(|decl| decl.name.as_ident())
+        .map(|ident| ident.sym.as_str()),
+      Some("second")
+    );
+    assert!(
+      state
+        .find_call_declaration(&call_of("create", "absent"))
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn find_call_declaration_answers_with_the_earliest_of_equal_declarators() {
+    let mut state = StateManager::default();
+
+    let call = call_of("create", "shared");
+
+    state.push_declaration(var_declarator("earlier", Expr::Call(call.clone())));
+    state.push_declaration(var_declarator("later", Expr::Call(call.clone())));
+
+    // Two declarators can hold structurally equal calls, and the walk this
+    // replaced answered with whichever came first in the module.
+    assert_eq!(
+      state
+        .find_call_declaration(&call)
+        .and_then(|decl| decl.name.as_ident())
+        .map(|ident| ident.sym.as_str()),
+      Some("earlier")
+    );
+  }
+
+  #[test]
+  fn find_call_declaration_ignores_a_declarator_with_no_initializer() {
+    let mut state = StateManager::default();
+
+    state.push_declaration(VarDeclarator {
+      init: None,
+      ..var_declarator("bare", string_expr("unused"))
+    });
+
+    assert!(
+      state
+        .find_call_declaration(&call_of("create", "anything"))
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn replacing_an_initializer_moves_the_declarator_to_the_call_it_now_holds() {
+    let mut state = StateManager::default();
+
+    let original = call_of("create", "original");
+    let replacement = call_of("create", "replacement");
+
+    state.push_declaration(var_declarator("styles", Expr::Call(original.clone())));
+    state.set_declaration_init(0, Expr::Call(replacement.clone()));
+
+    // The key the declarator was recorded under stops being true, so the call
+    // it no longer holds must stop finding it.
+    assert!(state.find_call_declaration(&original).is_none());
+    assert!(state.find_call_declaration(&replacement).is_some());
+  }
+
+  #[test]
+  fn replacing_an_initializer_with_a_non_call_leaves_it_findable_by_nothing() {
+    let mut state = StateManager::default();
+
+    let original = call_of("defineMarker", "marker");
+
+    state.push_declaration(var_declarator("marker", Expr::Call(original.clone())));
+    state.set_declaration_init(0, string_expr("a compiled marker object"));
+
+    assert!(state.find_call_declaration(&original).is_none());
+  }
+
+  #[test]
+  fn replacing_an_initializer_with_the_same_call_keeps_it_findable() {
+    let mut state = StateManager::default();
+
+    let call = call_of("create", "unchanged");
+
+    state.push_declaration(var_declarator("styles", Expr::Call(call.clone())));
+    state.set_declaration_init(0, Expr::Call(call.clone()));
+
+    // Forgetting and recording happen in that order, so a replacement that
+    // reads the same must not leave the record dropped.
+    assert!(state.find_call_declaration(&call).is_some());
+  }
+
+  #[test]
+  fn replacing_an_initializer_out_of_range_changes_nothing() {
+    let mut state = StateManager::default();
+
+    let call = call_of("create", "only");
+
+    state.push_declaration(var_declarator("styles", Expr::Call(call.clone())));
+    state.set_declaration_init(99, string_expr("nowhere"));
+
+    assert!(state.find_call_declaration(&call).is_some());
+  }
+
+  #[test]
+  fn find_top_level_expr_pins_the_entry_that_is_that_call() {
+    let mut state = StateManager::default();
+
+    let create = call_of("create", "styles");
+    let theme = call_of("createTheme", "theme");
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      Expr::Call(create),
+      Some("styles".into()),
+    ));
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::NamedExport,
+      Expr::Call(theme.clone()),
+      Some("theme".into()),
+    ));
+
+    assert_eq!(
+      state.find_top_level_expr(&theme).map(|tpe| tpe.0),
+      Some(TopLevelExpressionKind::NamedExport)
+    );
+    assert!(
+      state
+        .find_top_level_expr(&call_of("create", "absent"))
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn find_top_level_expr_ignores_an_entry_that_merely_holds_the_call() {
+    let mut state = StateManager::default();
+
+    let call = call_of("create", "styles");
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      Expr::Array(ArrayLit {
+        span: DUMMY_SP,
+        elems: vec![Some(ExprOrSpread {
+          spread: None,
+          expr: Box::new(Expr::Call(call.clone())),
+        })],
+      }),
+      Some("lotsOfStyles".into()),
+    ));
+
+    // The entry *is* the array, not the call inside it -- which is the whole
+    // reason `has_top_level_expr` takes a predicate for the shapes that hold a
+    // call without being one.
+    assert!(state.find_top_level_expr(&call).is_none());
+    assert!(state.has_top_level_expr(&call, |tpe| matches!(tpe.1, Expr::Array(_))));
+    assert!(!state.has_top_level_expr(&call, |_| false));
+  }
+
+  #[test]
+  fn has_top_level_expr_answers_from_the_index_before_the_predicate() {
+    let mut state = StateManager::default();
+
+    let call = call_of("create", "styles");
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      Expr::Call(call.clone()),
+      Some("styles".into()),
+    ));
+
+    assert!(state.has_top_level_expr(&call, |_| panic!("the predicate must not be reached")));
+  }
+
+  #[test]
+  fn replacing_a_top_level_expression_moves_it_to_the_call_it_now_is() {
+    let mut state = StateManager::default();
+
+    let original = call_of("create", "original");
+    let replacement = call_of("create", "replacement");
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      Expr::Call(original.clone()),
+      Some("styles".into()),
+    ));
+    state.set_top_level_expr(0, Expr::Call(replacement.clone()));
+
+    assert!(state.find_top_level_expr(&original).is_none());
+    assert!(state.find_top_level_expr(&replacement).is_some());
+  }
+
+  #[test]
+  fn find_top_level_expr_named_answers_for_the_name_it_binds() {
+    let mut state = StateManager::default();
+
+    let shared = Expr::Call(call_of("create", "shared"));
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::NamedExport,
+      shared.clone(),
+      Some("first".into()),
+    ));
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      shared.clone(),
+      Some("second".into()),
+    ));
+
+    // Both entries read the same, so only the name tells them apart -- where a
+    // walk comparing expressions answered with whichever came first for either.
+    assert_eq!(
+      state
+        .find_top_level_expr_named(&"second".into(), &shared)
+        .map(|tpe| tpe.0),
+      Some(TopLevelExpressionKind::Stmt)
+    );
+    assert_eq!(
+      state
+        .find_top_level_expr_named(&"first".into(), &shared)
+        .map(|tpe| tpe.0),
+      Some(TopLevelExpressionKind::NamedExport)
+    );
+  }
+
+  #[test]
+  fn find_top_level_expr_named_refuses_a_name_whose_expression_has_moved_on() {
+    let mut state = StateManager::default();
+
+    let recorded = Expr::Call(call_of("create", "recorded"));
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      recorded,
+      Some("styles".into()),
+    ));
+
+    assert!(
+      state
+        .find_top_level_expr_named(&"styles".into(), &string_expr("something else"))
+        .is_none()
+    );
+    assert!(
+      state
+        .find_top_level_expr_named(&"absent".into(), &string_expr("anything"))
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn holds_declaration_dedups_on_position_then_content() {
+    let mut state = StateManager::default();
+
+    let first = declarator_at("styles", span_at(1, 10), string_expr("value"));
+    let same_position_other_content = declarator_at("styles", span_at(1, 10), string_expr("other"));
+    let same_content_other_position =
+      declarator_at("styles", span_at(20, 30), string_expr("value"));
+
+    state.push_declaration(first.clone());
+
+    assert!(state.holds_declaration(&first));
+    assert!(!state.holds_declaration(&same_position_other_content));
+    // Two declarations that merely read alike stay two entries, because a
+    // lookup that pins a call to its declarator by span needs them to.
+    assert!(!state.holds_declaration(&same_content_other_position));
+  }
+
+  #[test]
+  fn holds_declaration_tells_synthesized_declarators_apart_by_content() {
+    let mut state = StateManager::default();
+
+    let first = declarator_at("a", DUMMY_SP, string_expr("first"));
+    let second = declarator_at("b", DUMMY_SP, string_expr("second"));
+
+    state.push_declaration(first.clone());
+
+    // Every synthesized declarator shares `DUMMY_SP`, so content is all that
+    // separates them.
+    assert!(state.holds_declaration(&first));
+    assert!(!state.holds_declaration(&second));
+  }
+
+  #[test]
+  fn matching_style_var_answers_for_the_name_the_declarator_binds() {
+    let mut state = StateManager::default();
+
+    let declarator = var_declarator("styles", Expr::Call(call_of("create", "styles")));
+
+    state.insert_style_var("styles".to_string(), declarator.clone());
+
+    assert!(state.matching_style_var(&declarator).is_some());
+    // A declarator of another name is another style variable, however it reads.
+    assert!(
+      state
+        .matching_style_var(&var_declarator(
+          "other",
+          Expr::Call(call_of("create", "styles"))
+        ))
+        .is_none()
+    );
+    // And the recorded name having moved on is not a match either.
+    assert!(
+      state
+        .matching_style_var(&var_declarator("styles", string_expr("something else")))
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn matching_style_var_refuses_a_declarator_bound_to_a_pattern() {
+    let mut state = StateManager::default();
+
+    let init = Expr::Call(call_of("create", "styles"));
+
+    state.insert_style_var("styles".to_string(), var_declarator("styles", init.clone()));
+
+    let pattern_bound = VarDeclarator {
+      span: DUMMY_SP,
+      name: Pat::Object(ObjectPat {
+        span: DUMMY_SP,
+        props: vec![],
+        optional: false,
+        type_ann: None,
+      }),
+      init: Some(Box::new(init)),
+      definite: false,
+    };
+
+    assert!(state.matching_style_var(&pattern_bound).is_none());
+  }
+
+  #[test]
+  fn replacing_a_style_var_initializer_moves_it_to_the_call_it_now_holds() {
+    let mut state = StateManager::default();
+
+    let original = call_of("create", "original");
+    let replacement = call_of("create", "replacement");
+
+    state.insert_style_var(
+      "styles".to_string(),
+      var_declarator("styles", Expr::Call(original)),
+    );
+    state.set_style_var_init("styles".to_string(), Expr::Call(replacement.clone()));
+
+    assert_eq!(
+      state.style_vars["styles"]
+        .init
+        .as_deref()
+        .and_then(Expr::as_call)
+        .map(|call| call.eq_ignore_span(&replacement)),
+      Some(true)
+    );
+  }
+
+  #[test]
+  fn inserting_a_style_var_twice_forgets_the_call_the_first_one_held() {
+    let mut state = StateManager::default();
+
+    let first = call_of("create", "first");
+    let second = call_of("create", "second");
+
+    state.insert_style_var(
+      "styles".to_string(),
+      var_declarator("styles", Expr::Call(first)),
+    );
+    state.insert_style_var(
+      "styles".to_string(),
+      var_declarator("styles", Expr::Call(second.clone())),
+    );
+
+    assert!(
+      state
+        .matching_style_var(&var_declarator("styles", Expr::Call(second)))
+        .is_some()
+    );
+  }
+
+  #[test]
+  fn declared_as_tells_a_class_from_a_function_and_keeps_the_first_position() {
+    let mut state = StateManager::default();
+
+    let class_name = Ident {
+      span: span_at(1, 10),
+      ..ident("Widget")
+    };
+    let later_spelling = Ident {
+      span: span_at(50, 60),
+      ..ident("Widget")
+    };
+
+    state.add_class_name_declaration(class_name);
+    state.add_class_name_declaration(later_spelling);
+    state.add_function_name_declaration(ident("render"));
+
+    assert!(matches!(
+      state.declared_as(&ident("Widget")),
+      Some(DeclarationType::Class)
+    ));
+    assert!(matches!(
+      state.declared_as(&ident("render")),
+      Some(DeclarationType::Function)
+    ));
+    assert!(state.declared_as(&ident("unbound")).is_none());
+    // First writer wins, which is the position a used-before-declaration
+    // diagnostic is about.
+    assert_eq!(
+      state.class_name_declaration(&ident("Widget")),
+      Some(span_at(1, 10))
+    );
+  }
+
+  #[test]
+  fn a_declaration_resolves_only_for_the_binding_its_own_context_names() {
+    let mut state = StateManager::default();
+
+    let outer = ident("Widget");
+    // A context of its own, spelled directly rather than through a `Mark`,
+    // which needs a `GLOBALS` scope this unit test has no other use for.
+    let shadowed = Ident {
+      ctxt: SyntaxContext::from_u32(1),
+      ..ident("Widget")
+    };
+
+    state.add_class_name_declaration(outer.clone());
+
+    assert!(matches!(
+      state.declared_as(&outer),
+      Some(DeclarationType::Class)
+    ));
+    // A name shadowing the class declares something else, and resolving it to
+    // the declaration it shadows is what keying on the symbol alone would do.
+    assert!(state.declared_as(&shadowed).is_none());
+  }
+
+  /// Far past any authored module, to show the lookups answer from a key rather
+  /// than by walking what has been recorded.
+  #[test]
+  fn the_lookups_stay_exact_across_ten_thousand_declarations() {
+    let mut state = StateManager::default();
+
+    let calls: Vec<CallExpr> = (0..10_000)
+      .map(|index| call_of("create", &format!("styles{index}")))
+      .collect();
+
+    for (index, call) in calls.iter().enumerate() {
+      let name = format!("styles{index}");
+
+      state.push_declaration(var_declarator(&name, Expr::Call(call.clone())));
+      state.push_top_level_expression(TopLevelExpression(
+        TopLevelExpressionKind::Stmt,
+        Expr::Call(call.clone()),
+        Some(name.as_str().into()),
+      ));
+    }
+
+    for index in [0usize, 1, 4_999, 9_998, 9_999] {
+      assert_eq!(
+        state
+          .find_call_declaration(&calls[index])
+          .and_then(|decl| decl.name.as_ident())
+          .map(|ident| ident.sym.as_str()),
+        Some(format!("styles{index}").as_str())
+      );
+      assert_eq!(
+        state
+          .find_top_level_expr(&calls[index])
+          .and_then(|tpe| tpe.2.as_ref())
+          .map(Atom::as_str),
+        Some(format!("styles{index}").as_str())
+      );
+    }
+
+    assert!(
+      state
+        .find_call_declaration(&call_of("create", "styles10000"))
+        .is_none()
+    );
+  }
+
+  /// A named import of `names` from `source`.
+  fn named_import(source: &str, names: &[&str]) -> ImportDecl {
+    ImportDecl {
+      span: DUMMY_SP,
+      specifiers: names
+        .iter()
+        .map(|name| {
+          ImportSpecifier::Named(ImportNamedSpecifier {
+            span: DUMMY_SP,
+            local: ident(name),
+            imported: None,
+            is_type_only: false,
+          })
+        })
+        .collect(),
+      src: Box::new(Str {
+        span: DUMMY_SP,
+        value: source.into(),
+        raw: None,
+      }),
+      type_only: false,
+      with: None,
+      phase: ImportPhase::Evaluation,
+    }
+  }
+
+  #[test]
+  fn find_top_level_expr_named_answers_for_a_redeclared_name() {
+    let mut state = StateManager::default();
+
+    let first = Expr::Call(call_of("create", "first"));
+    let second = Expr::Call(call_of("create", "second"));
+
+    // `var styles = ...; var styles = ...;` is legal, so one name can bind two
+    // entries and the second must stay findable.
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::NamedExport,
+      first.clone(),
+      Some("styles".into()),
+    ));
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      second.clone(),
+      Some("styles".into()),
+    ));
+
+    assert_eq!(
+      state
+        .find_top_level_expr_named(&"styles".into(), &second)
+        .map(|tpe| tpe.0),
+      Some(TopLevelExpressionKind::Stmt)
+    );
+    assert_eq!(
+      state
+        .find_top_level_expr_named(&"styles".into(), &first)
+        .map(|tpe| tpe.0),
+      Some(TopLevelExpressionKind::NamedExport)
+    );
+  }
+
+  #[test]
+  fn find_top_level_expr_named_ignores_an_entry_bound_to_another_name() {
+    let mut state = StateManager::default();
+
+    let shared = Expr::Call(call_of("create", "shared"));
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::NamedExport,
+      shared.clone(),
+      Some("exported".into()),
+    ));
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      shared.clone(),
+      Some("styles".into()),
+    ));
+
+    // Both entries read the same, and the exported one comes first. The answer
+    // is the entry this name binds, not whichever the module spells first --
+    // the kind belongs to a declarator, and reading another's is what the walk
+    // this replaced did.
+    assert_eq!(
+      state
+        .find_top_level_expr_named(&"styles".into(), &shared)
+        .map(|tpe| tpe.0),
+      Some(TopLevelExpressionKind::Stmt)
+    );
+  }
+
+  #[test]
+  fn replacing_out_of_range_entries_changes_nothing() {
+    let mut state = StateManager::default();
+
+    let call = call_of("create", "only");
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      Expr::Call(call.clone()),
+      Some("styles".into()),
+    ));
+    state.insert_style_var(
+      "styles".to_string(),
+      var_declarator("styles", Expr::Call(call.clone())),
+    );
+
+    state.set_top_level_expr(99, string_expr("nowhere"));
+    state.set_style_var_init("absent".to_string(), string_expr("nowhere"));
+
+    assert!(state.find_top_level_expr(&call).is_some());
+    assert!(
+      state
+        .matching_style_var(&var_declarator("styles", Expr::Call(call)))
+        .is_some()
+    );
+  }
+
+  #[test]
+  fn import_binding_answers_for_the_binding_a_specifier_declares() {
+    let mut state = StateManager::default();
+
+    state.push_top_import(named_import("theme.stylex.js", &["spacing", "colors"]));
+    state.push_top_import(named_import("other.stylex.js", &["radii"]));
+
+    assert_eq!(
+      state
+        .import_binding(&ident("colors"))
+        .and_then(|(import, _)| import.src.value.as_str()),
+      Some("theme.stylex.js")
+    );
+    assert_eq!(
+      state
+        .import_binding(&ident("radii"))
+        .and_then(|(import, _)| import.src.value.as_str()),
+      Some("other.stylex.js")
+    );
+    assert!(state.import_binding(&ident("unbound")).is_none());
+  }
+
+  #[test]
+  fn import_binding_refuses_a_reference_from_another_scope() {
+    let mut state = StateManager::default();
+
+    state.push_top_import(named_import("theme.stylex.js", &["spacing"]));
+
+    // A parameter named after an imported theme carries a context of its own,
+    // and resolving it to the import it shadows is the bug this keying avoids.
+    let shadowing = Ident {
+      ctxt: SyntaxContext::from_u32(1),
+      ..ident("spacing")
+    };
+
+    assert!(state.import_binding(&ident("spacing")).is_some());
+    assert!(state.import_binding(&shadowing).is_none());
+  }
+
+  #[test]
+  fn import_binding_answers_with_the_earliest_of_two_imports_of_one_name() {
+    let mut state = StateManager::default();
+
+    state.push_top_import(named_import("first.stylex.js", &["spacing"]));
+    state.push_top_import(named_import("second.stylex.js", &["spacing"]));
+
+    assert_eq!(
+      state
+        .import_binding(&ident("spacing"))
+        .and_then(|(import, _)| import.src.value.as_str()),
+      Some("first.stylex.js")
+    );
+  }
+
+  /// Far past any authored module, to show the lookup answers from a key rather
+  /// than by walking every specifier the module imports.
+  #[test]
+  fn import_binding_stays_exact_across_ten_thousand_specifiers() {
+    let mut state = StateManager::default();
+
+    let names: Vec<String> = (0..10_000).map(|index| format!("token{index}")).collect();
+
+    for chunk in names.chunks(100) {
+      let borrowed: Vec<&str> = chunk.iter().map(String::as_str).collect();
+
+      state.push_top_import(named_import("tokens.stylex.js", &borrowed));
+    }
+
+    for index in [0usize, 1, 4_999, 9_999] {
+      assert!(state.import_binding(&ident(&names[index])).is_some());
+    }
+
+    assert!(state.import_binding(&ident("token10000")).is_none());
   }
 }

--- a/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
@@ -6,9 +6,10 @@ mod state_manager {
     common::{BytePos, DUMMY_SP, EqIgnoreSpan, Span, SyntaxContext},
     ecma::ast::{
       ArrayLit, AssignPatProp, BindingIdent, CallExpr, Callee, Decl, Expr, ExprOrSpread, ExprStmt,
-      Ident, IdentName, ImportDecl, ImportNamedSpecifier, ImportPhase, ImportSpecifier, Lit,
-      MemberExpr, MemberProp, Module, ModuleDecl, ModuleItem, ObjectLit, ObjectPat, ObjectPatProp,
-      Pat, Prop, PropName, PropOrSpread, Stmt, Str, VarDecl, VarDeclKind, VarDeclarator,
+      Ident, IdentName, ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportPhase,
+      ImportSpecifier, ImportStarAsSpecifier, Lit, MemberExpr, MemberProp, Module, ModuleDecl,
+      ModuleItem, ObjectLit, ObjectPat, ObjectPatProp, Pat, Prop, PropName, PropOrSpread, Stmt,
+      Str, VarDecl, VarDeclKind, VarDeclarator,
     },
   };
 
@@ -1362,6 +1363,43 @@ mod state_manager {
       Some("other.stylex.js")
     );
     assert!(state.import_binding(&ident("unbound")).is_none());
+  }
+
+  /// `import * as stylex` binds through another arm of `local_binding_of` than
+  /// the named form the helper above builds, and the namespace form is what
+  /// every StyleX module actually writes.
+  #[test]
+  fn import_binding_answers_for_a_namespace_specifier() {
+    let mut state = StateManager::default();
+
+    state.push_top_import(ImportDecl {
+      specifiers: vec![ImportSpecifier::Namespace(ImportStarAsSpecifier {
+        span: DUMMY_SP,
+        local: ident("stylex"),
+      })],
+      ..named_import("@stylexjs/stylex", &[])
+    });
+
+    assert!(state.import_binding(&ident("stylex")).is_some());
+    assert!(state.import_binding(&ident("other")).is_none());
+  }
+
+  /// `import stylex from` is the third arm, and the only one whose binding is
+  /// the declaration's own default.
+  #[test]
+  fn import_binding_answers_for_a_default_specifier() {
+    let mut state = StateManager::default();
+
+    state.push_top_import(ImportDecl {
+      specifiers: vec![ImportSpecifier::Default(ImportDefaultSpecifier {
+        span: DUMMY_SP,
+        local: ident("stylex"),
+      })],
+      ..named_import("@stylexjs/stylex", &[])
+    });
+
+    assert!(state.import_binding(&ident("stylex")).is_some());
+    assert!(state.import_binding(&ident("other")).is_none());
   }
 
   #[test]

--- a/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
@@ -347,12 +347,12 @@ mod state_manager {
     let first = call_at(span_at(1, 10));
     let second = call_at(span_at(20, 30));
 
-    state.top_level_expressions.push(TopLevelExpression(
+    state.push_top_level_expression(TopLevelExpression(
       TopLevelExpressionKind::NamedExport,
       Expr::Call(first.clone()),
       Some("first".into()),
     ));
-    state.top_level_expressions.push(TopLevelExpression(
+    state.push_top_level_expression(TopLevelExpression(
       TopLevelExpressionKind::Stmt,
       Expr::Call(second.clone()),
       Some("second".into()),
@@ -381,7 +381,7 @@ mod state_manager {
 
     let call = call_at(span_at(1, 10));
 
-    state.top_level_expressions.push(TopLevelExpression(
+    state.push_top_level_expression(TopLevelExpression(
       TopLevelExpressionKind::NamedExport,
       Expr::Ident(Ident {
         span: span_at(1, 10),
@@ -401,7 +401,7 @@ mod state_manager {
   fn find_top_level_expr_by_span_never_matches_a_spanless_call() {
     let mut state = StateManager::default();
 
-    state.top_level_expressions.push(TopLevelExpression(
+    state.push_top_level_expression(TopLevelExpression(
       TopLevelExpressionKind::NamedExport,
       Expr::Call(call_at(DUMMY_SP)),
       Some("synthesized".into()),

--- a/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
@@ -823,6 +823,92 @@ mod state_manager {
     assert!(!state.has_top_level_expr(&call, |_| false));
   }
 
+  /// The array question is a count, so what it answers has to follow the list
+  /// in both directions -- including the case a flag could not express, where
+  /// the last array is rewritten into something else.
+  #[test]
+  fn the_top_level_array_count_follows_the_list_it_counts() {
+    let mut state = StateManager::default();
+
+    let call = call_of("create", "styles");
+    let array = Expr::Array(ArrayLit {
+      span: DUMMY_SP,
+      elems: vec![Some(ExprOrSpread {
+        spread: None,
+        expr: Box::new(Expr::Call(call.clone())),
+      })],
+    });
+
+    assert!(!state.holds_top_level_array());
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      Expr::Call(call),
+      Some("styles".into()),
+    ));
+
+    // A call is not an array.
+    assert!(!state.holds_top_level_array());
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      array.clone(),
+      Some("lotsOfStyles".into()),
+    ));
+
+    assert!(state.holds_top_level_array());
+
+    // A second array, so the count has something to come back to.
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      array,
+      Some("moreStyles".into()),
+    ));
+
+    state.set_top_level_expr(1, string_expr("no longer an array"));
+    assert!(state.holds_top_level_array());
+
+    state.set_top_level_expr(2, string_expr("nor is this"));
+    assert!(!state.holds_top_level_array());
+
+    // And a replacement out of range counts nothing.
+    state.set_top_level_expr(99, string_expr("nowhere"));
+    assert!(!state.holds_top_level_array());
+  }
+
+  /// A bucket a lookup can stop early in is one nothing has moved. Rewriting an
+  /// entry back to the expression it started with re-records it at the back, so
+  /// the bucket stops being ascending -- and the answer has to stay the earliest
+  /// entry the module writes, not the first the bucket holds.
+  #[test]
+  fn a_bucket_an_entry_moved_back_into_still_answers_with_the_earliest() {
+    let mut state = StateManager::default();
+
+    let shared = call_of("create", "shared");
+    let other = call_of("create", "other");
+
+    for name in ["first", "second", "third"] {
+      state.push_top_level_expression(TopLevelExpression(
+        TopLevelExpressionKind::Stmt,
+        Expr::Call(shared.clone()),
+        Some(name.into()),
+      ));
+    }
+
+    // Out of the bucket and back into it, which leaves position 0 behind
+    // positions 1 and 2 in it.
+    state.set_top_level_expr(0, Expr::Call(other));
+    state.set_top_level_expr(0, Expr::Call(shared.clone()));
+
+    assert_eq!(
+      state
+        .find_top_level_expr(&shared)
+        .and_then(|tpe| tpe.2.as_ref())
+        .map(Atom::as_str),
+      Some("first")
+    );
+  }
+
   #[test]
   fn has_top_level_expr_answers_from_the_index_before_the_predicate() {
     let mut state = StateManager::default();

--- a/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
+++ b/crates/stylex-transform/src/shared/structures/tests/state_manager_test.rs
@@ -824,57 +824,89 @@ mod state_manager {
     assert!(!state.has_top_level_expr(&call, |_| false));
   }
 
-  /// The array question is a count, so what it answers has to follow the list
-  /// in both directions -- including the case a flag could not express, where
-  /// the last array is rewritten into something else.
+  /// The arrays a module records have to follow the list they come from, in
+  /// both directions -- including the case where the last one is rewritten into
+  /// something else.
   #[test]
-  fn the_top_level_array_count_follows_the_list_it_counts() {
+  fn the_top_level_arrays_follow_the_list_they_come_from() {
     let mut state = StateManager::default();
 
-    let call = call_of("create", "styles");
-    let array = Expr::Array(ArrayLit {
-      span: DUMMY_SP,
-      elems: vec![Some(ExprOrSpread {
-        spread: None,
-        expr: Box::new(Expr::Call(call.clone())),
-      })],
-    });
+    let held = call_of_at("create", "held", span_at(12, 30));
+    let outside = call_of_at("create", "outside", span_at(90, 99));
+    let array = |span| {
+      Expr::Array(ArrayLit {
+        span,
+        elems: vec![Some(ExprOrSpread {
+          spread: None,
+          expr: Box::new(Expr::Call(held.clone())),
+        })],
+      })
+    };
 
-    assert!(!state.holds_top_level_array());
+    assert!(!state.holds_call_in_top_level_array(&held));
 
     state.push_top_level_expression(TopLevelExpression(
       TopLevelExpressionKind::Stmt,
-      Expr::Call(call),
+      Expr::Call(held.clone()),
       Some("styles".into()),
     ));
 
-    // A call is not an array.
-    assert!(!state.holds_top_level_array());
+    // A call is not an array, whatever it holds.
+    assert!(!state.holds_call_in_top_level_array(&held));
 
     state.push_top_level_expression(TopLevelExpression(
       TopLevelExpressionKind::Stmt,
-      array.clone(),
+      array(span_at(10, 40)),
       Some("lotsOfStyles".into()),
     ));
 
-    assert!(state.holds_top_level_array());
+    assert!(state.holds_call_in_top_level_array(&held));
+    // A call the array does not hold answers no, however many arrays the module
+    // writes. That is the whole of what containment decides.
+    assert!(!state.holds_call_in_top_level_array(&outside));
 
-    // A second array, so the count has something to come back to.
+    // A second array over the same call, so the answer has something to come
+    // back to.
     state.push_top_level_expression(TopLevelExpression(
       TopLevelExpressionKind::Stmt,
-      array,
+      array(span_at(50, 80)),
       Some("moreStyles".into()),
     ));
 
     state.set_top_level_expr(1, string_expr("no longer an array"));
-    assert!(state.holds_top_level_array());
+    // The second array does not hold the call, so nothing does.
+    assert!(!state.holds_call_in_top_level_array(&held));
+
+    state.set_top_level_expr(2, array(span_at(10, 40)));
+    assert!(state.holds_call_in_top_level_array(&held));
 
     state.set_top_level_expr(2, string_expr("nor is this"));
-    assert!(!state.holds_top_level_array());
+    assert!(!state.holds_call_in_top_level_array(&held));
 
-    // And a replacement out of range counts nothing.
-    state.set_top_level_expr(99, string_expr("nowhere"));
-    assert!(!state.holds_top_level_array());
+    // And a replacement out of range records nothing.
+    state.set_top_level_expr(99, array(span_at(10, 40)));
+    assert!(!state.holds_call_in_top_level_array(&held));
+  }
+
+  /// A synthesized call was written nowhere, so no recorded array can hold it.
+  /// A dummy span reads as position zero, which an array starting at zero would
+  /// otherwise contain.
+  #[test]
+  fn a_span_less_call_is_held_by_no_top_level_array() {
+    let mut state = StateManager::default();
+
+    let synthesized = call_of("create", "styles");
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      Expr::Array(ArrayLit {
+        span: span_at(0, 40),
+        elems: vec![],
+      }),
+      Some("lotsOfStyles".into()),
+    ));
+
+    assert!(!state.holds_call_in_top_level_array(&synthesized));
   }
 
   /// A bucket a lookup can stop early in is one nothing has moved. Rewriting an

--- a/crates/stylex-transform/src/shared/transformers/tests/stylex_create_test.rs
+++ b/crates/stylex-transform/src/shared/transformers/tests/stylex_create_test.rs
@@ -271,12 +271,12 @@ mod stylex_create {
     stylex_create_set(
       &EvaluateResultValue::Map(style_object),
       &mut EvaluationState::default(),
-      &mut StateManager {
-        options: StyleXStateOptions::default()
+      &mut StateManager::for_test(
+        None,
+        StyleXStateOptions::default()
           .with_debug(true)
           .with_enable_debug_class_names(true),
-        ..Default::default()
-      },
+      ),
       &FunctionMap::default(),
     )
   }

--- a/crates/stylex-transform/src/shared/transformers/tests/stylex_define_vars_test.rs
+++ b/crates/stylex-transform/src/shared/transformers/tests/stylex_define_vars_test.rs
@@ -145,10 +145,10 @@ mod stylex_define_vars {
       ),
     ]);
 
-    let mut state = Box::new(StateManager {
-      export_id: Some(export_id.to_string()),
-      ..StateManager::default()
-    });
+    let mut state = Box::new(StateManager::for_test(
+      Some(export_id),
+      StyleXStateOptions::default(),
+    ));
 
     let (js_output, css_output) = stylex_define_vars(&default_vars, &mut state);
 
@@ -262,10 +262,10 @@ mod stylex_define_vars {
       ),
     ]);
 
-    let mut state = Box::new(StateManager {
-      export_id: Some(export_id.to_string()),
-      ..StateManager::default()
-    });
+    let mut state = Box::new(StateManager::for_test(
+      Some(export_id),
+      StyleXStateOptions::default(),
+    ));
 
     let (js_output, css_output) = stylex_define_vars(&default_vars, &mut state);
 
@@ -361,10 +361,10 @@ mod stylex_define_vars {
       ),
     ]);
 
-    let mut state = Box::new(StateManager {
-      export_id: Some(export_id.to_string()),
-      ..StateManager::default()
-    });
+    let mut state = Box::new(StateManager::for_test(
+      Some(export_id),
+      StyleXStateOptions::default(),
+    ));
 
     let (js_output, css_output) = stylex_define_vars(&default_vars, &mut state);
 
@@ -507,13 +507,12 @@ mod stylex_define_vars {
       ),
     ]);
 
-    let mut state = Box::new(StateManager {
-      export_id: Some(export_id.to_string()),
-      options: StyleXStateOptions::default()
+    let mut state = Box::new(StateManager::for_test(
+      Some(export_id),
+      StyleXStateOptions::default()
         .with_debug(true)
         .with_enable_debug_class_names(true),
-      ..StateManager::default()
-    });
+    ));
 
     let (js_output, css_output) = stylex_define_vars(&default_vars, &mut state);
 
@@ -659,13 +658,12 @@ mod stylex_define_vars {
       ),
     ]);
 
-    let mut state = Box::new(StateManager {
-      export_id: Some(export_id.to_string()),
-      options: StyleXStateOptions::default()
+    let mut state = Box::new(StateManager::for_test(
+      Some(export_id),
+      StyleXStateOptions::default()
         .with_debug(false)
         .with_enable_debug_class_names(false),
-      ..StateManager::default()
-    });
+    ));
 
     let (js_output, css_output) = stylex_define_vars(&default_vars, &mut state);
 
@@ -879,15 +877,10 @@ mod stylex_define_vars {
       ),
     ]);
 
-    let state = Box::<StateManager>::default();
-    let mut state = Box::new(StateManager {
-      export_id: Some(export_id.to_string()),
-      options: state
-        .options
-        .clone()
-        .with_class_name_prefix(class_name_prefix),
-      ..*state
-    });
+    let mut state = Box::new(StateManager::for_test(
+      Some(export_id),
+      StyleXStateOptions::default().with_class_name_prefix(class_name_prefix),
+    ));
 
     let (_, css_output) = stylex_define_vars(&default_vars, &mut state);
 
@@ -1122,15 +1115,10 @@ mod stylex_define_vars {
       ),
     ]);
 
-    let state = Box::<StateManager>::default();
-    let mut state = Box::new(StateManager {
-      export_id: Some(export_id.to_string()),
-      options: state
-        .options
-        .clone()
-        .with_class_name_prefix(class_name_prefix),
-      ..*state
-    });
+    let mut state = Box::new(StateManager::for_test(
+      Some(export_id),
+      StyleXStateOptions::default().with_class_name_prefix(class_name_prefix),
+    ));
 
     let (_, css_output) = stylex_define_vars(&default_vars, &mut state);
 

--- a/crates/stylex-transform/src/shared/utils/common.rs
+++ b/crates/stylex-transform/src/shared/utils/common.rs
@@ -5,7 +5,7 @@ use stylex_types::traits::StyleOptions;
 use stylex_utils::{number::to_js_string, string::remove_quotes};
 use swc_core::atoms::Atom;
 use swc_core::{
-  common::{EqIgnoreSpan, FileName, Span},
+  common::{FileName, Span},
   ecma::ast::{
     Decl, Expr, Ident, ImportDecl, ImportSpecifier, KeyValueProp, Module, ModuleDecl, ModuleItem,
     ObjectPatProp, Pat, Prop, PropName, PropOrSpread, Stmt, VarDeclarator,
@@ -131,34 +131,14 @@ pub fn get_var_decl_by_ident<'a>(
 /// The import declaration and the specifier that bind `ident`, or `None` where
 /// no import binds it.
 ///
-/// The two travel together because the caller that asks *whether* an import
-/// binds a reference immediately asks *which specifier* did -- a named
-/// specifier resolves to a theme reference where a default one is refused. A
-/// second search for the specifier could come back empty and left the caller
-/// holding an unanswerable case; answering both from one scan removes it.
+/// Asked of the state, which indexes the bindings its imports declare -- see
+/// [`StateManager::import_binding`] for what the lookup answers and why it is
+/// the binding rather than the name.
 pub fn get_import_by_ident<'a>(
   ident: &Ident,
   state: &'a StateManager,
 ) -> Option<(&'a ImportDecl, &'a ImportSpecifier)> {
-  state.top_imports.iter().find_map(|import| {
-    import
-      .specifiers
-      .iter()
-      // The binding, not the name: a reference and an import specifier are the
-      // same thing only when their `SyntaxContext` agrees too. Matching on the
-      // symbol alone resolved a *shadowing* binding -- an arrow parameter
-      // carries a context of its own -- to the import it shadows, so a dynamic
-      // style whose parameter is named after an imported theme answered a
-      // confident `ThemeRef` and aborted the build (#1266).
-      //
-      // The local binding is the only name asked about. A specifier's
-      // *imported* name binds nothing in this module -- `import { spacing as
-      // sp }` leaves `spacing` unbound here -- so a reference spelled that way
-      // names something else, or nothing at all, and resolving it to the import
-      // it was aliased away from is not a resolution the language allows.
-      .find(|specifier| local_binding_of(specifier).eq_ignore_span(ident))
-      .map(|specifier| (import, specifier))
-  })
+  state.import_binding(ident)
 }
 
 pub(crate) fn get_var_decl_from<'a>(
@@ -415,14 +395,14 @@ pub fn fill_top_level_expressions(module: &Module, state: &mut StateManager) {
     ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(export_decl)) => {
       match export_decl.expr.as_paren() {
         Some(paren) => {
-          state.top_level_expressions.push(TopLevelExpression(
+          state.push_top_level_expression(TopLevelExpression(
             TopLevelExpressionKind::DefaultExport,
             paren.expr.as_ref().clone(),
             None,
           ));
         },
         _ => {
-          state.top_level_expressions.push(TopLevelExpression(
+          state.push_top_level_expression(TopLevelExpression(
             TopLevelExpressionKind::DefaultExport,
             export_decl.expr.as_ref().clone(),
             None,
@@ -458,7 +438,7 @@ fn record_top_level_declarator(
 
   match decl.name.as_ident() {
     Some(ident) => {
-      state.top_level_expressions.push(TopLevelExpression(
+      state.push_top_level_expression(TopLevelExpression(
         kind,
         decl_init.as_ref().clone(),
         Some(ident.sym.clone()),
@@ -477,20 +457,7 @@ fn record_top_level_declarator(
 }
 
 pub fn fill_state_declarations(state: &mut StateManager, decl: &VarDeclarator) {
-  // Dedup on position first, then content. Every filler runs in the `Discover`
-  // cycle over the pristine AST, so the same declaration seen on more than one
-  // of those passes carries the same span and is stored once — while two
-  // declarations that merely *read* the same, `var m = f(); var m = f();`, stay
-  // two entries, as a lookup that pins a call to its declarator by span needs
-  // them to be.
-  //
-  // Content is still compared span-insensitively, which is what decides the
-  // synthesized declarators that share `DUMMY_SP`.
-  if !state
-    .declarations
-    .iter()
-    .any(|existing| existing.span == decl.span && existing.eq_ignore_span(decl))
-  {
+  if !state.holds_declaration(decl) {
     state.push_declaration(decl.clone());
   }
 }

--- a/crates/stylex-transform/src/shared/utils/core/tests/convert_to_class_name_test.rs
+++ b/crates/stylex-transform/src/shared/utils/core/tests/convert_to_class_name_test.rs
@@ -53,16 +53,16 @@ mod convert_style_to_class_name {
   fn prefixes_classname_with_property_name_when_options_debug_is_true() {
     let class_name = class_name_of(
       ("margin", &PreRuleValue::number(10.0)),
-      &mut StateManager {
-        options: StyleXStateOptions::default()
+      &mut StateManager::for_test(
+        None,
+        StyleXStateOptions::default()
           .with_class_name_prefix("x")
           .with_style_resolution(StyleResolution::PropertySpecificity)
           .with_dev(false)
           .with_test(false)
           .with_debug(true)
           .with_enable_debug_class_names(true),
-        ..Default::default()
-      },
+      ),
     );
     assert!(class_name.as_str().starts_with("margin-"))
   }
@@ -71,16 +71,16 @@ mod convert_style_to_class_name {
   fn prefixes_classname_with_prefix_only_when_options_enable_debug_class_names_is_false() {
     let class_name = class_name_of(
       ("margin", &PreRuleValue::number(10.0)),
-      &mut StateManager {
-        options: StyleXStateOptions::default()
+      &mut StateManager::for_test(
+        None,
+        StyleXStateOptions::default()
           .with_class_name_prefix("x")
           .with_style_resolution(StyleResolution::PropertySpecificity)
           .with_dev(false)
           .with_test(false)
           .with_debug(true)
           .with_enable_debug_class_names(false),
-        ..Default::default()
-      },
+      ),
     );
     assert!(class_name.as_str().starts_with("x"));
     assert!(!class_name.as_str().starts_with("margin-x"));
@@ -90,15 +90,15 @@ mod convert_style_to_class_name {
   fn prefixes_classname_with_prefix_only_when_options_debug_is_false() {
     let class_name = class_name_of(
       ("margin", &PreRuleValue::number(10.0)),
-      &mut StateManager {
-        options: StyleXStateOptions::default()
+      &mut StateManager::for_test(
+        None,
+        StyleXStateOptions::default()
           .with_class_name_prefix("x")
           .with_style_resolution(StyleResolution::PropertySpecificity)
           .with_dev(false)
           .with_test(false)
           .with_debug(false),
-        ..Default::default()
-      },
+      ),
     );
     assert!(!class_name.as_str().starts_with("margin-"));
     assert!(class_name.as_str().starts_with("x"));

--- a/crates/stylex-transform/src/shared/utils/js/check_declaration.rs
+++ b/crates/stylex-transform/src/shared/utils/js/check_declaration.rs
@@ -1,7 +1,4 @@
-use swc_core::{
-  common::EqIgnoreSpan,
-  ecma::ast::{Expr, Ident},
-};
+use swc_core::ecma::ast::{Expr, Ident};
 
 use crate::shared::{
   enums::data_structures::evaluate_result_value::EvaluateResultValue,
@@ -55,12 +52,4 @@ pub(crate) fn check_ident_declaration(
     ),
     None => deopt(path, state, UNDEFINED_CONST),
   }
-}
-
-/// Whether `declarations` holds the binding `ident` names -- the same `Id`
-/// comparison every other step of the reference chain makes.
-pub(crate) fn declares_ident(declarations: &[Ident], ident: &Ident) -> bool {
-  declarations
-    .iter()
-    .any(|declared| declared.eq_ignore_span(ident))
 }

--- a/crates/stylex-transform/src/shared/utils/js/evaluate/binding.rs
+++ b/crates/stylex-transform/src/shared/utils/js/evaluate/binding.rs
@@ -12,7 +12,7 @@
 //! steps, which carry their own line ranges in the banner that opens them.
 
 use super::*;
-use swc_core::common::{EqIgnoreSpan, Span};
+use swc_core::common::Span;
 
 // A note on what the unit tests beside this file do and do not cover. The
 // resolved-import arm is exercised only by `validation_stylex_create_test`,
@@ -327,13 +327,16 @@ pub(super) fn resolve_reference(
   // so a reference above one of these is early rather than unsupported. Only the
   // reference above is taken from this step; one below still falls through to
   // step 8 and keeps its kind's wording.
-  if traversal_state
-    .class_name_declarations()
-    .iter()
-    .chain(traversal_state.function_name_declarations())
-    .any(|declared| {
-      declared.eq_ignore_span(ident) && reads_before_its_declaration(ident, declared.span)
-    })
+  // Both kinds are asked, not the first that answers: the walk this replaces
+  // ran over the two lists joined, so a `class` whose position does not read
+  // early must not hide a `function` of the same binding that does.
+  if [
+    traversal_state.class_name_declaration(ident),
+    traversal_state.function_name_declaration(ident),
+  ]
+  .into_iter()
+  .flatten()
+  .any(|declared| reads_before_its_declaration(ident, declared))
   {
     return deopt_at_declaration(
       path,

--- a/crates/stylex-transform/src/shared/utils/js/evaluate/tests/resolution_order.rs
+++ b/crates/stylex-transform/src/shared/utils/js/evaluate/tests/resolution_order.rs
@@ -435,9 +435,7 @@ impl ModuleState {
       let module_binding = (Atom::from(name), MODULE_CONTEXT);
 
       if let Some(imported_as) = &self.imported {
-        traversal_state
-          .top_imports
-          .push(imported_as.declaration_of(name));
+        traversal_state.push_top_import(imported_as.declaration_of(name));
 
         if imported_as.binds_the_subject() {
           Rc::make_mut(&mut traversal_state.declared_bindings).insert(module_binding.clone());

--- a/crates/stylex-transform/src/shared/utils/tests/common_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/tests/common_tests.rs
@@ -1096,9 +1096,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn finds_named_import_by_local() {
     let mut state = StateManager::default();
-    state
-      .top_imports
-      .push(import_from("@stylexjs/stylex", vec![named("stylex", 0)]));
+    state.push_top_import(import_from("@stylexjs/stylex", vec![named("stylex", 0)]));
     let ident = create_ident("stylex");
     let result = get_import_by_ident(&ident, &state);
     assert!(result.is_some());
@@ -1115,7 +1113,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn finds_default_import() {
     let mut state = StateManager::default();
-    state.top_imports.push(import_from(
+    state.push_top_import(import_from(
       "@stylexjs/stylex",
       vec![default_of("stylex", 0)],
     ));
@@ -1127,9 +1125,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn finds_namespace_import() {
     let mut state = StateManager::default();
-    state
-      .top_imports
-      .push(import_from("module", vec![namespace_of("ns", 0)]));
+    state.push_top_import(import_from("module", vec![namespace_of("ns", 0)]));
     let ident = create_ident("ns");
     let result = get_import_by_ident(&ident, &state);
     assert!(result.is_some());
@@ -1138,7 +1134,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn does_not_match_a_renamed_import_by_the_name_it_was_aliased_away_from() {
     let mut state = StateManager::default();
-    state.top_imports.push(import_from(
+    state.push_top_import(import_from(
       "@stylexjs/stylex",
       vec![aliased("localName", "create", 0)],
     ));
@@ -1154,7 +1150,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn finds_renamed_import_by_local_name() {
     let mut state = StateManager::default();
-    state.top_imports.push(import_from(
+    state.push_top_import(import_from(
       "@stylexjs/stylex",
       vec![aliased("localName", "create", 0)],
     ));
@@ -1166,9 +1162,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn does_not_match_wrong_ident() {
     let mut state = StateManager::default();
-    state
-      .top_imports
-      .push(import_from("@stylexjs/stylex", vec![named("stylex", 0)]));
+    state.push_top_import(import_from("@stylexjs/stylex", vec![named("stylex", 0)]));
     let ident = create_ident("wrongName");
     let result = get_import_by_ident(&ident, &state);
     assert!(result.is_none());
@@ -1177,7 +1171,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn does_not_match_a_string_named_specifier_by_its_imported_name() {
     let mut state = StateManager::default();
-    state.top_imports.push(import_from(
+    state.push_top_import(import_from(
       "module",
       vec![str_named("localName", "strExport", 0)],
     ));
@@ -1207,9 +1201,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn does_not_match_a_named_import_shadowed_by_another_binding() {
     let mut state = StateManager::default();
-    state
-      .top_imports
-      .push(import_from("zIndex.stylex.js", vec![named("zIndex", 1)]));
+    state.push_top_import(import_from("zIndex.stylex.js", vec![named("zIndex", 1)]));
 
     // The arrow parameter in `(zIndex) => ({ zIndex })`: same symbol, its own
     // context. Resolving it to the import is #1266.
@@ -1221,9 +1213,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn finds_a_named_import_from_its_own_context() {
     let mut state = StateManager::default();
-    state
-      .top_imports
-      .push(import_from("zIndex.stylex.js", vec![named("zIndex", 1)]));
+    state.push_top_import(import_from("zIndex.stylex.js", vec![named("zIndex", 1)]));
 
     // The other half of the same question: a genuine reference to the import
     // still resolves. A fix that answered `None` for everything would pass the
@@ -1234,7 +1224,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn does_not_match_an_aliased_import_shadowed_by_another_binding() {
     let mut state = StateManager::default();
-    state.top_imports.push(import_from(
+    state.push_top_import(import_from(
       "zIndex.stylex.js",
       vec![aliased("zi", "zIndex", 1)],
     ));
@@ -1247,12 +1237,8 @@ mod get_import_by_ident_tests {
   #[test]
   fn matches_only_the_specifier_whose_context_agrees() {
     let mut state = StateManager::default();
-    state
-      .top_imports
-      .push(import_from("first.stylex.js", vec![named("shadowed", 1)]));
-    state
-      .top_imports
-      .push(import_from("second.stylex.js", vec![named("shadowed", 2)]));
+    state.push_top_import(import_from("first.stylex.js", vec![named("shadowed", 1)]));
+    state.push_top_import(import_from("second.stylex.js", vec![named("shadowed", 2)]));
 
     // Two declarations cannot bind one name in valid source, but the lookup
     // scans a flat list and must not answer by position.
@@ -1267,7 +1253,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn matches_one_specifier_of_a_declaration_without_matching_its_siblings() {
     let mut state = StateManager::default();
-    state.top_imports.push(import_from(
+    state.push_top_import(import_from(
       "tokens.stylex.js",
       vec![named("spacing", 1), named("zIndex", 1)],
     ));
@@ -1286,10 +1272,8 @@ mod get_import_by_ident_tests {
   #[test]
   fn a_shadowed_default_or_namespace_import_was_already_context_aware() {
     let mut state = StateManager::default();
-    state
-      .top_imports
-      .push(import_from("theme.stylex.js", vec![default_of("theme", 1)]));
-    state.top_imports.push(import_from(
+    state.push_top_import(import_from("theme.stylex.js", vec![default_of("theme", 1)]));
+    state.push_top_import(import_from(
       "tokens.stylex.js",
       vec![namespace_of("tokens", 1)],
     ));
@@ -1305,7 +1289,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn a_string_named_specifier_answers_only_for_its_local_binding() {
     let mut state = StateManager::default();
-    state.top_imports.push(import_from(
+    state.push_top_import(import_from(
       "tokens.stylex.js",
       vec![str_named("spacing", "spacing-lg", 1)],
     ));
@@ -1331,12 +1315,8 @@ mod get_import_by_ident_tests {
     // lexer folds `\u007AIndex` to the atom `zIndex` long before this, so at
     // this seam the two spellings are one value. The escape is exercised where
     // it can still differ -- as authored source, in the parity corpus.
-    state
-      .top_imports
-      .push(import_from("zIndex.stylex.js", vec![named("zIndex", 1)]));
-    state
-      .top_imports
-      .push(import_from("accented.stylex.js", vec![named("zÍndex", 1)]));
+    state.push_top_import(import_from("zIndex.stylex.js", vec![named("zIndex", 1)]));
+    state.push_top_import(import_from("accented.stylex.js", vec![named("zÍndex", 1)]));
 
     assert!(get_import_by_ident(&ident_at("zIndex", 1), &state).is_some());
     assert!(get_import_by_ident(&ident_at("zÍndex", 1), &state).is_some());
@@ -1346,7 +1326,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn answers_with_the_specifier_that_bound_the_name() {
     let mut state = StateManager::default();
-    state.top_imports.push(import_from(
+    state.push_top_import(import_from(
       "tokens.stylex.js",
       vec![default_of("theme", 1), named("spacing", 1)],
     ));
@@ -1371,9 +1351,7 @@ mod get_import_by_ident_tests {
   #[test]
   fn an_empty_import_declaration_answers_for_nothing() {
     let mut state = StateManager::default();
-    state
-      .top_imports
-      .push(import_from("side-effect.css", vec![]));
+    state.push_top_import(import_from("side-effect.css", vec![]));
 
     // `import './side-effect.css'` binds no name at all. `Iterator::any` over
     // no specifiers is `false`, which is the answer -- pinned because a

--- a/crates/stylex-transform/src/shared/utils/validators.rs
+++ b/crates/stylex-transform/src/shared/utils/validators.rs
@@ -89,10 +89,7 @@ fn validate_single_object_arg_indent(
     build_code_frame_error_and_panic_at(init_expr, &non_static_value(fn_name), state);
   });
 
-  if state
-    .find_top_level_expr(init_call, |_| false, None)
-    .is_none()
-  {
+  if state.find_top_level_expr(init_call).is_none() {
     build_code_frame_error_and_panic_at(init_expr, &unbound_call_value(fn_name), state);
   }
 
@@ -200,13 +197,9 @@ pub(crate) fn validate_stylex_create(call: &CallExpr, state: &mut StateManager) 
   // `Expr::Call(call.clone())` deep-clones the whole style object, so it is
   // built lazily — only on the paths that are about to panic anyway.
   if state.find_call_declaration(call).is_none()
-    && state
-      .find_top_level_expr(
-        call,
-        |tpe: &TopLevelExpression| is_bound_create_expr(&tpe.1, call),
-        None,
-      )
-      .is_none()
+    && !state.has_top_level_expr(call, |tpe: &TopLevelExpression| {
+      is_bound_create_expr(&tpe.1, call)
+    })
   {
     build_code_frame_error_and_panic_at(
       &Expr::Call(call.clone()),
@@ -330,7 +323,7 @@ pub(crate) fn validate_stylex_create_theme_indent(
     );
   });
 
-  match state.find_top_level_expr(call, |_| false, None) {
+  match state.find_top_level_expr(call) {
     Some(_) => {},
     None => build_code_frame_error_and_panic(
       init_expr,
@@ -377,7 +370,7 @@ pub(crate) fn find_and_validate_stylex_define_vars(
 
   let call_expr = Expr::from(call.clone());
 
-  let stylex_create_theme_top_level_expr = match state.find_top_level_expr(call, |_| false, None) {
+  let stylex_create_theme_top_level_expr = match state.find_top_level_expr(call) {
     Some(stylex_create_theme_top_level_expr) => stylex_create_theme_top_level_expr,
     None => build_code_frame_error_and_panic(
       &call_expr,
@@ -487,7 +480,7 @@ pub(crate) fn find_and_validate_stylex_define_consts(
 
   let call_expr = Expr::from(call.clone());
 
-  let define_consts_top_level_expr = match state.find_top_level_expr(call, |_| false, None) {
+  let define_consts_top_level_expr = match state.find_top_level_expr(call) {
     Some(define_consts_top_level_expr) => define_consts_top_level_expr,
     None => build_code_frame_error_and_panic(
       &call_expr,
@@ -608,12 +601,9 @@ pub(crate) fn validate_define_call(
   state: &mut StateManager,
 ) -> TopLevelExpression {
   let call_expr = Expr::Call(call.clone());
-  let top_level_expr = state
-    .find_top_level_expr(call, |_| false, None)
-    .cloned()
-    .unwrap_or_else(|| {
-      build_code_frame_error_and_panic_at(&call_expr, &unbound_call_value(api_name), state)
-    });
+  let top_level_expr = state.find_top_level_expr(call).cloned().unwrap_or_else(|| {
+    build_code_frame_error_and_panic_at(&call_expr, &unbound_call_value(api_name), state)
+  });
 
   if require_export && !is_variable_named_exported(&top_level_expr, state) {
     build_code_frame_error_and_panic_at(&call_expr, &non_export_named_declaration(api_name), state);

--- a/crates/stylex-transform/src/transform/mod.rs
+++ b/crates/stylex-transform/src/transform/mod.rs
@@ -1,7 +1,7 @@
 use indexmap::{IndexMap, IndexSet};
 use rustc_hash::FxHashMap;
 use swc_core::{
-  common::{EqIgnoreSpan, Mark, comments::Comments},
+  common::{Mark, comments::Comments},
   ecma::{
     ast::{CallExpr, Callee, Expr, Id, MemberProp, Pass, VarDeclarator},
     transforms::{base::resolver, typescript::strip},
@@ -354,21 +354,7 @@ where
   ) -> (Option<String>, Option<VarDeclarator>) {
     let mut var_name: Option<String> = None;
 
-    let parent_var_decl = self
-      .state
-      .declarations
-      .iter()
-      .find(|decl| match &decl.init {
-        Some(init) => {
-          if let Expr::Call(init_call) = init.as_ref() {
-            init_call.eq_ignore_span(call)
-          } else {
-            false
-          }
-        },
-        _ => false,
-      })
-      .cloned();
+    let parent_var_decl = self.state.find_call_declaration(call).cloned();
 
     if let Some(ref parent_var_decl) = parent_var_decl
       && let Some(ident) = parent_var_decl.name.as_ident()

--- a/crates/stylex-transform/src/transform/stylex/transform_define_marker_call.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_define_marker_call.rs
@@ -91,9 +91,9 @@ where
     // here and there takes `&mut self.state` — `get_filename_for_hashing`
     // borrows it shared, and the rest only reads `options` — so the vector
     // cannot have been pushed to or reordered.
-    if let Some(declaration) = self.state.declarations.get_mut(parent_var_decl_index) {
-      declaration.init = Some(Box::new(marker_obj_ast.clone()));
-    }
+    self
+      .state
+      .set_declaration_init(parent_var_decl_index, marker_obj_ast.clone());
 
     Some(marker_obj_ast)
   }

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
@@ -80,7 +80,7 @@ use stylex_enums::{counter_mode::CounterMode, style_resolution::StyleResolution}
 use stylex_regex::regex::VAR_EXTRACTION_REGEX;
 use stylex_structures::{
   dynamic_style::DynamicStyle, order_pair::OrderPair, stylex_state_options::StyleXStateOptions,
-  top_level_expression::TopLevelExpression, uid_generator::UidGenerator,
+  uid_generator::UidGenerator,
 };
 use stylex_types::structures::injectable_style::InjectableStyle;
 use stylex_types::traits::WhenMarkerValue;
@@ -193,15 +193,17 @@ where
       // Asked first: it is a hash lookup on two integers, where
       // `find_top_level_expr` compares this call against every recorded one
       // with `eq_ignore_span` — a deep walk of the whole style object.
+      //
+      // The array question does not read the call, so it is a counter rather
+      // than a second walk. It keeps the answer the walk gave, including the
+      // case where the module holds an array that no longer belongs to this
+      // call.
       let is_program_level = self
         .state
         .pattern_bound_top_level_calls
         .contains(&call.span)
-        || self
-          .state
-          .has_top_level_expr(call, |tpe: &TopLevelExpression| {
-            matches!(tpe.1, Expr::Array(_))
-          });
+        || self.state.find_top_level_expr(call).is_some()
+        || self.state.holds_top_level_array();
 
       let mut first_arg = call.args.first()?.expr.clone();
 

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
@@ -199,12 +199,9 @@ where
         .contains(&call.span)
         || self
           .state
-          .find_top_level_expr(
-            call,
-            |tpe: &TopLevelExpression| matches!(tpe.1, Expr::Array(_)),
-            None,
-          )
-          .is_some();
+          .has_top_level_expr(call, |tpe: &TopLevelExpression| {
+            matches!(tpe.1, Expr::Array(_))
+          });
 
       let mut first_arg = call.args.first()?.expr.clone();
 
@@ -335,8 +332,7 @@ where
         if let Some(parent_var_decl) = parent_var_decl {
           self
             .state
-            .style_vars
-            .insert(var_name.clone(), parent_var_decl);
+            .insert_style_var(var_name.clone(), parent_var_decl);
         } else {
           let call_expr = Expr::Call(call.clone());
 

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
@@ -194,16 +194,17 @@ where
       // `find_top_level_expr` compares this call against every recorded one
       // with `eq_ignore_span` — a deep walk of the whole style object.
       //
-      // The array question does not read the call, so it is a counter rather
-      // than a second walk. It keeps the answer the walk gave, including the
-      // case where the module holds an array that no longer belongs to this
-      // call.
+      // A call inside a top-level array is program level too, and the entry
+      // recorded for it is the array. Asked of the arrays alone rather than of
+      // every recorded expression, and answered by containment: a call written
+      // inside a function is not at program level because the module holds an
+      // array elsewhere.
       let is_program_level = self
         .state
         .pattern_bound_top_level_calls
         .contains(&call.span)
         || self.state.find_top_level_expr(call).is_some()
-        || self.state.holds_top_level_array();
+        || self.state.holds_call_in_top_level_array(call);
 
       let mut first_arg = call.args.first()?.expr.clone();
 

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_import_decl.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_import_decl.rs
@@ -21,7 +21,7 @@ where
         return;
       }
 
-      self.state.top_imports.push(import_decl.clone());
+      self.state.push_top_import(import_decl.clone());
 
       let source_path = convert_atom_to_string(&import_decl.src.value);
 

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
@@ -116,9 +116,11 @@ where
           .and_then(|var_name| Some((var_name.name.as_ident()?, var_name)))
         {
           let Some(init) = var_name.init.as_deref() else {
-            stylex_panic!(
-              "Variable declaration must have an initializer for top-level expression lookup."
-            )
+            // A style variable is only ever recorded from a declarator its own
+            // initializer identified, so this cannot happen. Skipping keeps an
+            // unreachable shape from becoming an abort -- and from becoming a
+            // region no test can cover.
+            return;
           };
 
           let top_level_expression = self.state.find_top_level_expr_named(&binding.sym, init);

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 use stylex_macros::stylex_panic;
 use swc_core::{
   atoms::Atom,
-  common::{EqIgnoreSpan, comments::Comments},
+  common::comments::Comments,
   ecma::{
     ast::{
       CallExpr, Callee, Expr, KeyValueProp, Lit, ObjectLit, ObjectPatProp, Pat, Prop, PropName,
@@ -38,7 +38,7 @@ use crate::{
 use stylex_atoms::transform::ATOMS_SOURCE;
 use stylex_constants::constants::{
   api_names::STYLEX_CREATE,
-  messages::{KEY_VALUE_EXPECTED, PROPERTY_NOT_FOUND, VAR_DECL_NAME_NOT_IDENT},
+  messages::{KEY_VALUE_EXPECTED, PROPERTY_NOT_FOUND},
 };
 use stylex_enums::core::TransformationCycle;
 use stylex_structures::named_import_source::ImportSources;
@@ -102,21 +102,28 @@ where
           }
         }
 
-        for var_name in self.state.style_vars.values() {
-          if !var_declarator.eq_ignore_span(var_name) {
-            continue;
+        // The style variable this declarator is, and the top-level expression
+        // it was declared as -- both found by the name they are bound to rather
+        // than by a walk of every style variable and every recorded expression
+        // in the module, which ran once per declarator the finalize cycle
+        // visits.
+        // A style variable is bound to a name -- `matching_style_var` answers
+        // only for a declarator that is -- so the binding is read once here and
+        // both the lookup and the namespace set are asked with it.
+        if let Some((binding, var_name)) = self
+          .state
+          .matching_style_var(var_declarator)
+          .and_then(|var_name| Some((var_name.name.as_ident()?, var_name)))
+        {
+          let Some(init) = var_name.init.as_deref() else {
+            stylex_panic!(
+              "Variable declaration must have an initializer for top-level expression lookup."
+            )
           };
 
-          let top_level_expression = self.state.top_level_expressions.iter().find(
-            |TopLevelExpression(_, expr, _)| match var_name.init.as_ref() {
-              Some(init) => init.as_ref().eq_ignore_span(expr),
-              None => {
-                stylex_panic!(
-                  "Variable declaration must have an initializer for top-level expression lookup."
-                )
-              },
-            },
-          );
+          let top_level_expression = self
+            .state
+            .find_top_level_expr_named(&binding.sym.clone(), init);
 
           if let Some(TopLevelExpression(kind, _, _)) = top_level_expression
             && *kind == TopLevelExpressionKind::Stmt
@@ -125,10 +132,7 @@ where
               .as_mut()
               .and_then(|var_decl| var_decl.as_mut_object())
           {
-            let var_id = match var_name.name.as_ident() {
-              Some(i) => i.id.to_id(),
-              None => stylex_panic!("{}", VAR_DECL_NAME_NOT_IDENT),
-            };
+            let var_id = binding.id.to_id();
 
             let namespaces_to_keep = match vars_to_keep.get(&var_id) {
               Some(NonNullProps::Vec(vec)) => vec.clone(),

--- a/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
+++ b/crates/stylex-transform/src/transform/visit_mut/visit_mut_var_declarator.rs
@@ -121,9 +121,7 @@ where
             )
           };
 
-          let top_level_expression = self
-            .state
-            .find_top_level_expr_named(&binding.sym.clone(), init);
+          let top_level_expression = self.state.find_top_level_expr_named(&binding.sym, init);
 
           if let Some(TopLevelExpression(kind, _, _)) = top_level_expression
             && *kind == TopLevelExpressionKind::Stmt

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/program_level_positions.rs/a_create_inside_a_top_level_array_stays_where_it_was_written.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/program_level_positions.rs/a_create_inside_a_top_level_array_stays_where_it_was_written.js
@@ -1,0 +1,9 @@
+import * as stylex from '@stylexjs/stylex';
+export const lotsOfStyles = [
+    {
+        a: {
+            kMwMTN: "x1e2nbdu",
+            $$css: true
+        }
+    }
+];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/program_level_positions.rs/a_nested_create_is_hoisted_although_the_module_holds_an_array.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/program_level_positions.rs/a_nested_create_is_hoisted_although_the_module_holds_an_array.js
@@ -1,0 +1,19 @@
+import * as stylex from '@stylexjs/stylex';
+const _styles = {
+    b: {
+        kMwMTN: "xju2f9n",
+        $$css: true
+    }
+};
+export const lotsOfStyles = [
+    {
+        a: {
+            kMwMTN: "x1e2nbdu",
+            $$css: true
+        }
+    }
+];
+export function Component() {
+    const styles = _styles;
+    return stylex.props(styles.b);
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/program_level_positions.rs/a_nested_create_is_hoisted_when_the_module_holds_no_array.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/program_level_positions.rs/a_nested_create_is_hoisted_when_the_module_holds_no_array.js
@@ -1,0 +1,11 @@
+import * as stylex from '@stylexjs/stylex';
+const _styles = {
+    b: {
+        kMwMTN: "xju2f9n",
+        $$css: true
+    }
+};
+export function Component() {
+    const styles = _styles;
+    return stylex.props(styles.b);
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/structurally_identical_calls.rs/exported_style_object_survives_an_identical_unexported_one.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/structurally_identical_calls.rs/exported_style_object_survives_an_identical_unexported_one.js
@@ -1,0 +1,10 @@
+import * as stylex from '@stylexjs/stylex';
+export const a = {
+    red: {
+        kMwMTN: "x1e2nbdu",
+        $$css: true
+    }
+};
+export const x = {
+    className: "x1e2nbdu"
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/structurally_identical_calls.rs/exported_style_object_survives_when_it_is_declared_first.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/structurally_identical_calls.rs/exported_style_object_survives_when_it_is_declared_first.js
@@ -1,0 +1,10 @@
+import * as stylex from '@stylexjs/stylex';
+export const a = {
+    red: {
+        kMwMTN: "x1e2nbdu",
+        $$css: true
+    }
+};
+export const x = {
+    className: "x1e2nbdu"
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/structurally_identical_calls.rs/two_identical_exported_style_objects_both_survive.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/structurally_identical_calls.rs/two_identical_exported_style_objects_both_survive.js
@@ -1,0 +1,13 @@
+import * as stylex from '@stylexjs/stylex';
+export const a = {
+    red: {
+        kMwMTN: "x1e2nbdu",
+        $$css: true
+    }
+};
+export const b = {
+    red: {
+        kMwMTN: "x1e2nbdu",
+        $$css: true
+    }
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_vars_test/structurally_identical_calls.rs/two_identical_define_vars_calls_keep_their_own_export_ids.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_define_vars_test/structurally_identical_calls.rs/two_identical_define_vars_calls_keep_their_own_export_ids.js
@@ -1,0 +1,9 @@
+import * as stylex from '@stylexjs/stylex';
+export const a = {
+    color: "var(--x10z46f0)",
+    __varGroupHash__: "xjhlizl"
+};
+export const b = {
+    color: "var(--xxsbfo1)",
+    __varGroupHash__: "x16hr37e"
+};

--- a/crates/stylex-transform/tests/transform_stylex_create_test/mod.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/mod.rs
@@ -43,6 +43,7 @@ mod short_circuited_operands;
 mod static_styles;
 mod string_coercion;
 mod string_concatenation;
+mod structurally_identical_calls;
 mod stylex_functions_in_a_fold;
 mod template_interpolation;
 mod theme_members_in_a_fold;

--- a/crates/stylex-transform/tests/transform_stylex_create_test/mod.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/mod.rs
@@ -37,6 +37,7 @@ mod number_prototype_receivers;
 mod object_method_refusals;
 mod object_own_keys;
 mod operator_interaction;
+mod program_level_positions;
 mod refusals_a_module_reaches;
 mod refusals_that_fall_through;
 mod short_circuited_operands;

--- a/crates/stylex-transform/tests/transform_stylex_create_test/program_level_positions.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/program_level_positions.rs
@@ -1,0 +1,65 @@
+//! Where a `stylex.create` is written, and what that decides.
+//!
+//! A call at program level keeps the compiled object where the author put it. A
+//! call written inside a function is hoisted to a program-level `const` and read
+//! from there, so the object is built once rather than on every call.
+//!
+//! The question is about the position of *this* call. A module can hold a
+//! top-level array of styles and a component that declares its own, and the
+//! array says nothing about the component: reading the presence of an array as
+//! an answer for every call in the module left a nested style object built on
+//! each render.
+//!
+//! Every expectation below is compared against measured output of
+//! `@stylexjs/babel-plugin` 0.19.0 under the same options. Which calls are
+//! hoisted, and what each compiled object holds, agree with it.
+//!
+//! One thing does not, and it is neither new nor about the position being
+//! decided here: this compiler puts a hoisted declaration at the top of the
+//! module, where upstream puts it directly before the statement that holds the
+//! call. The second case below shows the difference. It shows the same way in a
+//! module with no array at all, so it belongs to the insertion rather than to
+//! this question, and to a change of its own.
+
+use crate::utils::prelude::*;
+
+fn stylex_transform(
+  comments: TestComments,
+  customize: impl FnOnce(TestBuilder) -> TestBuilder,
+) -> impl Pass {
+  build_test_transform(comments, customize)
+}
+
+stylex_test!(
+  a_create_inside_a_top_level_array_stays_where_it_was_written,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const lotsOfStyles = [stylex.create({ a: { color: 'red' } })];
+  "#
+);
+
+stylex_test!(
+  a_nested_create_is_hoisted_although_the_module_holds_an_array,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const lotsOfStyles = [stylex.create({ a: { color: 'red' } })];
+    export function Component() {
+      const styles = stylex.create({ b: { color: 'blue' } });
+      return stylex.props(styles.b);
+    }
+  "#
+);
+
+stylex_test!(
+  a_nested_create_is_hoisted_when_the_module_holds_no_array,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export function Component() {
+      const styles = stylex.create({ b: { color: 'blue' } });
+      return stylex.props(styles.b);
+    }
+  "#
+);

--- a/crates/stylex-transform/tests/transform_stylex_create_test/structurally_identical_calls.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/structurally_identical_calls.rs
@@ -1,0 +1,53 @@
+//! Two `stylex.create` calls that read the same, where only one of them is
+//! exported.
+//!
+//! The state manager pins a declarator to its top-level entry by the name it
+//! binds. Pinning it by the expression instead conflates these two calls, since
+//! nothing but the name tells them apart: the exported declarator resolved to
+//! the statement entry the unexported one recorded, read that entry's kind, and
+//! skipped the pruning that belongs to an export. What that costs is visible
+//! only in the emitted module, which is what these cases hold.
+//!
+//! Every expectation below is measured output of `@stylexjs/babel-plugin`
+//! 0.19.0 under the same options.
+
+use crate::utils::prelude::*;
+
+fn stylex_transform(
+  comments: TestComments,
+  customize: impl FnOnce(TestBuilder) -> TestBuilder,
+) -> impl Pass {
+  build_test_transform(comments, customize)
+}
+
+stylex_test!(
+  exported_style_object_survives_an_identical_unexported_one,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    const b = stylex.create({ red: { color: 'red' } });
+    export const a = stylex.create({ red: { color: 'red' } });
+    export const x = stylex.props(b.red);
+  "#
+);
+
+stylex_test!(
+  exported_style_object_survives_when_it_is_declared_first,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const a = stylex.create({ red: { color: 'red' } });
+    const b = stylex.create({ red: { color: 'red' } });
+    export const x = stylex.props(b.red);
+  "#
+);
+
+stylex_test!(
+  two_identical_exported_style_objects_both_survive,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const a = stylex.create({ red: { color: 'red' } });
+    export const b = stylex.create({ red: { color: 'red' } });
+  "#
+);

--- a/crates/stylex-transform/tests/transform_stylex_define_vars_test/mod.rs
+++ b/crates/stylex-transform/tests/transform_stylex_define_vars_test/mod.rs
@@ -6,3 +6,4 @@ mod options_debug_true_tests;
 mod options_dev_true_tests;
 mod options_runtime_injection_true;
 mod options_theme_file_extension_tests;
+mod structurally_identical_calls;

--- a/crates/stylex-transform/tests/transform_stylex_define_vars_test/structurally_identical_calls.rs
+++ b/crates/stylex-transform/tests/transform_stylex_define_vars_test/structurally_identical_calls.rs
@@ -1,0 +1,39 @@
+//! Two `stylex.defineVars` calls that read the same, in one module.
+//!
+//! `defineVars` resolves its declarator by the expression it holds rather than
+//! by the name it binds, so two identical calls share one key. What keeps them
+//! apart is that rewriting the first moves it off that key, which leaves the
+//! second alone in the bucket by the time it is processed. Nothing else pins
+//! that recovery, and what it costs if it stops working is a wrong CSS custom
+//! property name, because `defineVars` derives its export ID from the variable
+//! the call is bound to.
+//!
+//! Every expectation below is measured output of `@stylexjs/babel-plugin`
+//! 0.19.0 under the same options.
+
+use crate::utils::prelude::*;
+use swc_core::common::FileName;
+
+fn stylex_transform(
+  comments: TestComments,
+  customize: impl FnOnce(TestBuilder) -> TestBuilder,
+) -> impl Pass {
+  build_test_transform(comments, |b| {
+    customize(
+      b.with_filename(FileName::Real("/stylex/packages/vars.stylex.js".into()))
+        .with_unstable_module_resolution(ModuleResolution::common_js(Some(
+          "/stylex/packages/".to_string(),
+        ))),
+    )
+  })
+}
+
+stylex_test!(
+  two_identical_define_vars_calls_keep_their_own_export_ids,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const a = stylex.defineVars({ color: 'red' });
+    export const b = stylex.defineVars({ color: 'red' });
+  "#
+);

--- a/crates/stylex-utils/Cargo.toml
+++ b/crates/stylex-utils/Cargo.toml
@@ -21,7 +21,6 @@ serde_json.workspace = true
 swc_core = { workspace = true, features = ["common", "ecma_ast", "ecma_utils"] }
 xxhash-rust.workspace = true
 
-
 [dev-dependencies]
 swc_ecma_parser.workspace = true
 

--- a/crates/stylex-utils/Cargo.toml
+++ b/crates/stylex-utils/Cargo.toml
@@ -21,7 +21,6 @@ serde_json.workspace = true
 swc_core = { workspace = true, features = ["common", "ecma_ast", "ecma_utils"] }
 xxhash-rust.workspace = true
 
-stylex_regex = { path = "../stylex-regex" }
 
 [dev-dependencies]
 swc_ecma_parser.workspace = true

--- a/crates/stylex-utils/src/hash.rs
+++ b/crates/stylex-utils/src/hash.rs
@@ -1,7 +1,8 @@
 use std::{
   collections::hash_map::DefaultHasher,
   hash::{Hash, Hasher},
-  mem::discriminant,
+  mem::{Discriminant, discriminant},
+  sync::LazyLock,
 };
 
 use xxhash_rust::xxh3::Xxh3Default;
@@ -11,11 +12,11 @@ use swc_core::{
   ecma::{
     ast::{
       ArrayLit, ArrowExpr, AwaitExpr, BigInt, BinExpr, BlockStmtOrExpr, Bool, CallExpr, Callee,
-      ComputedPropName, CondExpr, Expr, ExprOrSpread, Ident, IdentName, Import, Lit, MemberExpr,
-      MemberProp, MetaPropExpr, NewExpr, Null, Number, ObjectLit, OptCall, OptChainBase,
-      OptChainExpr, ParenExpr, Pat, PrivateName, Prop, PropName, PropOrSpread, Regex, SeqExpr, Str,
-      Super, SuperProp, SuperPropExpr, TaggedTpl, ThisExpr, Tpl, TplElement, UnaryExpr, UpdateExpr,
-      YieldExpr,
+      ComputedPropName, CondExpr, Expr, ExprOrSpread, Ident, IdentName, Import, Invalid, Lit,
+      MemberExpr, MemberProp, MetaPropExpr, NewExpr, Null, Number, ObjectLit, OptCall,
+      OptChainBase, OptChainExpr, ParenExpr, Pat, PrivateName, Prop, PropName, PropOrSpread, Regex,
+      SeqExpr, Str, Super, SuperProp, SuperPropExpr, TaggedTpl, ThisExpr, Tpl, TplElement,
+      UnaryExpr, UpdateExpr, YieldExpr,
     },
     utils::drop_span,
   },
@@ -294,6 +295,46 @@ pub fn stable_hash_unspanned_call(call: &CallExpr) -> u128 {
     hasher.finish_wide()
   } else {
     stable_hash_wide(&drop_span(Expr::Call(call.clone())))
+  }
+}
+
+/// Hashes a [`MemberExpr`] producing the exact same key as
+/// `stable_hash_unspanned(&Expr::Member(member.clone()))` — so a member
+/// expression can be looked up against a map keyed by whole-`Expr` spread
+/// hashes — without cloning it into an owned `Expr` on the common, fully
+/// hashable path.
+///
+/// The counterpart of [`stable_hash_unspanned_call`], and it exists for the
+/// same reason: the caller holds a borrowed node and the question it asks runs
+/// on a hot path, so materializing an owned `Expr` per lookup is the cost the
+/// helper removes.
+///
+/// Unlike the call variant, the `Expr::Member` discriminant cannot be taken
+/// from a throwaway stack value: `MemberExpr::obj` is a `Box`, so building one
+/// would allocate on every call. It is computed once into a `LazyLock`
+/// instead. `Discriminant<T>` is `Send + Sync` for every `T` and depends only
+/// on the variant, never on the contents.
+#[inline]
+pub fn stable_hash_unspanned_member(member: &MemberExpr) -> u128 {
+  static MEMBER_DISCRIMINANT: LazyLock<Discriminant<Expr>> = LazyLock::new(|| {
+    discriminant(&Expr::Member(MemberExpr {
+      span: DUMMY_SP,
+      obj: Box::new(Expr::Invalid(Invalid { span: DUMMY_SP })),
+      prop: MemberProp::PrivateName(PrivateName {
+        span: DUMMY_SP,
+        name: "".into(),
+      }),
+    }))
+  });
+
+  let mut hasher = WideHasher::new();
+
+  MEMBER_DISCRIMINANT.hash(&mut hasher);
+
+  if hash_member_expr_unspanned(member, &mut hasher) {
+    hasher.finish_wide()
+  } else {
+    stable_hash_wide(&drop_span(Expr::Member(member.clone())))
   }
 }
 

--- a/crates/stylex-utils/src/hash.rs
+++ b/crates/stylex-utils/src/hash.rs
@@ -299,10 +299,13 @@ pub fn stable_hash_unspanned_call(call: &CallExpr) -> u128 {
 }
 
 /// Hashes a [`MemberExpr`] producing the exact same key as
-/// `stable_hash_unspanned(&Expr::Member(member.clone()))` — so a member
-/// expression can be looked up against a map keyed by whole-`Expr` spread
-/// hashes — without cloning it into an owned `Expr` on the common, fully
-/// hashable path.
+/// `stable_hash_unspanned(&Expr::Member(member.clone()))`, without cloning it
+/// into an owned `Expr` on the common, fully hashable path.
+///
+/// Nothing relies on that parity today: `callee_members` is the only map keyed
+/// this way, and it is written and read through this function alone. Kept
+/// identical anyway so a future consumer keyed by whole-`Expr` hashes can probe
+/// it without a special case, and pinned by the tests beside it.
 ///
 /// The counterpart of [`stable_hash_unspanned_call`], and it exists for the
 /// same reason: the caller holds a borrowed node and the question it asks runs

--- a/crates/stylex-utils/src/string.rs
+++ b/crates/stylex-utils/src/string.rs
@@ -17,6 +17,9 @@ pub fn dashify(s: &str) -> Cow<'_, str> {
     return Cow::Borrowed(s);
   }
 
+  // The input's length plus room for the hyphens this inserts. A CSS property
+  // name spells one or two, and overshooting by a few bytes costs less than the
+  // realloc that undershooting buys.
   let mut dashed = String::with_capacity(s.len() + 4);
   let mut previous: Option<char> = None;
 
@@ -36,6 +39,14 @@ pub fn dashify(s: &str) -> Cow<'_, str> {
     previous = Some(character);
   }
 
+  // Lowercased in a second pass over the built string rather than per character
+  // on the way in, which would save this allocation and be wrong.
+  // `str::to_lowercase` is context-sensitive where `char::to_lowercase` is not:
+  // a Greek capital sigma lowercases to the final form at the end of a word and
+  // the medial form elsewhere, and a single character cannot know which it is.
+  // `dashify("aBΣ")` is `a-bς` through the string and `a-bσ` through the chars.
+  // The regex this replaced also lowercased the finished string, so this keeps
+  // the answer it gave.
   Cow::Owned(dashed.to_lowercase())
 }
 

--- a/crates/stylex-utils/src/string.rs
+++ b/crates/stylex-utils/src/string.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-use stylex_regex::regex::DASHIFY_REGEX;
-
 /// Converts a camelCase or PascalCase string to its hyphenated (kebab-case)
 /// equivalent by inserting hyphens before uppercase letters and lowercasing
 /// the result.
@@ -19,7 +17,26 @@ pub fn dashify(s: &str) -> Cow<'_, str> {
     return Cow::Borrowed(s);
   }
 
-  Cow::Owned(DASHIFY_REGEX.replace_all(s, "-$1").to_lowercase())
+  let mut dashed = String::with_capacity(s.len() + 4);
+  let mut previous: Option<char> = None;
+
+  for character in s.chars() {
+    // The rule the pattern `(?<=^|[a-z])([A-Z])` spelled: an ASCII uppercase
+    // letter takes a hyphen when it opens the string or follows an ASCII
+    // lowercase one. Both classes are ASCII in the pattern, so a preceding
+    // non-ASCII character is no more a match here than it was there --
+    // `Ǆolume` keeps its single leading character either way.
+    if character.is_ascii_uppercase()
+      && previous.is_none_or(|previous| previous.is_ascii_lowercase())
+    {
+      dashed.push('-');
+    }
+
+    dashed.push(character);
+    previous = Some(character);
+  }
+
+  Cow::Owned(dashed.to_lowercase())
 }
 
 /// Whether a value spells no CSS text at all — empty, or nothing but

--- a/crates/stylex-utils/src/tests/hash_test.rs
+++ b/crates/stylex-utils/src/tests/hash_test.rs
@@ -432,7 +432,8 @@ mod hash_f64_tests {
 #[cfg(test)]
 mod unspanned_fast_path_tests {
   use super::super::{
-    create_hash, stable_hash_unspanned, stable_hash_unspanned_call, stable_hash_wide, to_base36,
+    create_hash, stable_hash_unspanned, stable_hash_unspanned_call, stable_hash_unspanned_member,
+    stable_hash_wide, to_base36,
   };
   use swc_core::{
     common::{DUMMY_SP, SyntaxContext},
@@ -773,6 +774,70 @@ mod unspanned_fast_path_tests {
     assert_eq!(
       stable_hash_unspanned_call(call),
       stable_hash_unspanned_call(shifted_call)
+    );
+  }
+
+  #[test]
+  fn unspanned_member_hash_matches_whole_expr() {
+    let expr = parse_expr("foo.bar");
+    let Expr::Member(member) = &expr else {
+      panic!("expected a member expression");
+    };
+
+    // The dedicated member hasher must produce exactly the same key as hashing
+    // the member wrapped in a whole `Expr`, for the reason its call-shaped
+    // counterpart must: the two sides of a lookup reach the key differently.
+    assert_eq!(
+      stable_hash_unspanned_member(member),
+      stable_hash_unspanned(&expr)
+    );
+
+    // ...and it must stay span-insensitive.
+    let shifted = parse_expr("      foo.bar");
+    let Expr::Member(shifted_member) = &shifted else {
+      panic!("expected a member expression");
+    };
+    assert_eq!(
+      stable_hash_unspanned_member(member),
+      stable_hash_unspanned_member(shifted_member)
+    );
+
+    // Different members must not collide on the discriminant prefix alone.
+    let other = parse_expr("foo.baz");
+    let Expr::Member(other_member) = &other else {
+      panic!("expected a member expression");
+    };
+    assert_ne!(
+      stable_hash_unspanned_member(member),
+      stable_hash_unspanned_member(other_member)
+    );
+  }
+
+  #[test]
+  fn unspanned_member_hash_fallback_matches_whole_expr() {
+    // A computed key holding a function expression is a shape the in-place
+    // hasher does not cover, so `stable_hash_unspanned_member` takes its
+    // fallback branch. On that branch it must still agree with
+    // `stable_hash_unspanned` over the whole `Expr::Member`, which falls back
+    // identically -- keeping the insertion-side and lookup-side keys aligned
+    // for exotic members too.
+    let expr = parse_expr("foo[function () {}]");
+    let Expr::Member(member) = &expr else {
+      panic!("expected a member expression");
+    };
+
+    assert_eq!(
+      stable_hash_unspanned_member(member),
+      stable_hash_unspanned(&expr)
+    );
+
+    let shifted = parse_expr("      foo[function () {}]");
+    let Expr::Member(shifted_member) = &shifted else {
+      panic!("expected a member expression");
+    };
+    assert_eq!(
+      stable_hash_unspanned_member(member),
+      stable_hash_unspanned_member(shifted_member)
     );
   }
 

--- a/crates/stylex-utils/src/tests/string_test.rs
+++ b/crates/stylex-utils/src/tests/string_test.rs
@@ -87,6 +87,25 @@ mod dashify_tests {
   fn handles_single_uppercase() {
     assert_eq!(dashify("A"), "-a");
   }
+
+  /// The hyphen tracks a preceding *lowercase* letter, not merely a
+  /// non-uppercase one, so only the first of a run takes one -- which is what
+  /// `(?<=^|[a-z])` spelled, and what the hand-rolled scan that replaced it has
+  /// to reproduce. Expectations produced by running
+  /// `str.replace(/(^|[a-z])([A-Z])/g, '$1-$2').toLowerCase()`.
+  #[test]
+  fn only_the_first_of_a_run_of_uppercase_takes_a_hyphen() {
+    assert_eq!(dashify("aBC"), "a-bc");
+    assert_eq!(dashify("msTransformXY"), "ms-transform-xy");
+    assert_eq!(dashify("ABC"), "-abc");
+  }
+
+  /// A digit is not a lowercase letter, so an uppercase letter after one takes
+  /// no hyphen -- the other half of the class the lookbehind named.
+  #[test]
+  fn a_digit_before_an_uppercase_letter_takes_no_hyphen() {
+    assert_eq!(dashify("grid2Column"), "grid2column");
+  }
 }
 
 #[cfg(test)]

--- a/crates/stylex-utils/src/tests/string_test.rs
+++ b/crates/stylex-utils/src/tests/string_test.rs
@@ -25,6 +25,14 @@ mod dashify_tests {
     assert_eq!(dashify("a"), "a");
   }
 
+  /// The lowercasing has to see the finished string. `char::to_lowercase` is
+  /// context-free, so fusing it into the hyphen scan would spell a trailing
+  /// Greek sigma in its medial form.
+  #[test]
+  fn lowercases_a_trailing_sigma_to_its_final_form() {
+    assert_eq!(dashify("aBΣ"), "a-bς");
+  }
+
   #[test]
   fn handles_empty_string() {
     assert_eq!(dashify(""), "");


### PR DESCRIPTION
## Description

This pull request introduces a new benchmark for the consumer phase of the StyleX transform and makes several related updates across the codebase. The main goal is to measure and ensure the transform's performance remains linear with respect to the number of `stylex.*` calls in a module, preventing regressions to quadratic complexity. Additionally, minor dependency and test updates are included to support the benchmark and improve code clarity.

**Benchmarking and Performance Measurement:**

* Added a new benchmark, `transform_consumers_bench`, which generates synthetic modules with varying numbers of components and measures the time spent in the consumer phase of the StyleX transform to ensure linear scaling. The benchmark asserts that all `stylex.props` calls are resolved and analyzes per-component cost. [[1]](diffhunk://#diff-0f6ee6ad78b748af96c184d1cd49238f85abe20fd2ccd0dbe74615dca3636262R1-R267) [[2]](diffhunk://#diff-bc568107cce36a60bcba6caf9d2e06431e0c016b8af8457fb4beb0274acfd44aR88-R91)

**Test and Fixture Updates:**

* Updated test cases and fixtures to include new generated values (such as `"rgb(0, {index}, 0)"` and `"rgb({index}, 0, 0)"`) in `harvested.json`, parser cases, and unit cases to align with the new benchmark scenarios. [[1]](diffhunk://#diff-f835a7fd0d73f2f66dbf16a4763df695d3bd5859ee350c6a0ba698512e36cc19R221-R226) [[2]](diffhunk://#diff-f835a7fd0d73f2f66dbf16a4763df695d3bd5859ee350c6a0ba698512e36cc19R1541-R1546) [[3]](diffhunk://#diff-b5923ce1f414ea29a24b2b97cdf4ba9479adb0eb14876278a598601768dbdd4fR810-R814) [[4]](diffhunk://#diff-b5923ce1f414ea29a24b2b97cdf4ba9479adb0eb14876278a598601768dbdd4fR1580-R1584) [[5]](diffhunk://#diff-b5923ce1f414ea29a24b2b97cdf4ba9479adb0eb14876278a598601768dbdd4fL4927-R4937) [[6]](diffhunk://#diff-b5923ce1f414ea29a24b2b97cdf4ba9479adb0eb14876278a598601768dbdd4fR5127) [[7]](diffhunk://#diff-b5923ce1f414ea29a24b2b97cdf4ba9479adb0eb14876278a598601768dbdd4fL32-R32)

**Dependency and Allocator Configuration:**

* Added the `swc_malloc` dependency (which uses `mimalloc` except on problematic targets) to improve allocation performance during the transform, and ensured it is linked in both the root and workspace manifests. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R110-R115) [[2]](diffhunk://#diff-60b48722d886b4f63978a64c2bdfc40e302facc62c816aa69c7233fa5f0b13e0R30) [[3]](diffhunk://#diff-034485a0429c4b30464593523de6a4a521674a7f1a1db0d7a7b2398333137e32R3-R17)

**Documentation Improvements:**

* Expanded `CONTEXT.md` with a detailed explanation of the "candidate index" concept, clarifying terminology around state management and lookup strategies in the transform.

**Code and Test Cleanup:**

* Removed unused code and references to `DASHIFY_REGEX` in the regex module and its test coverage, reflecting its deprecation or irrelevance to current transform logic. [[1]](diffhunk://#diff-e9c0eae6e17a0d1243021c689eb4597e5e23f77aa42335a11f7769a33b9d1db9L24-L28) [[2]](diffhunk://#diff-519a29b59699dd0c3e6d8b723032429d00c5ce3bd66be87b424bd3b038cfa749L6-R8) [[3]](diffhunk://#diff-519a29b59699dd0c3e6d8b723032429d00c5ce3bd66be87b424bd3b038cfa749L37)
* Removed an unused error message from `messages.rs` to clean up the codebase.
* Optimized the `get_compound_pseudo_priority` function to avoid unnecessary regex evaluation for non-pseudo selectors, improving performance for common property names.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
