### PR TITLE
Enhance state crate coverage and unify exclusion lists comparison

### DIFF
--- a/.lsp.json
+++ b/.lsp.json
@@ -1,0 +1,10 @@
+{
+  "rust": {
+    "command": "rust-analyzer",
+    "args": [],
+    "extensionToLanguage": {
+      ".rs": "rust"
+    },
+    "transport": "stdio"
+  }
+}

--- a/crates/stylex-state/src/state_manager.rs
+++ b/crates/stylex-state/src/state_manager.rs
@@ -1,6 +1,5 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::OnceCell;
-use std::collections::hash_map::Entry;
 use std::{option::Option, path::Path, rc::Rc, sync::Arc};
 use stylex_macros::{stylex_panic, stylex_unimplemented};
 
@@ -55,7 +54,6 @@ use stylex_state_index::{
 use stylex_structures::{
   style_vars_to_keep::StyleVarsToKeep, top_level_expression::TopLevelExpression,
 };
-use stylex_types::enums::data_structures::injectable_style::InjectableStyleKind;
 use stylex_utils::hash::{
   stable_hash_unspanned, stable_hash_unspanned_call, stable_hash_unspanned_member,
 };
@@ -413,33 +411,33 @@ impl CallExpressionState {
 
   /// Drops one occurrence of `member` from its bucket, forgetting the bucket
   /// once nothing holds it.
+  ///
+  /// One pass rather than a search and a shift, and no arm of its own for a
+  /// member the bucket does not hold: the last call that holds a member drops
+  /// it, any other one only decrements the count that keeps it alive for the
+  /// calls left, and a member nothing counts leaves every count as it was.
+  ///
+  /// At most one entry can match, because [`Self::add_call_expression`] counts a
+  /// second occurrence of a member onto the entry it finds rather than pushing a
+  /// second one -- so one release drops one occurrence, as the name says. A
+  /// count starts at one and is only ever raised, so the decrement below cannot
+  /// take one past zero.
+  ///
+  /// The lookup makes a bucket for a key that has none, which the emptiness
+  /// check drops again, so a miss leaves the index as it found it. Nothing pays
+  /// for that: every caller hands back a callee taken out of the call map, and
+  /// every member that map holds was bucketed when its call was recorded.
   fn release_member(&mut self, member: &MemberExpr) {
-    let Entry::Occupied(mut occupied) = self
-      .callee_members
-      .entry(stable_hash_unspanned_member(member))
-    else {
-      return;
-    };
+    let key = stable_hash_unspanned_member(member);
+    let bucket = self.callee_members.entry(key).or_default();
 
-    let bucket = occupied.get_mut();
-
-    if let Some(position) = bucket
-      .iter()
-      .position(|(candidate, _)| candidate.eq_ignore_span(member))
-    {
-      // The last call that holds a member drops it from the bucket. Any other
-      // one only decrements the count that keeps it alive for the calls left.
-      match bucket.get_mut(position) {
-        Some((_, 1)) => {
-          bucket.remove(position);
-        },
-        Some((_, count)) => *count -= 1,
-        None => {},
-      }
-    }
+    bucket.retain_mut(|(candidate, count)| {
+      *count -= u32::from(candidate.eq_ignore_span(member));
+      *count > 0
+    });
 
     if bucket.is_empty() {
-      occupied.remove();
+      self.callee_members.remove(&key);
     }
   }
 }
@@ -1242,11 +1240,13 @@ impl StateManager {
           .is_some_and(|specifier| local_binding_of(specifier).eq_ignore_span(ident))
       })
       .min()
+      // The filter above already read the specifier at this pair, so both halves
+      // are there to pair up.
       .and_then(|(import, specifier)| {
-        Some((
-          self.top_imports.get(*import)?,
-          self.specifier_at(*import, *specifier)?,
-        ))
+        self
+          .top_imports
+          .get(*import)
+          .zip(self.specifier_at(*import, *specifier))
       });
 
     debug_assert_eq!(
@@ -1266,7 +1266,10 @@ impl StateManager {
   }
 
   fn specifier_at(&self, import: usize, specifier: usize) -> Option<&ImportSpecifier> {
-    self.top_imports.get(import)?.specifiers.get(specifier)
+    self
+      .top_imports
+      .get(import)
+      .and_then(|import| import.specifiers.get(specifier))
   }
 
   /// Appends a top-level expression and records the call it is, if it is one.
@@ -1522,18 +1525,22 @@ impl StateManager {
     attrs: Vec<JSXAttrOrSpread>,
   ) -> bool {
     let key = stable_hash_unspanned_call(call);
-    let Some(bucket) = self.jsx_spread_attr_exprs_map.get_mut(&key) else {
+
+    let Some((_, replacement)) = self
+      .jsx_spread_attr_exprs_map
+      .get_mut(&key)
+      .and_then(|bucket| {
+        bucket
+          .iter_mut()
+          .find(|(seen, _)| matches!(seen, Expr::Call(seen_call) if seen_call.eq_ignore_span(call)))
+      })
+    else {
       return false;
     };
 
-    for (seen, replacement) in bucket.iter_mut() {
-      if matches!(seen, Expr::Call(seen_call) if seen_call.eq_ignore_span(call)) {
-        *replacement = attrs;
-        return true;
-      }
-    }
+    *replacement = attrs;
 
-    false
+    true
   }
 
   /// Looks up the replacement JSX attributes recorded for a spread expression,
@@ -1859,29 +1866,26 @@ impl StateManager {
 
       let package_dir_path = Path::new(&package_dir);
       let file_path = Path::new(file_path);
-      let relative_package_path = relative_path(file_path, package_dir_path);
 
-      if let Some(package_dir) = relative_package_path.to_str() {
-        // Normalize path separators to forward slashes for consistency across platforms
-        let normalized_path = package_dir.replace('\\', "/");
-        return format!(
-          "{}:{}",
-          package_name.unwrap_or_else(|| "_unknown_name_".to_string()),
-          normalized_path
-        );
-      }
+      // Separators are normalized to forward slashes so one file answers the
+      // same name on every platform. Both halves of the relative path come from
+      // `&str`, so reading it back as text loses nothing.
+      let normalized_path = relative_path(file_path, package_dir_path)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+      return format!(
+        "{}:{}",
+        package_name.unwrap_or_else(|| "_unknown_name_".to_string()),
+        normalized_path
+      );
     }
 
     if let Some(root_dir) = self.options.unstable_module_resolution.root_dir() {
-      let file_path = Path::new(file_path);
-      let root_dir = Path::new(root_dir);
-
-      if let Some(rel_path) = relative_path(file_path, root_dir).to_str() {
-        // Normalize path separators to forward slashes for consistency across platforms
-        let normalized_path = rel_path.replace('\\', "/");
-        return normalized_path;
-      }
-    };
+      return relative_path(Path::new(file_path), Path::new(root_dir))
+        .to_string_lossy()
+        .replace('\\', "/");
+    }
 
     let file_name = Path::new(file_path)
       .file_name()
@@ -2248,30 +2252,13 @@ impl StateManager {
       return;
     }
 
+    // One metadata per rule, so a style map that holds rules yields metadata.
     let metadatas = MetaData::convert_from_injected_styles_map(style);
-    if metadatas.is_empty() {
-      return;
-    }
-
-    let needs_runtime_injection = style.values().any(|value| {
-      matches!(
-        value.as_ref(),
-        InjectableStyleKind::Regular(_) | InjectableStyleKind::Const(_)
-      )
-    });
-
-    let inject_var_ident = if needs_runtime_injection {
-      Some(self.setup_injection_imports())
-    } else {
-      None
-    };
+    let inject_var_ident = self.setup_injection_imports();
 
     for metadata in metadatas {
       self.add_style(&metadata);
-
-      if let Some(ref inject_var_ident) = inject_var_ident {
-        self.add_style_to_inject(&metadata, inject_var_ident, ast, fallback_ast);
-      }
+      self.add_style_to_inject(&metadata, &inject_var_ident, ast, fallback_ast);
     }
 
     // Update all references to this call expression with the new AST
@@ -2293,9 +2280,6 @@ impl StateManager {
     }
 
     let metadatas = MetaData::convert_from_injected_styles_map(style);
-    if metadatas.is_empty() {
-      return;
-    }
 
     let inject_var_ident = if self.options.runtime_injection.is_some() {
       Some(self.setup_injection_imports())
@@ -2329,31 +2313,31 @@ impl StateManager {
       .cloned()
       .unwrap_or(RuntimeInjectionState::Boolean(true));
 
-    let (inject_module_ident, inject_var_ident) = match self.injection.inject_import_inserted.take()
-    {
-      Some(idents) => (idents.module, idents.var),
-      None => {
-        let module_ident = uid_generator.generate_ident();
+    // The early return above answers for every state that already holds the
+    // identifiers, so reaching here means there are none to read yet.
+    let module_ident = uid_generator.generate_ident();
 
-        let var_ident = match &runtime_injection {
-          RuntimeInjectionState::Regular(_) | RuntimeInjectionState::Boolean(_) => {
-            uid_generator.generate_ident()
-          },
-          RuntimeInjectionState::Named(NamedImportSource { r#as, .. }) => {
-            uid_generator = UidGenerator::new(r#as, CounterMode::Local);
-            uid_generator.generate_ident()
-          },
-        };
-
-        let idents = InjectImportIdents {
-          module: module_ident,
-          var: var_ident,
-        };
-        self.injection.inject_import_inserted = Some(idents.clone());
-
-        (idents.module, idents.var)
+    let var_ident = match &runtime_injection {
+      RuntimeInjectionState::Regular(_) | RuntimeInjectionState::Boolean(_) => {
+        uid_generator.generate_ident()
+      },
+      RuntimeInjectionState::Named(NamedImportSource { r#as, .. }) => {
+        uid_generator = UidGenerator::new(r#as, CounterMode::Local);
+        uid_generator.generate_ident()
       },
     };
+
+    let idents = InjectImportIdents {
+      module: module_ident,
+      var: var_ident,
+    };
+
+    self.injection.inject_import_inserted = Some(idents.clone());
+
+    let InjectImportIdents {
+      module: inject_module_ident,
+      var: inject_var_ident,
+    } = idents;
 
     let module_items = match &runtime_injection {
       RuntimeInjectionState::Boolean(_) => vec![
@@ -2651,11 +2635,9 @@ pub fn flush_pending_insertions(
       .unwrap_or(original.len());
     let mut merged = Vec::with_capacity(original.len() + after_imports.len());
     let mut iter = original.into_iter();
-    for _ in 0..import_end {
-      if let Some(item) = iter.next() {
-        merged.push(item);
-      }
-    }
+
+    // `import_end` is an index into `original`, so the take never runs short.
+    merged.extend(iter.by_ref().take(import_end));
     merged.extend(after_imports);
     merged.extend(iter);
     merged
@@ -2838,18 +2820,24 @@ fn add_inject_var_decl_expression(decl_ident: &Ident, value_ident: &Ident) -> Mo
   }))))
 }
 
+/// Whether `filename` carries `allowed_suffix`, either at its end or in front
+/// of a module extension -- `vars.stylex` and `vars.stylex.js` both carry
+/// `.stylex`.
+///
+/// The two halves are matched apart rather than joined: the extension is
+/// stripped and what is left is asked for the suffix. Joining them meant one
+/// `format!` per extension per ask, which the import resolver pays on every
+/// import a module makes. Fewer allocations, counted rather than timed -- this
+/// is not on a path the benches measure.
 pub(crate) fn matches_file_suffix(allowed_suffix: &str, filename: &str) -> bool {
   if filename.ends_with(allowed_suffix) {
     return true;
   }
 
-  EXTENSIONS.iter().any(|&suffix| {
-    let suffix = if allowed_suffix.is_empty() {
-      suffix
-    } else {
-      &format!("{}{}", allowed_suffix, suffix)[..]
-    };
-    filename.ends_with(suffix)
+  EXTENSIONS.iter().any(|extension| {
+    filename
+      .strip_suffix(extension)
+      .is_some_and(|stem| stem.ends_with(allowed_suffix))
   })
 }
 

--- a/crates/stylex-state/src/tests/binding_queries_test.rs
+++ b/crates/stylex-state/src/tests/binding_queries_test.rs
@@ -1,0 +1,229 @@
+//! What the state knows about the bindings a module declares and writes to.
+//!
+//! Every question here is asked of a *reference*, not of a name: the identifier
+//! carries the scope it was resolved in, so a global and a local that spell the
+//! same word are two bindings. The one exception is [`StateManager::has_binding`],
+//! which is asked of a name on purpose -- it decides whether a name is free to
+//! generate, and a name taken in any scope is not free.
+
+use rustc_hash::FxHashSet;
+use swc_core::{
+  common::{BytePos, DUMMY_SP, Span},
+  ecma::ast::Ident,
+};
+
+use crate::state_manager::BindingWrites;
+use crate::tests::prelude::{ident, ident_at, test_state as state};
+
+fn span(lo: u32, hi: u32) -> Span {
+  Span::new(BytePos(lo), BytePos(hi))
+}
+
+/// The four sets one pre-scan produced, each holding the bindings named.
+fn writes(
+  reassigned: &[Ident],
+  mutated: &[Ident],
+  deeply_mutated: &[Ident],
+  declared: &[Ident],
+) -> BindingWrites {
+  let collect = |idents: &[Ident]| -> FxHashSet<swc_core::ecma::ast::Id> {
+    idents.iter().map(Ident::to_id).collect()
+  };
+
+  BindingWrites {
+    reassignments: collect(reassigned),
+    mutations: collect(mutated),
+    deep_mutations: collect(deeply_mutated),
+    declared: collect(declared),
+  }
+}
+
+/// A state that has taken nothing knows of no writes at all.
+#[test]
+fn a_state_that_took_no_pre_scan_knows_of_no_writes() {
+  let state = state();
+  let subject = ident("styles");
+
+  assert!(!state.has_binding_reassignment(&subject));
+  assert!(!state.has_binding_mutation(&subject));
+  assert!(!state.has_deep_binding_mutation(&subject));
+  assert!(!state.declares_binding(&subject));
+}
+
+/// The four sets are taken together and read back apart: a binding in one of
+/// them answers for that question alone.
+#[test]
+fn each_set_answers_only_its_own_question() {
+  let mut state = state();
+
+  state.adopt_binding_writes(writes(
+    &[ident("reassigned")],
+    &[ident("mutated")],
+    &[ident("deeply")],
+    &[ident("declared")],
+  ));
+
+  assert!(state.has_binding_reassignment(&ident("reassigned")));
+  assert!(!state.has_binding_mutation(&ident("reassigned")));
+
+  assert!(state.has_binding_mutation(&ident("mutated")));
+  assert!(!state.has_binding_reassignment(&ident("mutated")));
+
+  assert!(state.has_deep_binding_mutation(&ident("deeply")));
+  assert!(!state.has_binding_mutation(&ident("deeply")));
+
+  assert!(state.declares_binding(&ident("declared")));
+  assert!(!state.has_deep_binding_mutation(&ident("declared")));
+}
+
+/// The scope is part of the question. A name written in one scope says nothing
+/// about the same name in another.
+#[test]
+fn a_write_in_one_scope_says_nothing_about_another() {
+  let mut state = state();
+
+  state.adopt_binding_writes(writes(
+    &[ident_at("styles", 1)],
+    &[],
+    &[],
+    &[ident_at("styles", 1)],
+  ));
+
+  assert!(state.has_binding_reassignment(&ident_at("styles", 1)));
+  assert!(!state.has_binding_reassignment(&ident_at("styles", 2)));
+
+  assert!(state.declares_binding(&ident_at("styles", 1)));
+  assert!(!state.declares_binding(&ident_at("styles", 2)));
+}
+
+/// Taking a second pre-scan replaces the first, rather than adding to it: one
+/// walk of the module produces the whole answer.
+#[test]
+fn a_second_pre_scan_replaces_the_first() {
+  let mut state = state();
+
+  state.adopt_binding_writes(writes(&[ident("first")], &[], &[], &[]));
+  state.adopt_binding_writes(writes(&[ident("second")], &[], &[], &[]));
+
+  assert!(state.has_binding_reassignment(&ident("second")));
+  assert!(!state.has_binding_reassignment(&ident("first")));
+}
+
+/// Whether a name is taken anywhere in the module, asked of the name and not of
+/// a reference, because a generated name must avoid every scope.
+#[test]
+fn a_name_taken_anywhere_is_taken() {
+  let mut state = state();
+
+  assert!(!state.has_binding("styles"));
+
+  state.bound_names.insert("styles".to_string());
+
+  assert!(state.has_binding("styles"));
+  assert!(!state.has_binding("style"));
+}
+
+/// A name re-bound locally blocks reuse only where the re-binding covers the
+/// site asking. A binding written elsewhere in the module leaves the site free.
+#[test]
+fn a_local_rebinding_blocks_only_the_sites_it_covers() {
+  let mut state = state();
+
+  state
+    .local_rebinding_scopes
+    .insert("stylex".to_string(), vec![span(100, 200)]);
+
+  assert!(state.is_locally_rebound_at("stylex", span(120, 180)));
+  assert!(state.is_locally_rebound_at("stylex", span(100, 200)));
+  assert!(!state.is_locally_rebound_at("stylex", span(50, 90)));
+  assert!(!state.is_locally_rebound_at("stylex", span(150, 250)));
+  assert!(!state.is_locally_rebound_at("other", span(120, 180)));
+}
+
+/// One name re-bound in two places is blocked at either of them.
+#[test]
+fn a_name_rebound_twice_blocks_both_places() {
+  let mut state = state();
+
+  state
+    .local_rebinding_scopes
+    .insert("stylex".to_string(), vec![span(10, 20), span(100, 200)]);
+
+  assert!(state.is_locally_rebound_at("stylex", span(12, 18)));
+  assert!(state.is_locally_rebound_at("stylex", span(120, 180)));
+  assert!(!state.is_locally_rebound_at("stylex", span(50, 60)));
+}
+
+/// A name recorded with no scopes covering it blocks nothing, which is the
+/// answer an empty list has to give.
+#[test]
+fn a_name_recorded_with_no_scopes_blocks_nothing() {
+  let mut state = state();
+
+  state
+    .local_rebinding_scopes
+    .insert("stylex".to_string(), vec![]);
+
+  assert!(!state.is_locally_rebound_at("stylex", span(0, 10)));
+}
+
+/// The short filename a debug annotation carries is worked out once and kept,
+/// because reading it means reading the package boundaries around the file.
+#[test]
+fn a_short_filename_is_worked_out_once_and_kept() {
+  let mut state = state();
+
+  assert_eq!(state.cached_short_filename("/repo/src/app.js"), None);
+
+  state.insert_cached_short_filename("/repo/src/app.js".to_string(), "app.js".to_string());
+
+  assert_eq!(
+    state.cached_short_filename("/repo/src/app.js"),
+    Some("app.js")
+  );
+  assert_eq!(state.cached_short_filename("/repo/src/other.js"), None);
+}
+
+/// A path recorded twice keeps the second answer, which is what an overwrite
+/// has to do for the memo to stay a memo of the current shortening.
+#[test]
+fn a_short_filename_recorded_twice_keeps_the_second() {
+  let mut state = state();
+
+  state.insert_cached_short_filename("/repo/src/app.js".to_string(), "app.js".to_string());
+  state.insert_cached_short_filename("/repo/src/app.js".to_string(), "src/app.js".to_string());
+
+  assert_eq!(
+    state.cached_short_filename("/repo/src/app.js"),
+    Some("src/app.js")
+  );
+}
+
+/// A declarator bound to a pattern declares no single name, so nothing is
+/// indexed for it -- but the declarator is still recorded, because its position
+/// is what marks the call in it as program level.
+#[test]
+fn a_declarator_bound_to_a_pattern_is_recorded_and_indexed_by_nothing() {
+  use swc_core::ecma::ast::{Expr, Lit, ObjectPat, Pat, Str, VarDeclarator};
+
+  let mut state = state();
+
+  state.push_declaration(VarDeclarator {
+    span: DUMMY_SP,
+    name: Pat::Object(ObjectPat {
+      span: DUMMY_SP,
+      props: vec![],
+      optional: false,
+      type_ann: None,
+    }),
+    init: Some(Box::new(Expr::Lit(Lit::Str(Str {
+      span: DUMMY_SP,
+      value: "styles".into(),
+      raw: None,
+    })))),
+    definite: false,
+  });
+
+  assert_eq!(state.declarations().len(), 1);
+  assert!(state.declaration_of(&ident("styles")).is_none());
+}

--- a/crates/stylex-state/src/tests/call_index_test.rs
+++ b/crates/stylex-state/src/tests/call_index_test.rs
@@ -260,3 +260,48 @@ fn a_call_on_super_records_no_member() {
 
   assert!(!state.is_member_call_callee(&member("stylex", "create")));
 }
+
+/// Releasing one callee leaves every other one alone. The index buckets by
+/// member, and `release_member` walks the whole bucket rather than stopping at
+/// the first match, so nothing may fall out of a bucket it was not asked about.
+#[test]
+fn releasing_one_callee_leaves_every_other_one_alone() {
+  let mut state = state();
+  let created = member_call("stylex", "create", vec![number_arg(1.0)]);
+  let spent = member_call("stylex", "props", vec![number_arg(2.0)]);
+
+  state.add_call_expression(&created);
+  state.add_call_expression(&spent);
+
+  replace(&mut state, &created, &object_expr());
+
+  assert!(!state.is_member_call_callee(&member("stylex", "create")));
+  assert!(
+    state.is_member_call_callee(&member("stylex", "props")),
+    "releasing one callee forgot another"
+  );
+}
+
+/// A callee released a second time stays forgotten, and the bucket it left is
+/// gone rather than held at a count the next call cannot raise. The release
+/// walks a bucket the key has no entry in, which is the miss the index has to
+/// leave exactly as it found it.
+#[test]
+fn a_callee_released_a_second_time_stays_forgotten() {
+  let mut state = state();
+  let call = member_call("stylex", "create", vec![]);
+
+  state.add_call_expression(&call);
+
+  replace(&mut state, &call, &object_expr());
+  replace(&mut state, &call, &object_expr());
+
+  assert!(!state.is_member_call_callee(&member("stylex", "create")));
+
+  state.add_call_expression(&call);
+
+  assert!(
+    state.is_member_call_callee(&member("stylex", "create")),
+    "a second release left a count the next call could not raise"
+  );
+}

--- a/crates/stylex-state/src/tests/call_index_test.rs
+++ b/crates/stylex-state/src/tests/call_index_test.rs
@@ -1,0 +1,262 @@
+//! Which member expressions are the callee of a call the module still holds.
+//!
+//! Asked once per member the visitor meets, so the answer has to stay exact
+//! while calls are rewritten under it: a member kept after its last call was
+//! replaced would make the visitor treat a plain property read as a call, and
+//! one forgotten while a call still holds it would do the opposite.
+
+use indexmap::IndexMap;
+use std::rc::Rc;
+
+use swc_core::{
+  common::DUMMY_SP,
+  ecma::ast::{CallExpr, Callee, Expr, ExprOrSpread, Lit, MemberExpr, MemberProp, Number},
+};
+
+use stylex_ast::ast::factories::{create_ident, create_ident_name};
+use stylex_types::enums::data_structures::injectable_style::InjectableStyleKind;
+use stylex_types::structures::injectable_style::InjectableStyle;
+
+use crate::state_manager::StateManager;
+use crate::tests::prelude::{object_expr, test_state as state};
+use crate::types::InjectableStylesMap;
+
+/// `object.property`, the shape every StyleX call off a namespace import takes.
+fn member(object: &str, property: &str) -> MemberExpr {
+  MemberExpr {
+    span: DUMMY_SP,
+    obj: Box::new(Expr::Ident(create_ident(object))),
+    prop: MemberProp::Ident(create_ident_name(property)),
+  }
+}
+
+fn number_arg(value: f64) -> ExprOrSpread {
+  ExprOrSpread {
+    spread: None,
+    expr: Box::new(Expr::Lit(Lit::Num(Number {
+      span: DUMMY_SP,
+      value,
+      raw: None,
+    }))),
+  }
+}
+
+fn call_of(callee: Callee, args: Vec<ExprOrSpread>) -> CallExpr {
+  CallExpr {
+    span: DUMMY_SP,
+    callee,
+    args,
+    type_args: None,
+    ctxt: Default::default(),
+  }
+}
+
+fn member_call(object: &str, property: &str, args: Vec<ExprOrSpread>) -> CallExpr {
+  call_of(
+    Callee::Expr(Box::new(Expr::Member(member(object, property)))),
+    args,
+  )
+}
+
+fn plain_call(name: &str) -> CallExpr {
+  call_of(
+    Callee::Expr(Box::new(Expr::Ident(create_ident(name)))),
+    vec![],
+  )
+}
+
+/// One rule, so that replacing a call has something to register.
+fn one_style() -> InjectableStylesMap {
+  let mut styles: InjectableStylesMap = IndexMap::new();
+
+  styles.insert(
+    "x1e2nbdu".into(),
+    Rc::new(InjectableStyleKind::Regular(InjectableStyle {
+      ltr: ".x1e2nbdu{color:red}".to_string(),
+      rtl: None,
+      priority: Some(3000.0),
+    })),
+  );
+
+  styles
+}
+
+/// Replaces `call` with `ast`, which is what registering the styles a call
+/// produced does to the call itself.
+fn replace(state: &mut StateManager, call: &CallExpr, ast: &Expr) {
+  state.register_styles(call, &one_style(), ast, None);
+}
+
+#[test]
+fn a_member_that_is_a_callee_is_recognised() {
+  let mut state = state();
+
+  state.add_call_expression(&member_call("stylex", "create", vec![]));
+
+  assert!(state.is_member_call_callee(&member("stylex", "create")));
+}
+
+/// A member nothing calls is not a callee, and neither is one that differs from
+/// a recorded callee in either half.
+#[test]
+fn a_member_nothing_calls_is_not_a_callee() {
+  let mut state = state();
+
+  state.add_call_expression(&member_call("stylex", "create", vec![]));
+
+  assert!(!state.is_member_call_callee(&member("stylex", "props")));
+  assert!(!state.is_member_call_callee(&member("other", "create")));
+}
+
+/// A call on a bare name has no member to record, so it leaves the index as it
+/// was.
+#[test]
+fn a_call_on_a_bare_name_records_no_member() {
+  let mut state = state();
+
+  state.add_call_expression(&plain_call("create"));
+
+  assert!(!state.is_member_call_callee(&member("stylex", "create")));
+}
+
+/// The position a call was written at is not part of what identifies its
+/// callee: the same call met twice under different spans is one callee.
+#[test]
+fn a_callee_is_recognised_wherever_the_call_was_written() {
+  let mut state = state();
+  let mut call = member_call("stylex", "create", vec![]);
+
+  call.span =
+    swc_core::common::Span::new(swc_core::common::BytePos(10), swc_core::common::BytePos(30));
+  state.add_call_expression(&call);
+
+  assert!(state.is_member_call_callee(&member("stylex", "create")));
+}
+
+/// A callee shared by two calls survives the first of them being replaced, and
+/// is forgotten only when the last one goes.
+#[test]
+fn a_shared_callee_lives_until_its_last_call_is_replaced() {
+  let mut state = state();
+  let first = member_call("stylex", "create", vec![number_arg(1.0)]);
+  let second = member_call("stylex", "create", vec![number_arg(2.0)]);
+
+  state.add_call_expression(&first);
+  state.add_call_expression(&second);
+
+  replace(&mut state, &first, &object_expr());
+
+  assert!(
+    state.is_member_call_callee(&member("stylex", "create")),
+    "the second call still holds the callee"
+  );
+
+  replace(&mut state, &second, &object_expr());
+
+  assert!(!state.is_member_call_callee(&member("stylex", "create")));
+}
+
+/// Recording one call twice records one call: the second recording replaces the
+/// first, and the callee it displaced is released with it.
+#[test]
+fn recording_one_call_twice_still_leaves_one_call() {
+  let mut state = state();
+  let call = member_call("stylex", "create", vec![]);
+
+  state.add_call_expression(&call);
+  state.add_call_expression(&call);
+
+  replace(&mut state, &call, &object_expr());
+
+  assert!(!state.is_member_call_callee(&member("stylex", "create")));
+}
+
+/// Replacing a call with another call moves the callee rather than dropping it:
+/// the new call's own member is what the index holds afterwards.
+#[test]
+fn replacing_a_call_with_a_call_records_the_new_callee() {
+  let mut state = state();
+  let call = member_call("stylex", "create", vec![]);
+
+  state.add_call_expression(&call);
+  replace(
+    &mut state,
+    &call,
+    &Expr::Call(member_call("runtime", "inject", vec![])),
+  );
+
+  assert!(!state.is_member_call_callee(&member("stylex", "create")));
+  assert!(state.is_member_call_callee(&member("runtime", "inject")));
+}
+
+/// Replacing a call the index never held leaves it as it was, rather than
+/// forgetting a callee some other call still holds.
+#[test]
+fn replacing_a_call_the_index_never_held_changes_nothing() {
+  let mut state = state();
+  let recorded = member_call("stylex", "create", vec![]);
+
+  state.add_call_expression(&recorded);
+  replace(
+    &mut state,
+    &member_call("stylex", "props", vec![]),
+    &object_expr(),
+  );
+
+  assert!(state.is_member_call_callee(&member("stylex", "create")));
+}
+
+/// A member read off a call rather than a name -- `f().b` -- is still a member,
+/// and it is a callee when something calls it.
+#[test]
+fn a_member_read_off_a_call_is_a_callee_too() {
+  let mut state = state();
+  let nested = MemberExpr {
+    span: DUMMY_SP,
+    obj: Box::new(Expr::Call(plain_call("factory"))),
+    prop: MemberProp::Ident(create_ident_name("create")),
+  };
+
+  state.add_call_expression(&call_of(
+    Callee::Expr(Box::new(Expr::Member(nested.clone()))),
+    vec![],
+  ));
+
+  assert!(state.is_member_call_callee(&nested));
+}
+
+/// Many calls on one callee are counted rather than listed, so the callee
+/// survives every replacement but the last however many there are.
+#[test]
+fn a_callee_held_by_a_thousand_calls_survives_all_but_the_last() {
+  let mut state = state();
+  let calls: Vec<CallExpr> = (0..1_000)
+    .map(|index| member_call("stylex", "create", vec![number_arg(f64::from(index))]))
+    .collect();
+
+  for call in &calls {
+    state.add_call_expression(call);
+  }
+
+  for call in &calls[..999] {
+    replace(&mut state, call, &object_expr());
+    assert!(state.is_member_call_callee(&member("stylex", "create")));
+  }
+
+  replace(&mut state, &calls[999], &object_expr());
+
+  assert!(!state.is_member_call_callee(&member("stylex", "create")));
+}
+
+/// A callee that is not an expression at all -- `super()` -- names no member,
+/// so the index has nothing to record for it.
+#[test]
+fn a_call_on_super_records_no_member() {
+  use swc_core::ecma::ast::Super;
+
+  let mut state = state();
+
+  state.add_call_expression(&call_of(Callee::Super(Super { span: DUMMY_SP }), vec![]));
+
+  assert!(!state.is_member_call_callee(&member("stylex", "create")));
+}

--- a/crates/stylex-state/src/tests/evaluate_result_value_test.rs
+++ b/crates/stylex-state/src/tests/evaluate_result_value_test.rs
@@ -174,12 +174,13 @@ mod accessors {
 
   #[test]
   fn a_theme_reference_answers_itself_and_nothing_else_does() {
-    let theme_ref = ThemeRef::new("vars.stylex.js", "vars", "x");
-    let value = EvaluateResultValue::ThemeRef(theme_ref.clone());
+    let value = EvaluateResultValue::ThemeRef(ThemeRef::new("vars.stylex.js", "vars", "x"));
 
+    // The identity is pinned as text rather than re-read off `theme_ref`, so
+    // an accessor that answered the wrong reference still fails here.
     assert_eq!(
       value.as_theme_ref().map(ThemeRef::base_id),
-      Some(theme_ref.base_id())
+      Some("vars.stylex.js//vars")
     );
     assert_eq!(count_answering(|value| value.as_theme_ref().is_some()), 1);
   }
@@ -247,6 +248,10 @@ mod when_marker {
     let value = EvaluateResultValue::ThemeRef(theme_ref.clone());
 
     assert!(value.is_proxy());
+    // The group's own name, spelled out rather than re-derived: comparing
+    // against `theme_ref.to_string_value()` would pass on any two wrong halves
+    // that agree.
+    assert_eq!(value.as_proxy_string(), Some("x3hqbbp".to_string()));
     assert_eq!(value.as_proxy_string(), Some(theme_ref.to_string_value()));
   }
 

--- a/crates/stylex-state/src/tests/evaluate_result_value_test.rs
+++ b/crates/stylex-state/src/tests/evaluate_result_value_test.rs
@@ -19,3 +19,394 @@ fn deserializes_json_null_as_null() {
 
   assert_eq!(value, EvaluateResultValue::Null);
 }
+
+/// Every key shape a property name can take, and the shapes that name none.
+mod string_key {
+  use swc_core::{
+    common::DUMMY_SP,
+    ecma::ast::{BigInt, Expr, Lit, Null, ObjectLit, Str},
+  };
+
+  use stylex_ast::ast::factories::create_ident;
+
+  use crate::evaluate_result_value::EvaluateResultValue;
+
+  fn key_of(expr: Expr) -> Option<String> {
+    EvaluateResultValue::Expr(expr).as_string_key()
+  }
+
+  /// A bare name reads as itself: `{ color: red }` names the key `color`.
+  #[test]
+  fn an_identifier_names_itself() {
+    assert_eq!(
+      key_of(Expr::Ident(create_ident("color"))).as_deref(),
+      Some("color")
+    );
+  }
+
+  /// A quoted key reads as its text, including the spellings no identifier can
+  /// take -- a custom property, a media query, an empty string.
+  #[test]
+  fn a_string_names_its_text() {
+    for text in ["color", "--custom-prop", "@media (min-width: 320px)", ""] {
+      assert_eq!(
+        key_of(Expr::Lit(Lit::Str(Str {
+          span: DUMMY_SP,
+          value: text.into(),
+          raw: None,
+        })))
+        .as_deref(),
+        Some(text)
+      );
+    }
+  }
+
+  /// A bigint key is spelled without the `n` the source carries, which is how
+  /// the language spells it.
+  #[test]
+  fn a_bigint_names_its_digits() {
+    assert_eq!(
+      key_of(Expr::Lit(Lit::BigInt(BigInt {
+        span: DUMMY_SP,
+        value: Box::new(123_456_789_012_345_678_901_234_567_890u128.into()),
+        raw: None,
+      })))
+      .as_deref(),
+      Some("123456789012345678901234567890")
+    );
+  }
+
+  /// Anything the language does not spell as a property name reads as no key,
+  /// and the caller decides what that means.
+  #[test]
+  fn a_value_that_is_not_a_key_names_none() {
+    assert_eq!(key_of(Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))), None);
+    assert_eq!(
+      key_of(Expr::Object(ObjectLit {
+        span: DUMMY_SP,
+        props: vec![],
+      })),
+      None
+    );
+  }
+
+  /// A value that is not an expression at all names no key either: the outer
+  /// match declines before the key shapes are read.
+  #[test]
+  fn a_non_expression_value_names_no_key() {
+    assert_eq!(EvaluateResultValue::Null.as_string_key(), None);
+    assert_eq!(EvaluateResultValue::Vec(vec![]).as_string_key(), None);
+  }
+}
+
+/// The four accessors that read one variant out of an evaluated value.
+mod accessors {
+  use indexmap::IndexMap;
+  use swc_core::ecma::ast::{Expr, KeyValueProp};
+
+  use stylex_ast::ast::factories::{create_ident, create_key_value_prop_ident};
+
+  use crate::tests::prelude::string_expr;
+  use crate::{evaluate_result_value::EvaluateResultValue, theme_ref::ThemeRef};
+
+  /// One value of every variant an accessor is asked about, so a case that must
+  /// name the variants it does not read has a list to take them from.
+  fn every_readable_variant() -> Vec<EvaluateResultValue> {
+    let mut map: IndexMap<Expr, Vec<KeyValueProp>> = IndexMap::new();
+
+    map.insert(
+      Expr::Ident(create_ident("base")),
+      vec![create_key_value_prop_ident("color", string_expr("red"))],
+    );
+
+    vec![
+      EvaluateResultValue::Null,
+      EvaluateResultValue::Expr(string_expr("red")),
+      EvaluateResultValue::Vec(vec![EvaluateResultValue::Null]),
+      EvaluateResultValue::Map(map),
+      EvaluateResultValue::ThemeRef(ThemeRef::new("vars.stylex.js", "vars", "x")),
+    ]
+  }
+
+  fn count_answering(accessor: impl Fn(&EvaluateResultValue) -> bool) -> usize {
+    every_readable_variant()
+      .iter()
+      .filter(|value| accessor(value))
+      .count()
+  }
+
+  #[test]
+  fn an_expression_answers_itself_and_nothing_else_does() {
+    let expr = string_expr("red");
+
+    assert_eq!(
+      EvaluateResultValue::Expr(expr.clone()).as_expr(),
+      Some(&expr)
+    );
+    assert_eq!(count_answering(|value| value.as_expr().is_some()), 1);
+  }
+
+  #[test]
+  fn a_list_answers_its_elements_and_nothing_else_does() {
+    let elements = vec![EvaluateResultValue::Null];
+
+    assert_eq!(
+      EvaluateResultValue::Vec(elements.clone()).as_vec(),
+      Some(&elements)
+    );
+    assert_eq!(count_answering(|value| value.as_vec().is_some()), 1);
+  }
+
+  /// An empty list is a list. A `create` call whose namespace holds no rule
+  /// evaluates to one, and reading it as absent would lose the namespace.
+  #[test]
+  fn an_empty_list_is_still_a_list() {
+    assert_eq!(EvaluateResultValue::Vec(vec![]).as_vec(), Some(&Vec::new()));
+  }
+
+  #[test]
+  fn a_map_answers_its_entries_and_nothing_else_does() {
+    let value = every_readable_variant().remove(3);
+
+    assert_eq!(value.as_map().map(IndexMap::len), Some(1));
+    assert_eq!(count_answering(|value| value.as_map().is_some()), 1);
+  }
+
+  #[test]
+  fn a_theme_reference_answers_itself_and_nothing_else_does() {
+    let theme_ref = ThemeRef::new("vars.stylex.js", "vars", "x");
+    let value = EvaluateResultValue::ThemeRef(theme_ref.clone());
+
+    assert_eq!(
+      value.as_theme_ref().map(ThemeRef::base_id),
+      Some(theme_ref.base_id())
+    );
+    assert_eq!(count_answering(|value| value.as_theme_ref().is_some()), 1);
+  }
+}
+
+/// What `stylex-css` reads off the second argument of a `when` call.
+///
+/// The marker can arrive as a literal class name, as a proxy standing in for a
+/// marker another file defined, or as the compiled object a `defineMarker` call
+/// left behind. Each accessor answers for one of those and declines the rest.
+mod when_marker {
+  use std::rc::Rc;
+
+  use indexmap::IndexMap;
+  use swc_core::{
+    common::DUMMY_SP,
+    ecma::ast::{
+      ComputedPropName, Expr, KeyValueProp, Lit, Prop, PropName, PropOrSpread, SpreadElement, Str,
+    },
+  };
+
+  use stylex_ast::ast::convertors::create_bool_expr;
+  use stylex_ast::ast::factories::{
+    create_ident, create_ident_key_value_prop, create_object_lit, create_str_key_value_prop,
+  };
+  use stylex_types::traits::WhenMarkerValue;
+
+  use crate::{evaluate_result_value::EvaluateResultValue, theme_ref::ThemeRef};
+
+  fn string_value(text: &str) -> EvaluateResultValue {
+    EvaluateResultValue::Expr(Expr::Lit(Lit::Str(Str {
+      span: DUMMY_SP,
+      value: text.into(),
+      raw: None,
+    })))
+  }
+
+  fn object_value(props: Vec<PropOrSpread>) -> EvaluateResultValue {
+    EvaluateResultValue::Expr(Expr::Object(create_object_lit(props)))
+  }
+
+  /// The object a compiled marker is: the compiled flag that says this compiler
+  /// wrote the object, and the marker's own class name.
+  fn compiled_marker() -> Vec<PropOrSpread> {
+    vec![
+      create_str_key_value_prop("$$css", create_bool_expr(true)),
+      create_str_key_value_prop("x1marker", create_bool_expr(true)),
+    ]
+  }
+
+  #[test]
+  fn a_literal_marker_is_read_as_written() {
+    assert_eq!(string_value("x1marker").as_str_value(), Some("x1marker"));
+  }
+
+  #[test]
+  fn a_value_that_is_not_a_string_carries_no_literal_marker() {
+    assert_eq!(EvaluateResultValue::Null.as_str_value(), None);
+    assert_eq!(object_value(compiled_marker()).as_str_value(), None);
+  }
+
+  #[test]
+  fn a_theme_reference_is_a_proxy_and_resolves_through_its_own_name() {
+    let theme_ref = ThemeRef::new("markers.stylex.js", "marker", "x");
+    let value = EvaluateResultValue::ThemeRef(theme_ref.clone());
+
+    assert!(value.is_proxy());
+    assert_eq!(value.as_proxy_string(), Some(theme_ref.to_string_value()));
+  }
+
+  #[test]
+  fn nothing_else_is_a_proxy() {
+    for value in [
+      EvaluateResultValue::Null,
+      string_value("x1marker"),
+      object_value(compiled_marker()),
+    ] {
+      assert!(!value.is_proxy());
+      assert_eq!(value.as_proxy_string(), None);
+    }
+  }
+
+  #[test]
+  fn a_compiled_marker_object_answers_its_one_class_name() {
+    assert_eq!(
+      object_value(compiled_marker()).first_css_key(),
+      Some("x1marker")
+    );
+  }
+
+  /// The compiled flag can be written before or after the class name, and the
+  /// answer is the class name either way: the search for the flag and the search
+  /// for the name are separate walks.
+  #[test]
+  fn the_compiled_flag_may_be_written_after_the_class_name() {
+    let mut props = compiled_marker();
+    props.reverse();
+
+    assert_eq!(object_value(props).first_css_key(), Some("x1marker"));
+  }
+
+  /// An object this compiler did not write carries no compiled flag, so it names
+  /// no marker even though it has keys that look like one.
+  #[test]
+  fn an_object_without_the_compiled_flag_names_no_marker() {
+    assert_eq!(
+      object_value(vec![create_str_key_value_prop(
+        "x1marker",
+        create_bool_expr(true)
+      )])
+      .first_css_key(),
+      None
+    );
+  }
+
+  /// The flag must be `true`. A `$$css` written as anything else -- `false`, or
+  /// the text `"true"` -- is not the flag.
+  #[test]
+  fn a_compiled_flag_that_is_not_true_names_no_marker() {
+    for flag in [
+      create_bool_expr(false),
+      Expr::Lit(Lit::Str(Str {
+        span: DUMMY_SP,
+        value: "true".into(),
+        raw: None,
+      })),
+    ] {
+      assert_eq!(
+        object_value(vec![
+          create_str_key_value_prop("$$css", flag),
+          create_str_key_value_prop("x1marker", create_bool_expr(true)),
+        ])
+        .first_css_key(),
+        None
+      );
+    }
+  }
+
+  /// An object carrying the flag and nothing else names no marker: there is no
+  /// key left after the flag for the class name to be.
+  #[test]
+  fn an_object_holding_only_the_compiled_flag_names_no_marker() {
+    assert_eq!(
+      object_value(vec![create_str_key_value_prop(
+        "$$css",
+        create_bool_expr(true)
+      )])
+      .first_css_key(),
+      None
+    );
+  }
+
+  /// An empty object names no marker, which is the same walk finding no flag.
+  #[test]
+  fn an_empty_object_names_no_marker() {
+    assert_eq!(object_value(vec![]).first_css_key(), None);
+  }
+
+  /// A key written as a bare name reads the same as a quoted one, because both
+  /// are what `Object.keys` walks.
+  #[test]
+  fn a_marker_key_written_as_a_bare_name_reads_the_same() {
+    assert_eq!(
+      object_value(vec![
+        create_ident_key_value_prop("$$css", create_bool_expr(true)),
+        create_ident_key_value_prop("marker", create_bool_expr(true)),
+      ])
+      .first_css_key(),
+      Some("marker")
+    );
+  }
+
+  /// Property shapes a compiled marker never carries are stepped over rather
+  /// than read: a spread, a shorthand, and a computed key are each skipped, so
+  /// the class name is still the first plain key that is not the flag.
+  #[test]
+  fn shapes_a_compiled_object_never_carries_are_stepped_over() {
+    let props = vec![
+      PropOrSpread::Spread(SpreadElement {
+        dot3_token: DUMMY_SP,
+        expr: Box::new(Expr::Ident(create_ident("base"))),
+      }),
+      create_str_key_value_prop("$$css", create_bool_expr(true)),
+      PropOrSpread::Prop(Box::new(Prop::Shorthand(create_ident("shorthand")))),
+      PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+        key: PropName::Computed(ComputedPropName {
+          span: DUMMY_SP,
+          expr: Box::new(Expr::Ident(create_ident("computed"))),
+        }),
+        value: Box::new(create_bool_expr(true)),
+      }))),
+      create_str_key_value_prop("x1marker", create_bool_expr(true)),
+    ];
+
+    assert_eq!(object_value(props).first_css_key(), Some("x1marker"));
+  }
+
+  /// A value that is not an object names no marker at all.
+  #[test]
+  fn a_value_that_is_not_an_object_names_no_marker() {
+    assert_eq!(EvaluateResultValue::Null.first_css_key(), None);
+    assert_eq!(string_value("x1marker").first_css_key(), None);
+  }
+
+  /// The class-name prefix is a property of the options and never of a marker,
+  /// so an evaluated value answers none whatever it holds.
+  #[test]
+  fn an_evaluated_value_never_carries_a_class_name_prefix() {
+    for value in [
+      EvaluateResultValue::Null,
+      string_value("x1marker"),
+      object_value(compiled_marker()),
+      EvaluateResultValue::ThemeRef(ThemeRef::new("markers.stylex.js", "marker", "x")),
+    ] {
+      assert_eq!(value.class_name_prefix(), None);
+    }
+  }
+
+  /// An env object is an evaluated value like any other and answers no marker
+  /// question, so a `when` call handed one refuses rather than reading into it.
+  #[test]
+  fn an_env_object_answers_no_marker_question() {
+    let value = EvaluateResultValue::EnvObject(Rc::new(IndexMap::new()));
+
+    assert_eq!(value.as_str_value(), None);
+    assert!(!value.is_proxy());
+    assert_eq!(value.as_proxy_string(), None);
+    assert_eq!(value.first_css_key(), None);
+  }
+}

--- a/crates/stylex-state/src/tests/file_and_options_test.rs
+++ b/crates/stylex-state/src/tests/file_and_options_test.rs
@@ -430,6 +430,17 @@ fn the_host_s_source_file_and_map_are_taken_as_handed_in() {
     Vec::new(),
     None,
   )));
+
+  let Some(source_file) = state.input_source_file.as_ref() else {
+    panic!("the source file the host handed in was not kept");
+  };
+
+  assert_eq!(source_file.src.as_str(), "const a = 1;");
+  assert_eq!(source_file.start_pos, BytePos(1));
+  assert!(
+    state.input_source_map.is_some(),
+    "the source map the host handed in was not kept"
+  );
 }
 
 /// An import of a module by path, which is what a theme side effect is written
@@ -455,11 +466,18 @@ fn an_import_of_a_module_is_written_as_a_bare_path() {
 /// same name whichever scope asked.
 #[test]
 fn a_file_name_does_not_depend_on_a_scope() {
-  let _ = SyntaxContext::empty();
-
   let state = state_for(real("/repo/src/app.js"), common_js(Some("/repo"), None));
 
-  assert_eq!(state.get_filename(), "/repo/src/app.js");
+  // Asked from the root scope and from one that is not it: the name is a
+  // property of the file, so neither answer may depend on which scope asked.
+  for ctxt in [SyntaxContext::empty(), SyntaxContext::from_u32(2)] {
+    assert_eq!(
+      state.get_filename(),
+      "/repo/src/app.js",
+      "the file name changed under `{:?}`",
+      ctxt
+    );
+  }
 }
 
 /// Under CommonJs an import of a variable file resolves to the name the file is
@@ -595,4 +613,76 @@ fn an_import_from_a_file_outside_every_package_is_refused() {
   let state = state_for(real("/vars.stylex.js"), common_js(None, None));
 
   state.import_path_resolver("./other.stylex.js", &mut FxHashMap::default());
+}
+
+/// What [`matches_file_suffix`] answers, which is what decides whether a file
+/// is a variable file and whether an import names one.
+///
+/// The suffix is carried at the end of a name or in front of a module
+/// extension, which is the shape Babel's
+/// `['', ...EXTENSIONS].some(e => filename.endsWith(`${suffix}${e}`))` spells.
+mod file_suffix {
+  use stylex_path_resolver::resolvers::EXTENSIONS;
+
+  use crate::state_manager::matches_file_suffix;
+
+  /// A file carries a suffix at its end, and in front of every extension the
+  /// resolver knows.
+  #[test]
+  fn a_suffix_is_carried_at_the_end_or_in_front_of_any_module_extension() {
+    assert!(matches_file_suffix(".stylex", "vars.stylex"));
+
+    for extension in EXTENSIONS {
+      let filename = format!("vars.stylex{}", extension);
+
+      assert!(
+        matches_file_suffix(".stylex", &filename),
+        "`{}` did not carry `.stylex`",
+        filename
+      );
+    }
+  }
+
+  /// The suffix has to sit where the name ends or where the extension begins:
+  /// an extension the resolver does not know, and a suffix read anywhere else
+  /// in the name, are both refused.
+  #[test]
+  fn a_suffix_elsewhere_in_the_name_is_not_carried() {
+    assert!(!matches_file_suffix(".stylex", "vars.js"));
+    assert!(!matches_file_suffix(".stylex", "vars.stylex.json"));
+    assert!(!matches_file_suffix(".stylex", "stylex.vars.js"));
+    assert!(!matches_file_suffix(".stylex", ".js"));
+  }
+
+  /// A name that is nothing but the suffix carries it, and a name that is
+  /// nothing but an extension has an empty stem, which carries only the empty
+  /// suffix.
+  #[test]
+  fn a_name_that_is_only_the_suffix_or_only_an_extension() {
+    assert!(matches_file_suffix(".stylex", ".stylex"));
+    assert!(matches_file_suffix("", ".js"));
+  }
+
+  /// A suffix that already names an extension is matched whole, so it is not
+  /// matched again in front of a second one.
+  #[test]
+  fn a_suffix_that_already_names_an_extension_is_matched_whole() {
+    assert!(matches_file_suffix(".stylex.js", "vars.stylex.js"));
+    assert!(!matches_file_suffix(".stylex.js", "vars.stylex.ts"));
+    assert!(!matches_file_suffix(".stylex.js", "vars.stylex.js.map"));
+  }
+
+  /// A project that spells the suffix as nothing marks every file, not every
+  /// module file: the empty suffix is carried by any name at all, so the first
+  /// check answers before the extension list is ever consulted. This is what
+  /// Babel answers -- its `''` entry makes `filename.endsWith('')` the first
+  /// question -- and the extension list is dead weight for this case in both.
+  #[test]
+  fn an_empty_suffix_is_carried_by_every_name_at_all() {
+    assert!(matches_file_suffix("", "vars.js"));
+    assert!(matches_file_suffix("", "vars.tsx"));
+    assert!(matches_file_suffix("", "vars.json"));
+    assert!(matches_file_suffix("", "vars"));
+    assert!(matches_file_suffix("", ""));
+  }
 }

--- a/crates/stylex-state/src/tests/file_and_options_test.rs
+++ b/crates/stylex-state/src/tests/file_and_options_test.rs
@@ -1,0 +1,598 @@
+//! What the state answers about the file it compiles and the project it
+//! compiles it for.
+//!
+//! The file reaches the state as a `FileName`, which is a real path only when
+//! the host has one: a module compiled from a string has no name to read, and
+//! every question below answers empty rather than refusing.
+
+use std::path::PathBuf;
+
+use rustc_hash::FxHashMap;
+use swc_core::common::{DUMMY_SP, FileName, Span, SyntaxContext};
+use swc_core::ecma::ast::Module;
+
+use stylex_enums::import_path_resolution::ImportPathResolution;
+use stylex_state_index::key_span_index::ModuleBase;
+use stylex_structures::core_stylex_options::CoreStyleXOptions;
+use stylex_structures::plugin_pass::PluginPass;
+use stylex_structures::stylex_options::CheckModuleResolution;
+use stylex_structures::stylex_state_options::StyleXStateOptions;
+
+use crate::state_manager::StateManager;
+use crate::tests::prelude::fixture_path as fixture;
+
+fn state_for(filename: FileName, resolution: CheckModuleResolution) -> StateManager {
+  let mut state = StateManager::for_test(
+    None,
+    StyleXStateOptions::default().with_unstable_module_resolution(resolution),
+  );
+
+  state.set_plugin_pass(PluginPass {
+    cwd: None,
+    filename,
+  });
+
+  state
+}
+
+fn real(path: &str) -> FileName {
+  FileName::Real(PathBuf::from(path))
+}
+
+fn common_js(root_dir: Option<&str>, theme_file_extension: Option<&str>) -> CheckModuleResolution {
+  CheckModuleResolution::CommonJs {
+    root_dir: root_dir.map(str::to_string),
+    theme_file_extension: theme_file_extension.map(str::to_string),
+  }
+}
+
+fn haste(theme_file_extension: Option<&str>) -> CheckModuleResolution {
+  CheckModuleResolution::Haste {
+    root_dir: None,
+    theme_file_extension: theme_file_extension.map(str::to_string),
+  }
+}
+
+/// Every option this state answers for, so a case can say which one it changed.
+#[test]
+fn the_build_flags_are_read_off_the_project() {
+  let plain = StateManager::for_test(None, StyleXStateOptions::default());
+
+  assert!(!plain.is_test());
+  assert!(!plain.is_dev());
+  assert!(!plain.is_debug());
+
+  let configured = StateManager::for_test(
+    None,
+    StyleXStateOptions::default()
+      .with_test(true)
+      .with_dev(true)
+      .with_debug(true),
+  );
+
+  assert!(configured.is_test());
+  assert!(configured.is_dev());
+  assert!(configured.is_debug());
+}
+
+/// Whether a conditional style is merged into the style it varies is the
+/// project's own setting.
+#[test]
+fn the_inlined_conditional_merge_setting_is_read_off_the_project() {
+  let mut options = StyleXStateOptions::default();
+  let default_setting = options.enable_inlined_conditional_merge;
+
+  assert_eq!(
+    StateManager::for_test(None, options.clone()).enable_inlined_conditional_merge(),
+    default_setting
+  );
+
+  options.enable_inlined_conditional_merge = !default_setting;
+
+  assert_eq!(
+    StateManager::for_test(None, options).enable_inlined_conditional_merge(),
+    !default_setting
+  );
+}
+
+/// A refusal is the subtree's own unless the walk was too deep to say where it
+/// came from, or was only reading a name to decide whether it could fold.
+#[test]
+fn a_refusal_is_the_subtree_s_own_unless_something_else_raised_it() {
+  let mut state = StateManager::for_test(None, StyleXStateOptions::default());
+
+  assert!(state.owns_its_refusals());
+
+  state.depth_refused = true;
+  assert!(!state.owns_its_refusals());
+
+  state.depth_refused = false;
+  state.speculating = true;
+  assert!(!state.owns_its_refusals());
+
+  state.depth_refused = true;
+  assert!(!state.owns_its_refusals());
+}
+
+/// A real path answers as itself, and as its name without the extension.
+#[test]
+fn a_real_file_answers_its_path_and_its_name() {
+  let state = state_for(real("/repo/src/app.stylex.js"), common_js(None, None));
+
+  assert_eq!(state.get_filename(), "/repo/src/app.stylex.js");
+  assert_eq!(state.get_short_filename(), "app.stylex");
+}
+
+/// A module with no file behind it answers empty rather than refusing, which is
+/// what lets a module compiled from a string still be compiled.
+#[test]
+fn a_module_with_no_file_answers_empty() {
+  let state = state_for(FileName::Anon, common_js(None, None));
+
+  assert_eq!(state.get_filename(), "");
+  assert_eq!(state.get_short_filename(), "");
+  assert_eq!(
+    state.get_filename_for_hashing(&mut FxHashMap::default()),
+    None
+  );
+}
+
+/// Only a file that defines variables or constants is named for hashing: every
+/// other file's styles are named from their own content.
+#[test]
+fn only_a_variable_file_is_named_for_hashing() {
+  let ordinary = state_for(real("/repo/src/app.js"), common_js(None, None));
+
+  assert_eq!(
+    ordinary.get_filename_for_hashing(&mut FxHashMap::default()),
+    None
+  );
+
+  let theme = state_for(
+    real(&fixture("package_json_with_name/vars.stylex.js").to_string_lossy()),
+    common_js(None, None),
+  );
+
+  assert_eq!(
+    theme.get_filename_for_hashing(&mut FxHashMap::default()),
+    Some("package_json_with_name:vars.stylex.js".to_string())
+  );
+
+  let consts = state_for(
+    real(&fixture("package_json_with_name/vars.stylex.const.js").to_string_lossy()),
+    common_js(None, None),
+  );
+
+  assert_eq!(
+    consts.get_filename_for_hashing(&mut FxHashMap::default()),
+    Some("package_json_with_name:vars.stylex.const.js".to_string())
+  );
+}
+
+/// The extension that marks a variable file is the project's own, so a project
+/// that spells it differently names its own files and not the default ones.
+#[test]
+fn the_variable_file_extension_is_the_project_s_own() {
+  let state = state_for(
+    real("/repo/src/vars.theme.js"),
+    common_js(None, Some(".theme")),
+  );
+
+  assert!(
+    state
+      .get_filename_for_hashing(&mut FxHashMap::default())
+      .is_some()
+  );
+
+  let default_extension = state_for(real("/repo/src/vars.theme.js"), common_js(None, None));
+
+  assert_eq!(
+    default_extension.get_filename_for_hashing(&mut FxHashMap::default()),
+    None
+  );
+}
+
+/// Under Haste resolution a file is named by its own name alone, because that
+/// is what a Haste import spells.
+#[test]
+fn haste_names_a_variable_file_by_its_own_name() {
+  let state = state_for(real("/repo/src/vars.stylex.js"), haste(None));
+
+  assert_eq!(
+    state.get_filename_for_hashing(&mut FxHashMap::default()),
+    Some("vars.stylex.js".to_string())
+  );
+}
+
+/// A module compiled from a string resolves no import: there is no file for a
+/// relative path to be relative to.
+#[test]
+fn a_module_with_no_file_resolves_no_import() {
+  let state = state_for(FileName::Anon, common_js(None, None));
+
+  assert!(matches!(
+    state.import_path_resolver("./vars.stylex.js", &mut FxHashMap::default()),
+    ImportPathResolution::Unresolved
+  ));
+}
+
+/// Only an import of a variable file is resolved. Every other import is left
+/// alone, because nothing in it can name a variable.
+#[test]
+fn an_import_that_names_no_variable_file_is_left_alone() {
+  let state = state_for(real("/repo/src/app.js"), common_js(None, None));
+
+  for import in ["react", "./helpers", "./styles.css"] {
+    assert!(
+      matches!(
+        state.import_path_resolver(import, &mut FxHashMap::default()),
+        ImportPathResolution::Unresolved
+      ),
+      "`{}` was resolved",
+      import
+    );
+  }
+}
+
+/// Under Haste an import of a variable file is resolved by giving it the
+/// importing file's own extension, and one that already has an extension keeps
+/// it.
+#[test]
+fn haste_gives_an_import_the_importing_file_s_extension() {
+  let state = state_for(real("/repo/src/app.tsx"), haste(None));
+
+  assert!(matches!(
+    state.import_path_resolver("vars.stylex", &mut FxHashMap::default()),
+    ImportPathResolution::Resolved { path } if path == "vars.stylex.tsx"
+  ));
+
+  assert!(matches!(
+    state.import_path_resolver("vars.stylex.js", &mut FxHashMap::default()),
+    ImportPathResolution::Resolved { path } if path == "vars.stylex.js"
+  ));
+}
+
+/// An importing file with no extension of its own has none to give, so the
+/// import is left as written.
+#[test]
+fn haste_leaves_an_import_alone_when_there_is_no_extension_to_give() {
+  let state = state_for(real("/repo/src/app"), haste(None));
+
+  assert!(matches!(
+    state.import_path_resolver("vars.stylex", &mut FxHashMap::default()),
+    ImportPathResolution::Resolved { path } if path == "vars.stylex"
+  ));
+}
+
+/// An import that cannot be found on disk is left unresolved rather than
+/// stopping the build: the file may be written by another tool.
+#[test]
+fn an_import_that_is_not_on_disk_is_left_unresolved() {
+  let state = state_for(
+    real(&fixture("package_json_with_name/app.js").to_string_lossy()),
+    common_js(None, None),
+  );
+
+  assert!(matches!(
+    state.import_path_resolver("./missing.stylex.js", &mut FxHashMap::default()),
+    ImportPathResolution::Unresolved
+  ));
+}
+
+/// The base a compiled call's position is measured from is recorded once, as
+/// the module walk begins.
+#[test]
+fn the_module_base_is_recorded_once() {
+  let mut state = StateManager::for_test(None, StyleXStateOptions::default());
+
+  assert!(state.input_module_base().is_none());
+
+  let module = Module {
+    span: Span::new(
+      swc_core::common::BytePos(100),
+      swc_core::common::BytePos(400),
+    ),
+    body: vec![],
+    shebang: None,
+  };
+
+  state.set_input_module_base(ModuleBase::of(&module));
+
+  assert_eq!(
+    format!("{:?}", state.input_module_base()),
+    format!("{:?}", Some(ModuleBase::of(&module)))
+  );
+}
+
+/// The module the compiler parsed is kept so a diagnostic can quote it, along
+/// with the source it was parsed from where the host has one.
+#[test]
+fn the_parsed_module_is_kept_for_a_diagnostic_to_quote() {
+  use stylex_diagnostics::state::DiagnosticState;
+
+  let mut state = StateManager::for_test(None, StyleXStateOptions::default());
+
+  assert!(state.get_seen_module_source_code().is_none());
+
+  let module = Module {
+    span: DUMMY_SP,
+    body: vec![],
+    shebang: None,
+  };
+
+  StateManager::set_seen_module_source_code(&mut state, &module, Some("const a = 1;".to_string()));
+
+  let Some((seen, source)) = state.get_seen_module_source_code() else {
+    panic!("the parsed module was not kept");
+  };
+
+  assert_eq!(seen.body.len(), 0);
+  assert_eq!(source, Some("const a = 1;"));
+}
+
+/// The `env` option reaches the function map two ways: through a namespace
+/// import, where it is a member of the namespace, and through a direct import
+/// of `env`, where it is a name of its own.
+#[test]
+fn the_env_option_reaches_the_function_map_both_ways() {
+  use std::rc::Rc;
+
+  use indexmap::IndexMap;
+  use swc_core::atoms::Atom;
+  use swc_core::ecma::ast::{Expr, Lit, Str};
+
+  use stylex_structures::named_import_source::ImportSources;
+  use stylex_structures::stylex_env::EnvEntry;
+
+  use crate::state_manager::ImportKind;
+  use crate::types::{FunctionMapIdentifiers, FunctionMapMemberExpression};
+
+  let mut env = IndexMap::new();
+
+  env.insert(
+    "breakpoint".to_string(),
+    EnvEntry::Expr(Expr::Lit(Lit::Str(Str {
+      span: DUMMY_SP,
+      value: "sm".into(),
+      raw: None,
+    }))),
+  );
+
+  let mut state = StateManager::for_test(
+    None,
+    StyleXStateOptions {
+      core: CoreStyleXOptions {
+        env: Rc::new(env),
+        ..CoreStyleXOptions::default()
+      },
+      ..StyleXStateOptions::default()
+    },
+  );
+
+  state.insert_stylex_import(ImportSources::Regular("stylex".to_string()));
+  state.insert_stylex_api_import(ImportKind::Env, Atom::from("env"));
+
+  let mut identifiers = FunctionMapIdentifiers::default();
+  let mut member_expressions = FunctionMapMemberExpression::default();
+
+  state.apply_stylex_env(&mut identifiers, &mut member_expressions);
+
+  assert!(identifiers.contains_key(&Atom::from("env")));
+  assert_eq!(member_expressions.len(), 1);
+}
+
+/// A project that configures no `env` adds nothing, so a module that never
+/// reads one pays no lookup for it.
+#[test]
+fn a_project_with_no_env_adds_nothing_to_the_function_map() {
+  use swc_core::atoms::Atom;
+
+  use stylex_structures::named_import_source::ImportSources;
+
+  use crate::state_manager::ImportKind;
+  use crate::types::{FunctionMapIdentifiers, FunctionMapMemberExpression};
+
+  let mut state = StateManager::for_test(None, StyleXStateOptions::default());
+
+  state.insert_stylex_import(ImportSources::Regular("stylex".to_string()));
+  state.insert_stylex_api_import(ImportKind::Env, Atom::from("env"));
+
+  let mut identifiers = FunctionMapIdentifiers::default();
+  let mut member_expressions = FunctionMapMemberExpression::default();
+
+  state.apply_stylex_env(&mut identifiers, &mut member_expressions);
+
+  assert!(identifiers.is_empty());
+  assert!(member_expressions.is_empty());
+}
+
+/// The parsed source file and its map are handed in by the host, and holding
+/// them is all the state does with them.
+#[test]
+fn the_host_s_source_file_and_map_are_taken_as_handed_in() {
+  use std::sync::Arc;
+
+  use swc_core::common::{BytePos, SourceFile};
+
+  let mut state = StateManager::for_test(None, StyleXStateOptions::default());
+
+  state.set_input_source_file(Arc::new(SourceFile::new(
+    Arc::new(real("/repo/src/app.js")),
+    false,
+    Arc::new(real("/repo/src/app.js")),
+    "const a = 1;".into(),
+    BytePos(1),
+  )));
+  state.set_input_source_map(Arc::new(swc_sourcemap::SourceMap::new(
+    None,
+    Vec::new(),
+    Vec::new(),
+    Vec::new(),
+    None,
+  )));
+}
+
+/// An import of a module by path, which is what a theme side effect is written
+/// as.
+#[test]
+fn an_import_of_a_module_is_written_as_a_bare_path() {
+  use swc_core::ecma::ast::{ModuleDecl, ModuleItem};
+
+  use crate::state_manager::add_import_expression;
+
+  let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) =
+    add_import_expression("./vars.stylex.js")
+  else {
+    panic!("the import was not written as an import");
+  };
+
+  assert_eq!(import.src.value.as_str(), Some("./vars.stylex.js"));
+  assert!(import.specifiers.is_empty());
+  assert!(!import.type_only);
+}
+
+/// A syntax context is not part of what a file name is, so the state answers the
+/// same name whichever scope asked.
+#[test]
+fn a_file_name_does_not_depend_on_a_scope() {
+  let _ = SyntaxContext::empty();
+
+  let state = state_for(real("/repo/src/app.js"), common_js(Some("/repo"), None));
+
+  assert_eq!(state.get_filename(), "/repo/src/app.js");
+}
+
+/// Under CommonJs an import of a variable file resolves to the name the file is
+/// hashed under, which is what makes a variable imported from another file name
+/// the same CSS variable in both.
+#[test]
+fn common_js_resolves_an_import_to_the_name_the_file_is_hashed_under() {
+  let state = state_for(
+    real(&fixture("package_json_with_name/app.js").to_string_lossy()),
+    common_js(None, None),
+  );
+
+  assert!(matches!(
+    state.import_path_resolver("./vars.stylex.js", &mut FxHashMap::default()),
+    ImportPathResolution::Resolved { path }
+      if path == "package_json_with_name:vars.stylex.js"
+  ));
+}
+
+/// Reading variables out of the file that imports them is not supported, and
+/// the compiler says so rather than resolving the import to nothing.
+#[test]
+#[should_panic(expected = "This module resolution strategy is not yet supported.")]
+fn cross_file_parsing_is_refused() {
+  let state = state_for(
+    real("/repo/src/app.js"),
+    CheckModuleResolution::CrossFileParsing {
+      root_dir: None,
+      theme_file_extension: None,
+    },
+  );
+
+  state.import_path_resolver("./vars.stylex.js", &mut FxHashMap::default());
+}
+
+/// A project that spells the variable-file extension as nothing marks every
+/// module file as one, because every module file ends in a module extension.
+#[test]
+fn an_empty_variable_file_extension_marks_every_module_file() {
+  let state = state_for(real("/repo/src/app.tsx"), haste(Some("")));
+
+  assert_eq!(
+    state.get_filename_for_hashing(&mut FxHashMap::default()),
+    Some("app.tsx".to_string())
+  );
+}
+
+/// The name a file is hashed under falls back to its place under the project
+/// root when no package encloses it, and to its own name when neither does.
+#[test]
+fn a_file_outside_every_package_is_named_from_the_project_root() {
+  let rooted = state_for(
+    real("/unknown/src/app.js"),
+    common_js(Some("/unknown"), None),
+  );
+
+  assert_eq!(
+    rooted.get_canonical_file_path("/unknown/src/app.js", &mut FxHashMap::default()),
+    "src/app.js"
+  );
+
+  let unrooted = state_for(real("/unknown/src/app.js"), common_js(None, None));
+
+  assert_eq!(
+    unrooted.get_canonical_file_path("/unknown/src/app.js", &mut FxHashMap::default()),
+    "_unknown_path_:app.js"
+  );
+}
+
+/// A namespace import carries `env` whether or not `env` was also imported by
+/// name, so a project that never imports it directly still reads it as a member.
+#[test]
+fn a_namespace_import_carries_env_without_a_direct_import() {
+  use std::rc::Rc;
+
+  use indexmap::IndexMap;
+  use swc_core::ecma::ast::{Expr, Lit, Str};
+
+  use stylex_structures::named_import_source::ImportSources;
+  use stylex_structures::stylex_env::EnvEntry;
+
+  use crate::types::{FunctionMapIdentifiers, FunctionMapMemberExpression};
+
+  let mut env = IndexMap::new();
+
+  env.insert(
+    "breakpoint".to_string(),
+    EnvEntry::Expr(Expr::Lit(Lit::Str(Str {
+      span: DUMMY_SP,
+      value: "sm".into(),
+      raw: None,
+    }))),
+  );
+
+  let mut state = StateManager::for_test(
+    None,
+    StyleXStateOptions {
+      core: CoreStyleXOptions {
+        env: Rc::new(env),
+        ..CoreStyleXOptions::default()
+      },
+      ..StyleXStateOptions::default()
+    },
+  );
+
+  state.insert_stylex_import(ImportSources::Regular("stylex".to_string()));
+
+  let mut identifiers = FunctionMapIdentifiers::default();
+  let mut member_expressions = FunctionMapMemberExpression::default();
+
+  state.apply_stylex_env(&mut identifiers, &mut member_expressions);
+
+  assert!(identifiers.is_empty());
+  assert_eq!(member_expressions.len(), 1);
+}
+
+/// A path with no folder above it names no package, which is where the walk up
+/// the tree stops.
+#[test]
+fn a_path_with_no_folder_above_it_names_no_package() {
+  assert_eq!(
+    StateManager::get_package_name_and_path("", &mut FxHashMap::default()),
+    None
+  );
+}
+
+/// Resolving an import needs the package the importing file belongs to. A file
+/// that belongs to none cannot be resolved against, and the compiler says which
+/// file it was.
+#[test]
+#[should_panic(expected = "Cannot get package name and path for")]
+fn an_import_from_a_file_outside_every_package_is_refused() {
+  let state = state_for(real("/vars.stylex.js"), common_js(None, None));
+
+  state.import_path_resolver("./other.stylex.js", &mut FxHashMap::default());
+}

--- a/crates/stylex-state/src/tests/fixtures/package_json_with_name/app.js
+++ b/crates/stylex-state/src/tests/fixtures/package_json_with_name/app.js
@@ -1,0 +1,4 @@
+// The importing file the resolver measures a relative import against.
+import { vars } from './vars.stylex.js';
+
+export default vars;

--- a/crates/stylex-state/src/tests/fixtures/package_json_with_name/vars.stylex.js
+++ b/crates/stylex-state/src/tests/fixtures/package_json_with_name/vars.stylex.js
@@ -1,0 +1,3 @@
+// A variable file for the import resolver to find. Its contents do not matter:
+// the resolver reads the path and never opens the file.
+export const vars = {};

--- a/crates/stylex-state/src/tests/flat_compiled_styles_value_test.rs
+++ b/crates/stylex-state/src/tests/flat_compiled_styles_value_test.rs
@@ -1,0 +1,219 @@
+//! What one compiled style value answers about itself.
+//!
+//! Every accessor here reads one variant and declines the rest, and a namespace
+//! holds a mix of them: a class name, a `null` for a property the namespace
+//! declares but does not set, a `true` for the compiled marker, an injectable
+//! style, a variable pair. So each case asks one accessor for the variant it
+//! reads *and* for a variant it does not, because an accessor that answered
+//! `Some` for the wrong variant is what would let a `null` be written as a class
+//! name.
+
+use swc_core::{
+  common::DUMMY_SP,
+  ecma::ast::{Expr, Lit, Str},
+};
+
+use stylex_enums::{css_syntax::CSSSyntax, value_with_default::ValueWithDefault};
+use stylex_structures::{base_css_type::BaseCSSType, pair::Pair};
+use stylex_styleq::StyleqValue;
+use stylex_types::structures::injectable_style::InjectableStyle;
+
+use crate::flat_compiled_styles_value::FlatCompiledStylesValue;
+
+fn string_value(value: &str) -> FlatCompiledStylesValue {
+  FlatCompiledStylesValue::String(value.to_string())
+}
+
+fn injectable() -> InjectableStyle {
+  InjectableStyle {
+    ltr: ".x1e2nbdu{color:red}".to_string(),
+    rtl: None,
+    priority: Some(3000.0),
+  }
+}
+
+fn css_type() -> BaseCSSType {
+  BaseCSSType {
+    value: ValueWithDefault::String("red".to_string()),
+    syntax: CSSSyntax::Color,
+  }
+}
+
+fn tuple_value() -> FlatCompiledStylesValue {
+  FlatCompiledStylesValue::Tuple(
+    "--x1abcdef".to_string(),
+    Box::new(Expr::Lit(Lit::Str(Str {
+      span: DUMMY_SP,
+      value: "red".into(),
+      raw: None,
+    }))),
+    Some(css_type()),
+  )
+}
+
+/// Every variant, so a case that must name one it does not read has a list to
+/// take it from rather than building one more.
+fn every_variant() -> Vec<FlatCompiledStylesValue> {
+  vec![
+    string_value("x1e2nbdu"),
+    FlatCompiledStylesValue::KeyValue(Pair::new("color", "red")),
+    FlatCompiledStylesValue::KeyValues(vec![Pair::new("color", "red")]),
+    FlatCompiledStylesValue::Null,
+    FlatCompiledStylesValue::InjectableStyle(injectable()),
+    FlatCompiledStylesValue::Bool(true),
+    tuple_value(),
+    FlatCompiledStylesValue::CSSType(
+      "--x1abcdef".to_string(),
+      CSSSyntax::Color,
+      "red".to_string(),
+    ),
+  ]
+}
+
+/// How many variants answered `Some` to one accessor. Every accessor reads
+/// exactly one variant, so the count is the whole assertion.
+fn count_answering(accessor: impl Fn(&FlatCompiledStylesValue) -> bool) -> usize {
+  every_variant()
+    .iter()
+    .filter(|value| accessor(value))
+    .count()
+}
+
+#[test]
+fn a_tuple_answers_its_three_parts_and_nothing_else_does() {
+  let value = tuple_value();
+
+  let Some((key, expr, base)) = value.as_tuple() else {
+    panic!("a tuple did not answer its parts");
+  };
+
+  assert_eq!(key, "--x1abcdef");
+  assert_eq!(
+    expr
+      .as_lit()
+      .and_then(|lit| lit.as_str())
+      .and_then(|str_lit| str_lit.value.as_str()),
+    Some("red")
+  );
+  assert_eq!(base.as_ref(), Some(&css_type()));
+
+  assert_eq!(count_answering(|value| value.as_tuple().is_some()), 1);
+}
+
+/// A tuple with no CSS type is the shape a plain variable takes, and the third
+/// part is `None` rather than the accessor declining.
+#[test]
+fn a_tuple_without_a_css_type_still_answers_its_parts() {
+  let value = FlatCompiledStylesValue::Tuple(
+    "--x1abcdef".to_string(),
+    Box::new(Expr::Lit(Lit::Str(Str {
+      span: DUMMY_SP,
+      value: "red".into(),
+      raw: None,
+    }))),
+    None,
+  );
+
+  let Some((key, _, base)) = value.as_tuple() else {
+    panic!("a tuple without a CSS type did not answer its parts");
+  };
+
+  assert_eq!(key, "--x1abcdef");
+  assert_eq!(base.as_ref(), None);
+}
+
+#[test]
+fn a_string_answers_itself_and_nothing_else_does() {
+  assert_eq!(
+    string_value("x1e2nbdu").as_string(),
+    Some(&"x1e2nbdu".to_string())
+  );
+  assert_eq!(count_answering(|value| value.as_string().is_some()), 1);
+}
+
+/// An empty class name is still a string: nothing about the accessor treats the
+/// empty string as an absent one.
+#[test]
+fn an_empty_string_is_still_a_string() {
+  assert_eq!(string_value("").as_string(), Some(&String::new()));
+}
+
+#[test]
+fn an_injectable_style_answers_itself_and_nothing_else_does() {
+  let value = FlatCompiledStylesValue::InjectableStyle(injectable());
+
+  assert_eq!(value.as_injectable_style(), Some(&injectable()));
+  assert_eq!(
+    count_answering(|value| value.as_injectable_style().is_some()),
+    1
+  );
+}
+
+#[test]
+fn a_bool_answers_itself_and_nothing_else_does() {
+  assert_eq!(FlatCompiledStylesValue::Bool(true)._as_bool(), Some(&true));
+  assert_eq!(
+    FlatCompiledStylesValue::Bool(false)._as_bool(),
+    Some(&false)
+  );
+  assert_eq!(count_answering(|value| value._as_bool().is_some()), 1);
+}
+
+#[test]
+fn a_null_answers_itself_and_nothing_else_does() {
+  assert_eq!(FlatCompiledStylesValue::Null._as_null(), Some(()));
+  assert_eq!(count_answering(|value| value._as_null().is_some()), 1);
+}
+
+#[test]
+fn a_key_value_answers_its_pair_and_nothing_else_does() {
+  let pair = Pair::new("color", "red");
+  let value = FlatCompiledStylesValue::KeyValue(pair.clone());
+
+  assert_eq!(value.as_key_value(), Some(&pair));
+  assert_eq!(count_answering(|value| value.as_key_value().is_some()), 1);
+}
+
+/// A list of pairs is its own variant: one pair and a list holding that pair are
+/// two values, and neither accessor reads the other.
+#[test]
+fn key_values_answer_their_list_and_nothing_else_does() {
+  let pairs = vec![Pair::new("color", "red"), Pair::new("color", "blue")];
+  let value = FlatCompiledStylesValue::KeyValues(pairs.clone());
+
+  assert_eq!(value.as_key_values(), Some(&pairs));
+  assert_eq!(count_answering(|value| value.as_key_values().is_some()), 1);
+}
+
+/// An empty list is a list, not an absent one -- a fallback set that resolved to
+/// nothing reaches here.
+#[test]
+fn an_empty_key_value_list_is_still_a_list() {
+  let value = FlatCompiledStylesValue::KeyValues(vec![]);
+
+  assert_eq!(value.as_key_values(), Some(&vec![]));
+}
+
+/// The three questions `styleq` asks of a namespace entry. A class name is the
+/// string, `null` marks a property the namespace clears, and `true` is the
+/// compiled marker -- so only the string variant names a class.
+#[test]
+fn styleq_reads_a_class_name_out_of_the_string_alone() {
+  assert_eq!(string_value("x1e2nbdu").as_class_name(), Some("x1e2nbdu"));
+  assert_eq!(count_answering(|value| value.as_class_name().is_some()), 1);
+}
+
+#[test]
+fn styleq_reads_null_out_of_the_null_alone() {
+  assert!(FlatCompiledStylesValue::Null.is_null());
+  assert_eq!(count_answering(StyleqValue::is_null), 1);
+}
+
+/// `false` is not the compiled marker. The marker is written as `true` and only
+/// `true`, so a namespace carrying `$$css: false` is not treated as compiled.
+#[test]
+fn styleq_reads_the_compiled_marker_out_of_a_true_alone() {
+  assert!(FlatCompiledStylesValue::Bool(true).is_true_bool());
+  assert!(!FlatCompiledStylesValue::Bool(false).is_true_bool());
+  assert_eq!(count_answering(StyleqValue::is_true_bool), 1);
+}

--- a/crates/stylex-state/src/tests/functions_test.rs
+++ b/crates/stylex-state/src/tests/functions_test.rs
@@ -1,0 +1,73 @@
+//! Which function-config shape carries a map.
+//!
+//! A namespace's API surface is registered as one of four shapes, and only one
+//! of them -- the map -- is added to after registration. `as_map_mut` is what
+//! the registration asks, so it must decline the other three rather than making
+//! a map to hand back.
+
+use std::rc::Rc;
+
+use indexmap::IndexMap;
+use stylex_structures::stylex_env::{EnvEntry, JSFunction};
+use stylex_utils::collections::FxIndexMap;
+
+use crate::functions::{FunctionConfig, FunctionConfigType, FunctionType};
+use crate::tests::prelude::string_expr;
+
+fn regular_config() -> FunctionConfig {
+  FunctionConfig {
+    fn_ptr: FunctionType::Callback(Box::new(string_expr("callback"))),
+    takes_path: false,
+  }
+}
+
+#[test]
+fn a_map_answers_itself_and_can_be_added_to() {
+  let mut config = FunctionConfigType::Map(FxIndexMap::default());
+
+  let Some(map) = config.as_map_mut() else {
+    panic!("a map config did not answer its map");
+  };
+
+  assert!(map.is_empty());
+  map.insert("when".into(), FunctionConfigType::Regular(regular_config()));
+
+  // The insert reached the config and not a copy of it, which is the whole
+  // reason the accessor hands back a mutable borrow.
+  assert_eq!(config.as_map_mut().map(|map| map.len()), Some(1));
+}
+
+#[test]
+fn a_regular_config_holds_no_map() {
+  assert!(
+    FunctionConfigType::Regular(regular_config())
+      .as_map_mut()
+      .is_none()
+  );
+}
+
+#[test]
+fn a_compiled_namespace_holds_no_map() {
+  assert!(
+    FunctionConfigType::IndexMap(IndexMap::new())
+      .as_map_mut()
+      .is_none()
+  );
+}
+
+#[test]
+fn an_env_object_holds_no_map() {
+  let mut env = IndexMap::new();
+
+  env.insert("breakpoint".to_string(), EnvEntry::Expr(string_expr("sm")));
+  env.insert(
+    "spacing".to_string(),
+    EnvEntry::Function(JSFunction::new(|_| string_expr("8px"))),
+  );
+
+  assert!(
+    FunctionConfigType::EnvObject(Rc::new(env))
+      .as_map_mut()
+      .is_none()
+  );
+}

--- a/crates/stylex-state/src/tests/get_canonical_file_path_test.rs
+++ b/crates/stylex-state/src/tests/get_canonical_file_path_test.rs
@@ -1,24 +1,16 @@
 #[cfg(test)]
 mod get_canonical_file_path {
-  use std::{env, path::PathBuf};
+  use std::path::PathBuf;
 
-  use path_clean::PathClean;
   use rustc_hash::FxHashMap;
 
   use crate::state_manager::StateManager;
+  use crate::tests::prelude::fixture_path;
   use stylex_structures::stylex_options::CheckModuleResolution;
-
-  fn get_fixture_path(test_path: &str) -> PathBuf {
-    env::current_dir()
-      .unwrap()
-      .join("src/tests/fixtures")
-      .join(test_path)
-      .clean()
-  }
 
   #[test]
   fn get_canonical_file_path_with_name() {
-    let fixture_path = get_fixture_path("package_json_with_name");
+    let fixture_path = fixture_path("package_json_with_name");
 
     let stage_manager = StateManager::default();
 
@@ -30,7 +22,7 @@ mod get_canonical_file_path {
 
   #[test]
   fn get_canonical_file_path_without_name() {
-    let fixture_path = get_fixture_path("package_json_without_name");
+    let fixture_path = fixture_path("package_json_without_name");
 
     let stage_manager = StateManager::default();
 
@@ -74,7 +66,7 @@ mod get_canonical_file_path {
 
   #[test]
   fn get_canonical_file_from_root_dir() {
-    let fixture_path = get_fixture_path("package_json_with_name");
+    let fixture_path = fixture_path("package_json_with_name");
 
     let root_dir = fixture_path.parent().unwrap();
 

--- a/crates/stylex-state/src/tests/get_canonical_file_path_test.rs
+++ b/crates/stylex-state/src/tests/get_canonical_file_path_test.rs
@@ -90,4 +90,43 @@ mod get_canonical_file_path {
       "@stylexswc/state:src/tests/fixtures/src/components"
     );
   }
+
+  fn rooted(root_dir: &str) -> StateManager {
+    let mut state = StateManager::default();
+
+    state.options =
+      state
+        .options
+        .with_unstable_module_resolution(CheckModuleResolution::CommonJs {
+          root_dir: Some(root_dir.to_string()),
+          theme_file_extension: None,
+        });
+
+    state
+  }
+
+  /// Separators are normalized, so a path written the Windows way answers the
+  /// name a POSIX one does. The backslash is data rather than a separator off
+  /// Windows, which is what lets one assertion stand on every platform.
+  #[test]
+  fn a_backslash_in_a_path_is_answered_as_a_forward_slash() {
+    let state = rooted("/root");
+
+    assert_eq!(
+      state.get_canonical_file_path("/root/src\\components\\app.js", &mut FxHashMap::default()),
+      "src/components/app.js"
+    );
+  }
+
+  /// A file the root dir does not enclose is named by climbing out of it rather
+  /// than refused, which is what a relative path with no common prefix reads as.
+  #[test]
+  fn a_file_beside_the_root_dir_is_named_by_climbing_out_of_it() {
+    let state = rooted("/root/src");
+
+    assert_eq!(
+      state.get_canonical_file_path("/root/lib/app.js", &mut FxHashMap::default()),
+      "../lib/app.js"
+    );
+  }
 }

--- a/crates/stylex-state/src/tests/get_package_name_and_path_test.rs
+++ b/crates/stylex-state/src/tests/get_package_name_and_path_test.rs
@@ -1,23 +1,13 @@
 #[cfg(test)]
 mod get_package_name_and_path {
-  use std::{env, path::PathBuf};
-
-  use path_clean::PathClean;
   use rustc_hash::FxHashMap;
 
   use crate::state_manager::StateManager;
-
-  fn get_fixture_path(test_path: &str) -> PathBuf {
-    env::current_dir()
-      .unwrap()
-      .join("src/tests/fixtures")
-      .join(test_path)
-      .clean()
-  }
+  use crate::tests::prelude::fixture_path;
 
   #[test]
   fn get_package_json_with_name() {
-    let fixture_path = get_fixture_path("package_json_with_name");
+    let fixture_path = fixture_path("package_json_with_name");
 
     let (package_name, package_path) = StateManager::get_package_name_and_path(
       fixture_path.to_str().unwrap(),
@@ -31,7 +21,7 @@ mod get_package_name_and_path {
 
   #[test]
   fn get_package_json_without_name() {
-    let fixture_path = get_fixture_path("package_json_without_name");
+    let fixture_path = fixture_path("package_json_without_name");
 
     let (package_name, package_path) = StateManager::get_package_name_and_path(
       fixture_path.to_str().unwrap(),

--- a/crates/stylex-state/src/tests/import_kind_test.rs
+++ b/crates/stylex-state/src/tests/import_kind_test.rs
@@ -1,0 +1,87 @@
+//! Which StyleX API a name imports.
+//!
+//! The name in the source is the whole of what decides, so every API the
+//! compiler answers for is listed once here. A name this compiler does not know
+//! answers nothing, which is what lets an unrelated import of the same module
+//! pass through untouched.
+
+use crate::state_manager::ImportKind;
+
+/// Every API name, paired with the kind it names. Written out rather than read
+/// off the constants, so a constant that changes value fails here.
+const EVERY_API: &[(&str, ImportKind)] = &[
+  ("attrs", ImportKind::Attrs),
+  ("create", ImportKind::Create),
+  ("createTheme", ImportKind::CreateTheme),
+  ("defaultMarker", ImportKind::DefaultMarker),
+  ("defineConsts", ImportKind::DefineConsts),
+  ("defineMarker", ImportKind::DefineMarker),
+  ("defineVars", ImportKind::DefineVars),
+  ("env", ImportKind::Env),
+  ("firstThatWorks", ImportKind::FirstThatWorks),
+  ("keyframes", ImportKind::Keyframes),
+  ("positionTry", ImportKind::PositionTry),
+  ("props", ImportKind::Props),
+  ("types", ImportKind::Types),
+  ("unstable_conditional", ImportKind::Conditional),
+  ("unstable_createThemeNested", ImportKind::CreateThemeNested),
+  (
+    "unstable_defineConstsNested",
+    ImportKind::DefineConstsNested,
+  ),
+  ("unstable_defineVarsNested", ImportKind::DefineVarsNested),
+  ("viewTransitionClass", ImportKind::ViewTransitionClass),
+  ("when", ImportKind::When),
+];
+
+#[test]
+fn every_api_name_answers_its_own_kind() {
+  for (name, kind) in EVERY_API {
+    assert_eq!(
+      ImportKind::from_import_name(name),
+      Some(*kind),
+      "`{}` named the wrong API",
+      name
+    );
+  }
+}
+
+/// No two names answer the same kind, which is what makes the table above a
+/// mapping rather than a list.
+#[test]
+fn no_two_api_names_answer_one_kind() {
+  for (index, (name, kind)) in EVERY_API.iter().enumerate() {
+    for (other_name, other_kind) in &EVERY_API[index + 1..] {
+      assert_ne!(
+        kind, other_kind,
+        "`{}` and `{}` named the same API",
+        name, other_name
+      );
+    }
+  }
+}
+
+/// A name this compiler does not know is not an API, whatever it looks like.
+/// The spellings below are the near misses: a different case, a plural, a
+/// prefixed form, the empty name.
+#[test]
+fn a_name_this_compiler_does_not_know_is_not_an_api() {
+  for name in [
+    "",
+    "Create",
+    "creates",
+    "stylex.create",
+    "createThemeNested",
+    "unstable_create",
+    " create",
+    "create ",
+    "CREATE",
+  ] {
+    assert_eq!(
+      ImportKind::from_import_name(name),
+      None,
+      "`{}` was read as an API",
+      name
+    );
+  }
+}

--- a/crates/stylex-state/src/tests/import_queries_test.rs
+++ b/crates/stylex-state/src/tests/import_queries_test.rs
@@ -1,0 +1,269 @@
+//! What the state knows about the module's imports.
+//!
+//! Two sets, asked in two ways. The *import sources* come from the project
+//! options and say which modules count as StyleX; the *stylex imports* and the
+//! *API imports* come from the module walk and say which local names those
+//! modules bound. A name resolves to a StyleX API when it is a namespace the
+//! module imported, or when it is one of the API names imported directly -- and
+//! which API names count depends on the cycle the compiler is in.
+
+use swc_core::atoms::Atom;
+
+use stylex_enums::core::TransformationCycle;
+use stylex_structures::core_stylex_options::CoreStyleXOptions;
+use stylex_structures::named_import_source::{ImportSources, NamedImportSource};
+use stylex_structures::stylex_state_options::StyleXStateOptions;
+
+use crate::state_manager::{ImportKind, StateManager};
+use crate::tests::prelude::test_state as state;
+
+fn named(from: &str, r#as: &str) -> ImportSources {
+  ImportSources::Named(NamedImportSource {
+    from: from.to_string(),
+    r#as: r#as.to_string(),
+  })
+}
+
+/// A project whose import sources are the two shapes an option can take: a bare
+/// module, and a module paired with the name its export is read under.
+fn state_with_sources(sources: Vec<ImportSources>) -> StateManager {
+  StateManager::for_test(
+    None,
+    StyleXStateOptions {
+      core: CoreStyleXOptions {
+        import_sources: sources.into_iter().collect(),
+        ..CoreStyleXOptions::default()
+      },
+      ..StyleXStateOptions::default()
+    },
+  )
+}
+
+/// Whether the module imported anything at all, which is what decides if the
+/// compiler has any work to look for.
+#[test]
+fn a_module_that_imports_nothing_has_no_import_paths() {
+  let mut state = state();
+
+  assert!(!state.has_import_paths());
+
+  state.insert_import_path("@stylexjs/stylex".to_string());
+
+  assert!(state.has_import_paths());
+}
+
+/// One path recorded twice is one path: the record is a set, because it answers
+/// a yes-or-no question about the module.
+#[test]
+fn one_import_path_recorded_twice_is_one_path() {
+  let mut state = state();
+
+  state.insert_import_path("@stylexjs/stylex".to_string());
+  state.insert_import_path("@stylexjs/stylex".to_string());
+
+  assert!(state.has_import_paths());
+}
+
+/// A namespace import is remembered under the local name it bound, and reading
+/// the set back gives the names in the order they were met.
+#[test]
+fn namespace_imports_are_kept_in_the_order_they_were_met() {
+  let mut state = state();
+
+  state.insert_stylex_import(ImportSources::Regular("stylex".to_string()));
+  state.insert_stylex_import(named("@stylexjs/stylex", "css"));
+
+  assert_eq!(
+    state.stylex_import_names().collect::<Vec<_>>(),
+    vec!["stylex", "css"]
+  );
+  assert_eq!(state.stylex_imports().len(), 2);
+}
+
+/// The same import met twice is one import, so a module that imports a name in
+/// two places does not answer it twice.
+#[test]
+fn one_namespace_import_met_twice_is_one_import() {
+  let mut state = state();
+
+  state.insert_stylex_import(ImportSources::Regular("stylex".to_string()));
+  state.insert_stylex_import(ImportSources::Regular("stylex".to_string()));
+
+  assert_eq!(state.stylex_imports().len(), 1);
+}
+
+/// A plain namespace import is a "regular" one; a named import is not, even
+/// where the name it is read under is the same.
+#[test]
+fn a_named_import_is_not_a_regular_one() {
+  let mut state = state();
+
+  state.insert_stylex_import(named("@stylexjs/stylex", "stylex"));
+
+  assert!(!state.is_regular_stylex_import("stylex"));
+  assert!(state.is_stylex_namespace_import("stylex"));
+
+  state.insert_stylex_import(ImportSources::Regular("css".to_string()));
+
+  assert!(state.is_regular_stylex_import("css"));
+}
+
+/// A name the module never imported is neither.
+#[test]
+fn a_name_the_module_never_imported_is_no_import() {
+  let mut state = state();
+
+  state.insert_stylex_import(ImportSources::Regular("stylex".to_string()));
+
+  assert!(!state.is_regular_stylex_import("css"));
+  assert!(!state.is_stylex_namespace_import("css"));
+}
+
+/// An API imported by name is remembered under the kind it names, and the local
+/// name it was bound to -- which need not be the API's own name.
+#[test]
+fn an_api_import_is_remembered_under_its_kind() {
+  let mut state = state();
+
+  state.insert_stylex_api_import(ImportKind::Create, Atom::from("create"));
+  state.insert_stylex_api_import(ImportKind::Create, Atom::from("makeStyles"));
+
+  let Some(names) = state.get_stylex_api_import(ImportKind::Create) else {
+    panic!("the create import was not remembered");
+  };
+
+  assert_eq!(names.len(), 2);
+  assert!(names.contains(&Atom::from("makeStyles")));
+}
+
+/// A kind nothing imported is remembered as nothing, rather than as an empty
+/// set: the caller reads the difference.
+#[test]
+fn a_kind_nothing_imported_is_remembered_as_nothing() {
+  let mut state = state();
+
+  state.insert_stylex_api_import(ImportKind::Create, Atom::from("create"));
+
+  assert!(state.get_stylex_api_import(ImportKind::Props).is_none());
+}
+
+/// Asking about several kinds at once answers whether *any* of them bound the
+/// name, which is how a cycle asks about the whole group it cares about.
+#[test]
+fn a_name_bound_by_any_of_the_kinds_asked_about_answers_yes() {
+  let mut state = state();
+
+  state.insert_stylex_api_import(ImportKind::Props, Atom::from("props"));
+
+  assert!(state.any_stylex_api_import_contains(
+    &[ImportKind::Attrs, ImportKind::Props],
+    &Atom::from("props")
+  ));
+  assert!(!state.any_stylex_api_import_contains(
+    &[ImportKind::Attrs, ImportKind::Create],
+    &Atom::from("props")
+  ));
+  assert!(!state.any_stylex_api_import_contains(&[], &Atom::from("props")));
+}
+
+/// A namespace import answers for every kind, because every API is reachable
+/// through it.
+#[test]
+fn a_namespace_import_answers_for_every_kind() {
+  let mut state = state();
+
+  state.insert_stylex_import(ImportSources::Regular("stylex".to_string()));
+
+  assert!(state.is_stylex_import_for_kinds("stylex", &[ImportKind::Create]));
+  assert!(state.is_stylex_import_for_kinds("stylex", &[]));
+}
+
+/// A name bound by a direct import answers only for the kind it names.
+#[test]
+fn a_direct_import_answers_only_for_its_own_kind() {
+  let mut state = state();
+
+  state.insert_stylex_api_import(ImportKind::Create, Atom::from("create"));
+
+  assert!(state.is_stylex_import_for_kinds("create", &[ImportKind::Create]));
+  assert!(!state.is_stylex_import_for_kinds("create", &[ImportKind::Props]));
+}
+
+/// Which APIs count depends on the cycle. The producing cycle reads the APIs
+/// that make styles, the consuming cycle reads the two that spend them, and
+/// every other cycle reads only a namespace import.
+#[test]
+fn the_cycle_decides_which_apis_count() {
+  let mut state = state();
+
+  state.insert_stylex_api_import(ImportKind::Create, Atom::from("create"));
+  state.insert_stylex_api_import(ImportKind::Props, Atom::from("props"));
+
+  state.cycle = TransformationCycle::TransformProducers;
+  assert!(state.is_stylex_import_for_current_cycle("create"));
+  assert!(!state.is_stylex_import_for_current_cycle("props"));
+
+  state.cycle = TransformationCycle::TransformConsumers;
+  assert!(state.is_stylex_import_for_current_cycle("props"));
+  assert!(!state.is_stylex_import_for_current_cycle("create"));
+
+  for cycle in [TransformationCycle::Discover, TransformationCycle::Finalize] {
+    state.cycle = cycle;
+    assert!(!state.is_stylex_import_for_current_cycle("create"));
+    assert!(!state.is_stylex_import_for_current_cycle("props"));
+  }
+}
+
+/// A namespace import answers in every cycle, including the ones that read no
+/// direct import at all.
+#[test]
+fn a_namespace_import_answers_in_every_cycle() {
+  let mut state = state();
+
+  state.insert_stylex_import(ImportSources::Regular("stylex".to_string()));
+
+  for cycle in [
+    TransformationCycle::Discover,
+    TransformationCycle::TransformProducers,
+    TransformationCycle::TransformConsumers,
+    TransformationCycle::Finalize,
+  ] {
+    state.cycle = cycle;
+    assert!(state.is_stylex_import_for_current_cycle("stylex"));
+  }
+}
+
+/// A module the project names as a StyleX source is one whichever shape the
+/// option took, and the name it is read under is answered only for the shape
+/// that carries one.
+#[test]
+fn a_configured_import_source_is_recognised_in_both_shapes() {
+  let state = state_with_sources(vec![
+    ImportSources::Regular("@stylexjs/stylex".to_string()),
+    named("./my-stylex", "css"),
+  ]);
+
+  assert!(state.is_import_source("@stylexjs/stylex"));
+  assert!(state.is_import_source("./my-stylex"));
+  assert!(!state.is_import_source("react"));
+
+  assert_eq!(state.import_as("./my-stylex"), Some("css"));
+  assert_eq!(state.import_as("@stylexjs/stylex"), None);
+  assert_eq!(state.import_as("react"), None);
+
+  assert_eq!(
+    state.import_source_names().collect::<Vec<_>>(),
+    vec!["@stylexjs/stylex", "./my-stylex"]
+  );
+}
+
+/// A project that names no import source recognises none, and answers an empty
+/// list rather than refusing.
+#[test]
+fn a_project_with_no_import_sources_recognises_none() {
+  let state = state_with_sources(vec![]);
+
+  assert!(!state.is_import_source("@stylexjs/stylex"));
+  assert_eq!(state.import_as("@stylexjs/stylex"), None);
+  assert_eq!(state.import_source_names().count(), 0);
+}

--- a/crates/stylex-state/src/tests/jsx_spread_test.rs
+++ b/crates/stylex-state/src/tests/jsx_spread_test.rs
@@ -1,0 +1,203 @@
+//! The JSX attributes a `stylex.props(...)` spread was rewritten into.
+//!
+//! The spread is met twice: once while the module is walked, which records the
+//! expression, and once while it is rewritten, which records the attributes it
+//! became. The two meetings are joined by the expression's shape rather than by
+//! its position, so the record has to confirm the shape and never answer on a
+//! matching hash alone.
+
+use swc_core::{
+  common::{BytePos, DUMMY_SP, Span},
+  ecma::ast::{
+    CallExpr, Callee, Expr, ExprOrSpread, JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, Lit,
+    Str,
+  },
+};
+
+use stylex_ast::ast::factories::{create_ident, create_ident_name};
+
+use crate::tests::prelude::test_state as state;
+
+fn string_arg(value: &str) -> ExprOrSpread {
+  ExprOrSpread {
+    spread: None,
+    expr: Box::new(Expr::Lit(Lit::Str(Str {
+      span: DUMMY_SP,
+      value: value.into(),
+      raw: None,
+    }))),
+  }
+}
+
+fn props_call(args: Vec<ExprOrSpread>) -> CallExpr {
+  CallExpr {
+    span: DUMMY_SP,
+    callee: Callee::Expr(Box::new(Expr::Ident(create_ident("props")))),
+    args,
+    type_args: None,
+    ctxt: Default::default(),
+  }
+}
+
+/// One attribute, standing for whatever the call was rewritten into.
+fn class_name_attr(value: &str) -> Vec<JSXAttrOrSpread> {
+  vec![JSXAttrOrSpread::JSXAttr(JSXAttr {
+    span: DUMMY_SP,
+    name: JSXAttrName::Ident(create_ident_name("className")),
+    value: Some(JSXAttrValue::Str(Str {
+      span: DUMMY_SP,
+      value: value.into(),
+      raw: None,
+    })),
+  })]
+}
+
+/// The class names the recorded attributes carry, so a case can say what was
+/// recorded without matching on the attribute shape.
+fn class_names(attrs: &[JSXAttrOrSpread]) -> Vec<&str> {
+  attrs
+    .iter()
+    .filter_map(|attr| match attr {
+      JSXAttrOrSpread::JSXAttr(attr) => match &attr.value {
+        Some(JSXAttrValue::Str(value)) => value.value.as_str(),
+        _ => None,
+      },
+      JSXAttrOrSpread::SpreadElement(_) => None,
+    })
+    .collect()
+}
+
+/// A spread nothing recorded is unknown, and recording it makes it known while
+/// leaving it without a replacement yet.
+#[test]
+fn a_seeded_spread_is_known_and_has_no_replacement_yet() {
+  let mut state = state();
+  let call = props_call(vec![string_arg("styles")]);
+  let expr = Expr::Call(call.clone());
+
+  assert!(!state.has_jsx_spread_call(&call));
+  assert_eq!(state.jsx_spread_replacement(&expr), None);
+
+  state.seed_jsx_spread_expr(&expr);
+
+  assert!(state.has_jsx_spread_call(&call));
+  assert_eq!(state.jsx_spread_replacement(&expr), Some(&[][..]));
+}
+
+/// Recording the attributes a spread became makes them the answer, and says
+/// that a matching record was found.
+#[test]
+fn the_attributes_a_spread_became_are_answered_back() {
+  let mut state = state();
+  let call = props_call(vec![string_arg("styles")]);
+  let expr = Expr::Call(call.clone());
+
+  state.seed_jsx_spread_expr(&expr);
+
+  assert!(state.set_jsx_spread_replacement(&call, class_name_attr("x1e2nbdu")));
+
+  let Some(attrs) = state.jsx_spread_replacement(&expr) else {
+    panic!("the recorded attributes were not answered");
+  };
+
+  assert_eq!(class_names(attrs), vec!["x1e2nbdu"]);
+}
+
+/// Recording attributes for a spread that was never seeded records nothing and
+/// says so, rather than inventing an entry the walk did not meet.
+#[test]
+fn attributes_for_a_spread_that_was_never_seeded_are_refused() {
+  let mut state = state();
+  let call = props_call(vec![string_arg("styles")]);
+
+  assert!(!state.set_jsx_spread_replacement(&call, class_name_attr("x1e2nbdu")));
+  assert_eq!(state.jsx_spread_replacement(&Expr::Call(call)), None);
+}
+
+/// The position the spread was written at is not part of what identifies it:
+/// the same call met at a different span is the same spread.
+#[test]
+fn a_spread_is_recognised_wherever_it_was_written() {
+  let mut state = state();
+  let seeded = props_call(vec![string_arg("styles")]);
+  let mut rewritten = seeded.clone();
+
+  rewritten.span = Span::new(BytePos(100), BytePos(200));
+
+  state.seed_jsx_spread_expr(&Expr::Call(seeded));
+
+  assert!(state.has_jsx_spread_call(&rewritten));
+  assert!(state.set_jsx_spread_replacement(&rewritten, class_name_attr("x1e2nbdu")));
+}
+
+/// Two spreads that differ in their arguments are two spreads, and each keeps
+/// its own attributes.
+#[test]
+fn two_different_spreads_keep_their_own_attributes() {
+  let mut state = state();
+  let first = props_call(vec![string_arg("base")]);
+  let second = props_call(vec![string_arg("variant")]);
+
+  state.seed_jsx_spread_expr(&Expr::Call(first.clone()));
+  state.seed_jsx_spread_expr(&Expr::Call(second.clone()));
+
+  assert!(state.set_jsx_spread_replacement(&first, class_name_attr("x1base")));
+  assert!(state.set_jsx_spread_replacement(&second, class_name_attr("x1variant")));
+
+  assert_eq!(
+    state
+      .jsx_spread_replacement(&Expr::Call(first))
+      .map(class_names),
+    Some(vec!["x1base"])
+  );
+  assert_eq!(
+    state
+      .jsx_spread_replacement(&Expr::Call(second))
+      .map(class_names),
+    Some(vec!["x1variant"])
+  );
+}
+
+/// Seeding one spread twice records it once, so the second walk over a module
+/// cannot double the entry the first one made.
+#[test]
+fn seeding_one_spread_twice_records_it_once() {
+  let mut state = state();
+  let call = props_call(vec![string_arg("styles")]);
+  let expr = Expr::Call(call.clone());
+
+  state.seed_jsx_spread_expr(&expr);
+  state.seed_jsx_spread_expr(&expr);
+  state.set_jsx_spread_replacement(&call, class_name_attr("x1e2nbdu"));
+
+  assert_eq!(
+    state.jsx_spread_replacement(&expr).map(class_names),
+    Some(vec!["x1e2nbdu"])
+  );
+}
+
+/// An expression that is not a call can be seeded and read back, but it is not
+/// a spread *call*: the two questions read the same record differently.
+#[test]
+fn an_expression_that_is_not_a_call_is_no_spread_call() {
+  let mut state = state();
+  let expr = Expr::Ident(create_ident("styles"));
+
+  state.seed_jsx_spread_expr(&expr);
+
+  assert_eq!(state.jsx_spread_replacement(&expr), Some(&[][..]));
+  assert!(!state.has_jsx_spread_call(&props_call(vec![])));
+}
+
+/// A spread nothing seeded has no attributes, whatever else the record holds.
+#[test]
+fn an_unseeded_spread_has_no_attributes() {
+  let mut state = state();
+
+  state.seed_jsx_spread_expr(&Expr::Call(props_call(vec![string_arg("styles")])));
+
+  assert_eq!(
+    state.jsx_spread_replacement(&Expr::Ident(create_ident("styles"))),
+    None
+  );
+}

--- a/crates/stylex-state/src/tests/jsx_spread_test.rs
+++ b/crates/stylex-state/src/tests/jsx_spread_test.rs
@@ -168,7 +168,7 @@ fn seeding_one_spread_twice_records_it_once() {
 
   state.seed_jsx_spread_expr(&expr);
   state.seed_jsx_spread_expr(&expr);
-  state.set_jsx_spread_replacement(&call, class_name_attr("x1e2nbdu"));
+  assert!(state.set_jsx_spread_replacement(&call, class_name_attr("x1e2nbdu")));
 
   assert_eq!(
     state.jsx_spread_replacement(&expr).map(class_names),

--- a/crates/stylex-state/src/tests/mod.rs
+++ b/crates/stylex-state/src/tests/mod.rs
@@ -1,11 +1,20 @@
 mod prelude;
 
+mod binding_queries_test;
+mod call_index_test;
 mod diagnostic_state_test;
 mod evaluate_result_value_test;
+mod file_and_options_test;
+mod flat_compiled_styles_value_test;
+mod functions_test;
 mod get_canonical_file_path_test;
 mod get_package_name_and_path_test;
+mod import_kind_test;
+mod import_queries_test;
+mod jsx_spread_test;
 mod resolution_convertors_test;
 mod resolution_lookup_test;
 mod state_manager_test;
 mod state_writers_test;
+mod style_injection_test;
 mod theme_ref_test;

--- a/crates/stylex-state/src/tests/prelude.rs
+++ b/crates/stylex-state/src/tests/prelude.rs
@@ -3,14 +3,22 @@
 //! A declarator over an identifier name is what a test hands the state to
 //! record a binding, and four modules asked for one. They built it four times,
 //! which was unavoidable while they sat in different crates and is not now that
-//! they are siblings.
+//! they are siblings. The same holds for the handful of builders beside it: an
+//! empty state, the two expression shapes a style value takes, an identifier at
+//! a named scope, and the path of a fixture package.
 
+use std::{env, path::PathBuf};
+
+use path_clean::PathClean;
 use swc_core::{
-  common::DUMMY_SP,
-  ecma::ast::{BindingIdent, Expr, Pat, VarDeclarator},
+  common::{DUMMY_SP, SyntaxContext},
+  ecma::ast::{BindingIdent, Expr, Ident, Lit, Pat, Str, VarDeclarator},
 };
 
-use stylex_ast::ast::factories::create_ident;
+use stylex_ast::ast::factories::{create_ident, create_object_lit};
+use stylex_structures::stylex_state_options::StyleXStateOptions;
+
+use crate::state_manager::StateManager;
 
 /// One declarator over the initializer handed in. No case cares about the name
 /// pattern beyond it being an identifier, which is also the only shape
@@ -34,5 +42,55 @@ fn declarator(name: &str, init: Option<Box<Expr>>) -> VarDeclarator {
     }),
     init,
     definite: false,
+  }
+}
+
+/// A state for a project that sets no option, which is what a case asking about
+/// the state itself rather than about the project wants.
+pub(super) fn test_state() -> StateManager {
+  StateManager::for_test(None, StyleXStateOptions::default())
+}
+
+/// An identifier at a given scope. Zero is the scope every identifier the parser
+/// produces before the resolver runs, so it doubles as "the scope does not
+/// matter to this case"; anything else is a different scope.
+///
+/// `SyntaxContext::from_u32` rather than `apply_mark`, which would need
+/// `GLOBALS` installed for what is only "some other scope than that one".
+pub(super) fn ident_at(name: &str, ctxt: u32) -> Ident {
+  Ident {
+    span: DUMMY_SP,
+    sym: name.into(),
+    optional: false,
+    ctxt: SyntaxContext::from_u32(ctxt),
+  }
+}
+
+/// The same identifier at the parser's own scope, for the cases a scope never
+/// enters.
+pub(super) fn ident(name: &str) -> Ident {
+  ident_at(name, 0)
+}
+
+/// A string literal, which is what a style value most often is.
+pub(super) fn string_expr(value: &str) -> Expr {
+  Expr::Lit(Lit::Str(Str {
+    span: DUMMY_SP,
+    value: value.into(),
+    raw: None,
+  }))
+}
+
+/// An empty object literal, standing for the namespace a compiled `create` call
+/// leaves behind. No case reads into it.
+pub(super) fn object_expr() -> Expr {
+  Expr::Object(create_object_lit(vec![]))
+}
+
+/// The path of a fixture package under this crate's own test tree.
+pub(super) fn fixture_path(name: &str) -> PathBuf {
+  match env::current_dir() {
+    Ok(dir) => dir.join("src/tests/fixtures").join(name).clean(),
+    Err(error) => panic!("the working directory could not be read: {error}"),
   }
 }

--- a/crates/stylex-state/src/tests/state_manager_test.rs
+++ b/crates/stylex-state/src/tests/state_manager_test.rs
@@ -12,7 +12,7 @@ mod state_manager {
   };
 
   use crate::state_manager::{InsertionSlot, StateManager, flush_pending_insertions};
-  use crate::tests::prelude::make_var_declarator;
+  use crate::tests::prelude::{ident, ident_at, make_var_declarator, string_expr};
   use stylex_enums::declaration_type::DeclarationType;
   use stylex_enums::top_level_expression::TopLevelExpressionKind;
   use stylex_structures::ceiling::Ceiling;
@@ -21,37 +21,8 @@ mod state_manager {
   use stylex_structures::top_level_expression::TopLevelExpression;
   use stylex_utils::hash::stable_hash_unspanned;
 
-  /// An identifier at a given syntax context. Zero is the context every ident
-  /// the parser produces before the resolver runs, so it doubles as "context
-  /// does not matter to this test"; anything else is a distinct scope.
-  ///
-  /// `SyntaxContext::from_u32` rather than `apply_mark`, which would need
-  /// `GLOBALS` installed for what is only "some other context than that one".
-  fn ident_at(name: &str, ctxt: u32) -> Ident {
-    Ident {
-      span: DUMMY_SP,
-      sym: name.into(),
-      optional: false,
-      ctxt: SyntaxContext::from_u32(ctxt),
-    }
-  }
-
-  /// The same identifier at the parser's own context, for the cases a scope
-  /// never enters.
-  fn ident(name: &str) -> Ident {
-    ident_at(name, 0)
-  }
-
   fn ident_expr(name: &str) -> Expr {
     Expr::Ident(ident(name))
-  }
-
-  fn string_expr(value: &str) -> Expr {
-    Expr::Lit(Lit::Str(Str {
-      span: DUMMY_SP,
-      value: value.into(),
-      raw: None,
-    }))
   }
 
   fn expr_stmt(value: &str) -> ModuleItem {

--- a/crates/stylex-state/src/tests/style_injection_test.rs
+++ b/crates/stylex-state/src/tests/style_injection_test.rs
@@ -132,8 +132,9 @@ fn var_item(name: &str, init: Expr) -> ModuleItem {
   }))))
 }
 
-/// A style with nothing in it registers nothing, and the two ways a map can be
-/// empty -- no entry at all -- reach the same answer.
+/// A style map with no entry in it registers nothing, through either entry --
+/// the one that always sets up injection and the one that asks the options
+/// first both answer before they reach it.
 #[test]
 fn an_empty_style_map_registers_nothing() {
   let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));

--- a/crates/stylex-state/src/tests/style_injection_test.rs
+++ b/crates/stylex-state/src/tests/style_injection_test.rs
@@ -1,0 +1,826 @@
+//! Recording the styles a call produced, and placing the runtime calls that
+//! inject them.
+//!
+//! Two entries: `register_styles`, for a call the module still holds a
+//! declarator for, and `register_atom_styles`, for one compiled away before the
+//! body is written. Both add the style to the metadata the host collects; they
+//! part company over *where* the `_inject2(...)` call goes, and over whether the
+//! runtime helpers are imported at all.
+
+use indexmap::IndexMap;
+use std::rc::Rc;
+
+use swc_core::{
+  common::DUMMY_SP,
+  ecma::ast::{
+    CallExpr, Callee, Decl, Expr, ExprStmt, Lit, ModuleDecl, ModuleItem, Stmt, Str, VarDecl,
+    VarDeclKind,
+  },
+};
+
+use stylex_ast::ast::factories::create_ident;
+use stylex_structures::core_stylex_options::CoreStyleXOptions;
+use stylex_structures::named_import_source::{NamedImportSource, RuntimeInjectionState};
+use stylex_structures::stylex_state_options::StyleXStateOptions;
+use stylex_types::enums::data_structures::injectable_style::InjectableStyleKind;
+use stylex_types::structures::injectable_style::{InjectableConstStyle, InjectableStyle};
+
+use crate::state_manager::{InsertionSlot, StateManager, flush_pending_insertions};
+use crate::tests::prelude::{make_var_declarator, object_expr, string_expr};
+use crate::types::InjectableStylesMap;
+
+fn options(runtime_injection: Option<RuntimeInjectionState>) -> StyleXStateOptions {
+  StyleXStateOptions::default().with_runtime_injection(runtime_injection)
+}
+
+fn state_with(runtime_injection: Option<RuntimeInjectionState>) -> StateManager {
+  StateManager::for_test(None, options(runtime_injection))
+}
+
+/// One ordinary rule, which is what a `create` call produces.
+fn regular_style(class_name: &str, css: &str, rtl: Option<&str>) -> InjectableStylesMap {
+  let mut styles: InjectableStylesMap = IndexMap::new();
+
+  styles.insert(
+    class_name.into(),
+    Rc::new(InjectableStyleKind::Regular(InjectableStyle {
+      ltr: css.to_string(),
+      rtl: rtl.map(str::to_string),
+      priority: Some(3000.0),
+    })),
+  );
+
+  styles
+}
+
+/// One constant, which is what a `defineConsts` call produces: the same rule
+/// with the key and value the constant is written under.
+fn const_style(class_name: &str, const_key: &str, const_value: &str) -> InjectableStylesMap {
+  let mut styles: InjectableStylesMap = IndexMap::new();
+
+  styles.insert(
+    class_name.into(),
+    Rc::new(InjectableStyleKind::Const(InjectableConstStyle {
+      ltr: String::new(),
+      rtl: None,
+      priority: Some(0.0),
+      const_key: const_key.to_string(),
+      const_value: const_value.to_string(),
+    })),
+  );
+
+  styles
+}
+
+fn call_expr(callee: &str) -> CallExpr {
+  CallExpr {
+    span: DUMMY_SP,
+    callee: Callee::Expr(Box::new(Expr::Ident(create_ident(callee)))),
+    args: vec![],
+    type_args: None,
+    ctxt: Default::default(),
+  }
+}
+
+/// The module body as text, so a case can say what was written rather than
+/// matching on the AST shape of every statement.
+fn body_shapes(body: &[ModuleItem]) -> Vec<&'static str> {
+  body
+    .iter()
+    .map(|item| match item {
+      ModuleItem::ModuleDecl(ModuleDecl::Import(_)) => "import",
+      ModuleItem::Stmt(Stmt::Decl(Decl::Var(_))) => "var",
+      ModuleItem::Stmt(Stmt::Expr(expr_stmt)) => match expr_stmt.expr.as_ref() {
+        Expr::Lit(Lit::Str(_)) => "directive",
+        Expr::Call(_) => "call",
+        _ => "expr",
+      },
+      _ => "other",
+    })
+    .collect()
+}
+
+fn directive(text: &str) -> ModuleItem {
+  ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+    span: DUMMY_SP,
+    expr: Box::new(string_expr(text)),
+  }))
+}
+
+fn import_item(source: &str) -> ModuleItem {
+  ModuleItem::ModuleDecl(ModuleDecl::Import(swc_core::ecma::ast::ImportDecl {
+    span: DUMMY_SP,
+    specifiers: vec![],
+    src: Box::new(Str {
+      span: DUMMY_SP,
+      value: source.into(),
+      raw: None,
+    }),
+    type_only: false,
+    with: None,
+    phase: swc_core::ecma::ast::ImportPhase::Evaluation,
+  }))
+}
+
+fn var_item(name: &str, init: Expr) -> ModuleItem {
+  ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+    span: DUMMY_SP,
+    kind: VarDeclKind::Const,
+    declare: false,
+    decls: vec![make_var_declarator(name, init)],
+    ctxt: Default::default(),
+  }))))
+}
+
+/// A style with nothing in it registers nothing, and the two ways a map can be
+/// empty -- no entry at all -- reach the same answer.
+#[test]
+fn an_empty_style_map_registers_nothing() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+
+  state.register_styles(&call_expr("create"), &IndexMap::new(), &object_expr(), None);
+  state.register_atom_styles(&IndexMap::new());
+
+  assert!(state.metadata().is_empty());
+}
+
+/// The style the call produced reaches the metadata the host collects, keyed
+/// under the one name every style is collected under.
+#[test]
+fn a_registered_style_reaches_the_metadata() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &object_expr(),
+    None,
+  );
+
+  let Some(styles) = state.metadata().get("stylex") else {
+    panic!("the style did not reach the metadata");
+  };
+
+  assert_eq!(styles.len(), 1);
+  assert_eq!(
+    styles.iter().next().map(|style| style.get_class_name()),
+    Some("x1e2nbdu")
+  );
+}
+
+/// Registering the same style twice records it once: the metadata is a set of
+/// rules, and two calls that produce one rule inject it once.
+#[test]
+fn one_style_registered_twice_is_recorded_once() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let styles = regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None);
+
+  state.register_styles(&call_expr("create"), &styles, &object_expr(), None);
+  state.register_styles(&call_expr("create"), &styles, &object_expr(), None);
+
+  assert_eq!(state.metadata().get("stylex").map(|set| set.len()), Some(1));
+}
+
+/// With no runtime injection configured, the style is still recorded -- the
+/// host writes the stylesheet -- and nothing is queued to inject it.
+#[test]
+fn a_style_is_recorded_without_the_runtime_helpers() {
+  let mut state = state_with(None);
+  let mut body = vec![var_item("styles", object_expr())];
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &object_expr(),
+    None,
+  );
+
+  assert_eq!(state.metadata().get("stylex").map(|set| set.len()), Some(1));
+
+  flush_pending_insertions(&mut state, &mut body, false);
+
+  assert_eq!(body_shapes(&body), vec!["var"]);
+}
+
+/// With runtime injection on, a style is injected by a call written directly in
+/// front of the declarator the style belongs to, and the helpers it calls are
+/// imported at the top of the module.
+#[test]
+fn a_style_is_injected_in_front_of_its_own_declarator() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+  let mut body = vec![
+    import_item("react"),
+    var_item("styles", ast.clone()),
+    var_item("other", string_expr("unrelated")),
+  ];
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &ast,
+    None,
+  );
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(
+    body_shapes(&body),
+    vec!["import", "var", "import", "call", "var", "var"]
+  );
+}
+
+/// A directive prologue keeps position zero: the helpers go after it, never
+/// above it, because a directive above anything else is no longer a directive.
+#[test]
+fn a_directive_prologue_stays_at_the_top() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+  let mut body = vec![directive("use strict"), var_item("styles", ast.clone())];
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &ast,
+    None,
+  );
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body).first(), Some(&"directive"));
+}
+
+/// The helpers are imported once however many styles are registered: the second
+/// registration reads the identifiers the first one made.
+#[test]
+fn the_runtime_helpers_are_imported_once() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+  let mut body = vec![var_item("styles", ast.clone())];
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &ast,
+    None,
+  );
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1t137rt", ".x1t137rt{display:block}", None),
+    &ast,
+    None,
+  );
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(
+    body_shapes(&body)
+      .iter()
+      .filter(|shape| **shape == "import")
+      .count(),
+    1
+  );
+}
+
+/// The three ways runtime injection can be configured each import the helpers,
+/// and each writes the injecting call.
+#[test]
+fn every_runtime_injection_shape_imports_the_helpers() {
+  for injection in [
+    RuntimeInjectionState::Boolean(true),
+    RuntimeInjectionState::Regular("@stylexjs/stylex/inject".to_string()),
+    RuntimeInjectionState::Named(NamedImportSource {
+      from: "@stylexjs/stylex".to_string(),
+      r#as: "inject".to_string(),
+    }),
+  ] {
+    let mut state = state_with(Some(injection));
+    let ast = object_expr();
+    let mut body = vec![var_item("styles", ast.clone())];
+
+    state.register_styles(
+      &call_expr("create"),
+      &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+      &ast,
+      None,
+    );
+
+    flush_pending_insertions(&mut state, &mut body, true);
+
+    assert_eq!(body_shapes(&body), vec!["import", "var", "call", "var"]);
+  }
+}
+
+/// A rule with a right-to-left half injects both halves in one call, and a
+/// constant injects the key and the value beside them.
+#[test]
+fn a_directional_rule_and_a_constant_carry_their_extra_parts() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style(
+      "x1e2nbdu",
+      ".x1e2nbdu{margin-left:1px}",
+      Some(".x1e2nbdu{margin-right:1px}"),
+    ),
+    &ast,
+    None,
+  );
+
+  let mut consts_state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+
+  consts_state.register_styles(
+    &call_expr("defineConsts"),
+    &const_style("x1const", "--x1const", "8"),
+    &ast,
+    None,
+  );
+
+  assert_eq!(state.metadata().get("stylex").map(|set| set.len()), Some(1));
+  assert_eq!(
+    consts_state.metadata().get("stylex").map(|set| set.len()),
+    Some(1)
+  );
+}
+
+/// A constant whose value is not a number keeps its text, which is the other
+/// half of how a constant's value is written.
+#[test]
+fn a_constant_with_a_text_value_keeps_its_text() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+  let mut body = vec![var_item("consts", ast.clone())];
+
+  state.register_styles(
+    &call_expr("defineConsts"),
+    &const_style("x1const", "--x1const", "8px"),
+    &ast,
+    None,
+  );
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body), vec!["import", "var", "call", "var"]);
+}
+
+/// A call that produced a fallback shape injects in front of both: the
+/// declarator may end up holding either one, and only one of them survives.
+#[test]
+fn a_fallback_shape_is_injected_in_front_of_too() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+  let fallback = string_expr("fallback");
+  let mut body = vec![var_item("styles", fallback.clone())];
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &ast,
+    Some(&fallback),
+  );
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body), vec!["import", "var", "call", "var"]);
+}
+
+/// Registering the same style against one shape twice queues the injecting call
+/// once, so a re-registration cannot double the rule at runtime.
+#[test]
+fn one_shape_is_injected_in_front_of_once() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+  let styles = regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None);
+  let mut body = vec![var_item("styles", ast.clone())];
+
+  state.register_styles(&call_expr("create"), &styles, &ast, Some(&ast));
+  state.register_styles(&call_expr("create"), &styles, &ast, Some(&ast));
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(
+    body_shapes(&body)
+      .iter()
+      .filter(|shape| **shape == "call")
+      .count(),
+    1
+  );
+}
+
+/// An atom style has no declarator left to sit in front of, so its injecting
+/// call goes after the import block instead -- ahead of the body that uses it.
+#[test]
+fn an_atom_style_is_injected_after_the_import_block() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let mut body = vec![
+    directive("use client"),
+    import_item("react"),
+    var_item("component", object_expr()),
+  ];
+
+  state.register_atom_styles(&regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None));
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(
+    body_shapes(&body),
+    vec!["directive", "import", "var", "import", "call", "var"]
+  );
+}
+
+/// An atom style is recorded even where nothing injects it, and it is placed
+/// after the imports whether or not the runtime helpers were written.
+#[test]
+fn an_atom_style_is_recorded_without_the_runtime_helpers() {
+  let mut state = state_with(None);
+  let mut body = vec![var_item("component", object_expr())];
+
+  state.register_atom_styles(&regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None));
+
+  assert_eq!(state.metadata().get("stylex").map(|set| set.len()), Some(1));
+
+  flush_pending_insertions(&mut state, &mut body, false);
+
+  assert_eq!(body_shapes(&body), vec!["var"]);
+}
+
+/// An atom style carrying a right-to-left half writes both halves into the one
+/// injecting call.
+#[test]
+fn an_atom_style_carries_its_right_to_left_half() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let mut body = vec![var_item("component", object_expr())];
+
+  state.register_atom_styles(&regular_style(
+    "x1e2nbdu",
+    ".x1e2nbdu{margin-left:1px}",
+    Some(".x1e2nbdu{margin-right:1px}"),
+  ));
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body), vec!["import", "var", "call", "var"]);
+}
+
+/// A theme import is queued once however often it is offered, because the
+/// import is a side effect and repeating it repeats the effect.
+#[test]
+fn a_theme_import_is_queued_once() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let mut body = vec![var_item("component", object_expr())];
+
+  state.queue_theme_import_if_absent(import_item("./vars.stylex.js"));
+  state.queue_theme_import_if_absent(import_item("./vars.stylex.js"));
+  state.queue_theme_import_if_absent(import_item("./other.stylex.js"));
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body), vec!["import", "import", "var"]);
+}
+
+/// Theme imports are dropped with the rest of the runtime work when injection
+/// is off, which is what makes them a runtime concern rather than a module one.
+#[test]
+fn theme_imports_are_dropped_without_the_runtime_helpers() {
+  let mut state = state_with(None);
+  let mut body = vec![var_item("component", object_expr())];
+
+  state.queue_theme_import_if_absent(import_item("./vars.stylex.js"));
+
+  flush_pending_insertions(&mut state, &mut body, false);
+
+  assert_eq!(body_shapes(&body), vec!["var"]);
+}
+
+/// A namespace import queued for an `sx` attribute goes above everything,
+/// including the runtime helpers, and is written whether or not injection is on.
+#[test]
+fn a_prepended_import_goes_above_the_runtime_helpers() {
+  let mut state = state_with(None);
+  let mut body = vec![import_item("react"), var_item("component", object_expr())];
+
+  state.queue_insertion(
+    InsertionSlot::PrependImport,
+    import_item("@stylexjs/stylex"),
+  );
+
+  flush_pending_insertions(&mut state, &mut body, false);
+
+  assert_eq!(body_shapes(&body), vec!["import", "import", "var"]);
+}
+
+/// Nothing queued is nothing to place, and the body is left as it was.
+#[test]
+fn a_body_with_nothing_queued_is_left_alone() {
+  let mut state = state_with(None);
+  let mut body = vec![var_item("component", object_expr())];
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body), vec!["var"]);
+}
+
+/// A module of nothing but imports puts the atom injection at the end, because
+/// the import block is the whole body and the call goes after it.
+#[test]
+fn a_module_of_only_imports_takes_the_injection_at_the_end() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let mut body = vec![import_item("react"), import_item("./styles")];
+
+  state.register_atom_styles(&regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None));
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(
+    body_shapes(&body),
+    vec!["import", "var", "import", "import", "call"]
+  );
+}
+
+/// A default export of an object is a declarator for this purpose: the style it
+/// produced is injected in front of the export.
+#[test]
+fn a_default_exported_object_takes_its_injection_in_front() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+  let mut body = vec![ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
+    swc_core::ecma::ast::ExportDefaultExpr {
+      span: DUMMY_SP,
+      expr: Box::new(ast.clone()),
+    },
+  ))];
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &ast,
+    None,
+  );
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body), vec!["import", "var", "call", "other"]);
+}
+
+/// An exported declarator takes its injection in front of the export too.
+#[test]
+fn an_exported_declarator_takes_its_injection_in_front() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+  let mut body = vec![ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(
+    swc_core::ecma::ast::ExportDecl {
+      span: DUMMY_SP,
+      decl: Decl::Var(Box::new(VarDecl {
+        span: DUMMY_SP,
+        kind: VarDeclKind::Const,
+        declare: false,
+        decls: vec![make_var_declarator("styles", ast.clone())],
+        ctxt: Default::default(),
+      })),
+    },
+  ))];
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &ast,
+    None,
+  );
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body), vec!["import", "var", "call", "other"]);
+}
+
+/// The style whose declarator the module does not hold is still recorded, and
+/// its injecting call is dropped for want of a place to write it.
+#[test]
+fn a_style_with_no_declarator_left_is_still_recorded() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let mut body = vec![var_item("unrelated", Expr::Ident(create_ident("other")))];
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &object_expr(),
+    None,
+  );
+
+  assert_eq!(state.metadata().get("stylex").map(|set| set.len()), Some(1));
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body), vec!["import", "var", "var"]);
+}
+
+/// Whether the compiler adds theme imports for the sake of tree shaking is the
+/// project's own setting, read here and decided nowhere else.
+#[test]
+fn the_treeshake_setting_is_read_off_the_project() {
+  assert!(!state_with(None).get_treeshake_compensation());
+
+  let state = StateManager::for_test(
+    None,
+    StyleXStateOptions {
+      core: CoreStyleXOptions {
+        treeshake_compensation: true,
+        ..CoreStyleXOptions::default()
+      },
+      ..StyleXStateOptions::default()
+    },
+  );
+
+  assert!(state.get_treeshake_compensation());
+}
+
+/// Registering the styles a call produced also rewrites the call itself,
+/// wherever the state recorded it: the declarator it initialises, the style
+/// variable it is bound to, and the top-level expression it is.
+mod rewriting_the_call {
+  use std::rc::Rc;
+
+  use indexmap::IndexMap;
+  use swc_core::{
+    common::DUMMY_SP,
+    ecma::ast::{CallExpr, Callee, Expr},
+  };
+
+  use stylex_ast::ast::factories::create_ident;
+  use stylex_enums::top_level_expression::TopLevelExpressionKind;
+  use stylex_structures::top_level_expression::TopLevelExpression;
+  use stylex_types::enums::data_structures::injectable_style::InjectableStyleKind;
+  use stylex_types::structures::injectable_style::InjectableStyle;
+
+  use crate::tests::prelude::{make_var_declarator, object_expr, string_expr, test_state as state};
+  use crate::types::{InjectableStylesMap, StylesObjectMap};
+
+  fn create_call() -> CallExpr {
+    CallExpr {
+      span: DUMMY_SP,
+      callee: Callee::Expr(Box::new(Expr::Ident(create_ident("create")))),
+      args: vec![],
+      type_args: None,
+      ctxt: Default::default(),
+    }
+  }
+
+  fn one_style() -> InjectableStylesMap {
+    let mut styles: InjectableStylesMap = IndexMap::new();
+
+    styles.insert(
+      "x1e2nbdu".into(),
+      Rc::new(InjectableStyleKind::Regular(InjectableStyle {
+        ltr: ".x1e2nbdu{color:red}".to_string(),
+        rtl: None,
+        priority: Some(3000.0),
+      })),
+    );
+
+    styles
+  }
+
+  /// The declarator the call initialises holds the compiled object afterwards,
+  /// so the module body no longer calls the API.
+  #[test]
+  fn the_declarator_the_call_initialises_holds_the_compiled_object() {
+    let mut state = state();
+    let call = create_call();
+
+    state.push_declaration(make_var_declarator("styles", Expr::Call(call.clone())));
+    state.register_styles(&call, &one_style(), &object_expr(), None);
+
+    let Some(declarator) = state.declarations().first() else {
+      panic!("the declarator was not recorded");
+    };
+
+    assert!(
+      matches!(declarator.init.as_deref(), Some(Expr::Object(_))),
+      "the declarator still holds the call"
+    );
+  }
+
+  /// A style variable's declarator is rewritten the same way, which is the
+  /// record the consuming cycle reads a namespace out of.
+  #[test]
+  fn the_style_variable_the_call_is_bound_to_holds_the_compiled_object() {
+    let mut state = state();
+    let call = create_call();
+
+    state.insert_style_var(
+      "styles".to_string(),
+      make_var_declarator("styles", Expr::Call(call.clone())),
+    );
+    state.register_styles(&call, &one_style(), &object_expr(), None);
+
+    let Some(declarator) = state.style_vars.get("styles") else {
+      panic!("the style variable was not recorded");
+    };
+
+    assert!(
+      matches!(declarator.init.as_deref(), Some(Expr::Object(_))),
+      "the style variable still holds the call"
+    );
+  }
+
+  /// A top-level expression that is the call is rewritten too, so a later
+  /// lookup by name reads the compiled object rather than the call.
+  #[test]
+  fn the_top_level_expression_the_call_is_holds_the_compiled_object() {
+    let mut state = state();
+    let call = create_call();
+
+    state.push_top_level_expression(TopLevelExpression(
+      TopLevelExpressionKind::Stmt,
+      Expr::Call(call.clone()),
+      Some("styles".into()),
+    ));
+    state.register_styles(&call, &one_style(), &object_expr(), None);
+
+    let Some(expression) = state.top_level_expressions.first() else {
+      panic!("the top-level expression was not recorded");
+    };
+
+    assert!(
+      matches!(expression.1, Expr::Object(_)),
+      "the top-level expression is still the call"
+    );
+  }
+
+  /// An identifier names a style variable when the module bound it to one and
+  /// the compiler has compiled that variable's namespace. Either half alone is
+  /// not enough, and neither is a name bound in another scope.
+  #[test]
+  fn an_identifier_names_a_style_variable_only_when_both_records_hold_it() {
+    let mut state = state();
+    let declarator = make_var_declarator("styles", string_expr("compiled"));
+
+    // Bound but not compiled.
+    state.insert_style_var("styles".to_string(), declarator);
+    assert!(!state.is_style_var_ident(&create_ident("styles")));
+
+    // Compiled as well, and now it is one.
+    state
+      .style_map
+      .insert("styles".to_string(), Rc::new(StylesObjectMap::new()));
+    assert!(state.is_style_var_ident(&create_ident("styles")));
+
+    // A name the module never bound is not one, however it was compiled.
+    state
+      .style_map
+      .insert("other".to_string(), Rc::new(StylesObjectMap::new()));
+    assert!(!state.is_style_var_ident(&create_ident("other")));
+  }
+
+  /// The identifier is asked about with the scope it was resolved in, so a name
+  /// that shadows a style variable is not that variable.
+  #[test]
+  fn a_name_that_shadows_a_style_variable_is_not_that_variable() {
+    use swc_core::{common::SyntaxContext, ecma::ast::Ident};
+
+    let mut state = state();
+
+    state.insert_style_var(
+      "styles".to_string(),
+      make_var_declarator("styles", object_expr()),
+    );
+    state
+      .style_map
+      .insert("styles".to_string(), Rc::new(StylesObjectMap::new()));
+
+    let shadowed = Ident {
+      span: DUMMY_SP,
+      sym: "styles".into(),
+      optional: false,
+      ctxt: SyntaxContext::from_u32(1),
+    };
+
+    assert!(!state.is_style_var_ident(&shadowed));
+  }
+}
+
+/// A default export that is not an object anchors no injection: only an object
+/// is a namespace a style could have come from.
+#[test]
+fn a_default_exported_value_that_is_not_an_object_anchors_no_injection() {
+  let mut state = state_with(Some(RuntimeInjectionState::Boolean(true)));
+  let ast = object_expr();
+  let mut body = vec![ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
+    swc_core::ecma::ast::ExportDefaultExpr {
+      span: DUMMY_SP,
+      expr: Box::new(Expr::Ident(create_ident("styles"))),
+    },
+  ))];
+
+  state.register_styles(
+    &call_expr("create"),
+    &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
+    &ast,
+    None,
+  );
+
+  flush_pending_insertions(&mut state, &mut body, true);
+
+  assert_eq!(body_shapes(&body), vec!["import", "var", "other"]);
+}

--- a/crates/stylex-state/src/tests/theme_ref_test.rs
+++ b/crates/stylex-state/src/tests/theme_ref_test.rs
@@ -212,3 +212,232 @@ fn a_non_ascii_key_is_hashed_as_written_and_made_safe_to_read() {
     readable
   );
 }
+
+/// The two options as one value, and the two ways it is read.
+mod var_naming {
+  use stylex_structures::stylex_state_options::StyleXStateOptions;
+
+  use crate::state_manager::StateManager;
+  use crate::theme_ref::VarNaming;
+
+  fn state(debug: bool, readable_names: bool) -> StateManager {
+    StateManager::for_test(
+      None,
+      StyleXStateOptions::default()
+        .with_debug(debug)
+        .with_enable_debug_class_names(readable_names),
+    )
+  }
+
+  /// The pair is read off the project once, and it is the two options as the
+  /// project set them.
+  #[test]
+  fn the_pair_is_read_off_the_project_options() {
+    for debug in [false, true] {
+      for readable_names in [false, true] {
+        assert_eq!(
+          VarNaming::of(&state(debug, readable_names)).as_flags(),
+          (debug, readable_names)
+        );
+      }
+    }
+  }
+
+  /// The pair the engine carries reads back as the pair it was handed, which is
+  /// what keeps the engine and the evaluator naming a member the same way.
+  #[test]
+  fn the_pair_survives_the_trip_through_the_engine() {
+    for debug in [false, true] {
+      for readable_names in [false, true] {
+        assert_eq!(
+          VarNaming::from_flags(debug, readable_names).as_flags(),
+          (debug, readable_names)
+        );
+      }
+    }
+  }
+}
+
+/// A reference to a `defineVars` group, as the evaluator holds one.
+mod theme_reference {
+  use stylex_constants::constants::common::VAR_GROUP_HASH_KEY;
+  use stylex_enums::theme_ref::ThemeRefResult;
+  use stylex_structures::stylex_state_options::StyleXStateOptions;
+
+  use crate::state_manager::StateManager;
+  use crate::theme_ref::{IS_PROXY_KEY, ThemeRef, VarNaming, var_group_member};
+
+  fn plain_state() -> StateManager {
+    StateManager::for_test(None, StyleXStateOptions::default())
+  }
+
+  fn theme_ref() -> ThemeRef {
+    ThemeRef::new("vars.stylex.js", "vars", "x")
+  }
+
+  /// The identity is the file and the export joined the way every name derived
+  /// from the group is derived.
+  #[test]
+  fn the_identity_is_the_file_and_the_export() {
+    assert_eq!(theme_ref().base_id(), "vars.stylex.js//vars");
+  }
+
+  #[test]
+  fn the_prefix_is_kept_as_handed_in() {
+    assert_eq!(theme_ref().class_name_prefix(), "x");
+    assert_eq!(
+      ThemeRef::new("vars.stylex.js", "vars", "").class_name_prefix(),
+      ""
+    );
+  }
+
+  /// `toString` is the one key that answers a bare name rather than a `var()`,
+  /// and it is the same name `to_string_value` answers.
+  #[test]
+  fn the_to_string_key_answers_the_group_s_own_name() {
+    let mut reference = theme_ref();
+    let expected = reference.to_string_value();
+
+    let ThemeRefResult::ToString(name) = reference.get("toString", &plain_state()) else {
+      panic!("`toString` did not answer the group's own name");
+    };
+
+    assert_eq!(name, expected);
+    assert!(name.starts_with('x'), "got `{}`", name);
+  }
+
+  /// The marker key answers that the value stands in for a group rather than
+  /// holding one, which is how every reader tells a reference from an object.
+  #[test]
+  fn the_proxy_key_answers_that_this_stands_in_for_a_group() {
+    let mut reference = theme_ref();
+
+    assert!(matches!(
+      reference.get(IS_PROXY_KEY, &plain_state()),
+      ThemeRefResult::Proxy
+    ));
+  }
+
+  /// Every other key answers the variable the derivation names, so a read
+  /// through the reference and a read through the derivation agree.
+  #[test]
+  fn a_member_read_answers_the_variable_the_derivation_names() {
+    let mut reference = theme_ref();
+    let state = plain_state();
+
+    assert_eq!(
+      reference.get("primary", &state).as_css_var(),
+      Some(
+        var_group_member(
+          "vars.stylex.js//vars",
+          "x",
+          "primary",
+          VarNaming::of(&state)
+        )
+        .as_str()
+      )
+    );
+  }
+
+  /// The second read of one key answers the first read's own value: the name is
+  /// derived once and kept.
+  #[test]
+  fn a_second_read_of_one_key_answers_the_first_read_s_value() {
+    let mut reference = theme_ref();
+    let state = plain_state();
+
+    let Some(first) = reference
+      .get("primary", &state)
+      .as_css_var()
+      .map(str::to_string)
+    else {
+      panic!("the first read named no variable");
+    };
+    let Some(second) = reference
+      .get("primary", &state)
+      .as_css_var()
+      .map(str::to_string)
+    else {
+      panic!("the second read named no variable");
+    };
+
+    assert_eq!(first, second);
+  }
+
+  /// The group's hash key answers a bare name rather than a `var()`, because it
+  /// names the group and not a variable of it.
+  #[test]
+  fn the_group_hash_key_answers_a_bare_name() {
+    let mut reference = theme_ref();
+    let state = plain_state();
+
+    let answer = reference.get(VAR_GROUP_HASH_KEY, &state);
+    let Some(name) = answer.as_css_var() else {
+      panic!("the group hash key named nothing");
+    };
+
+    assert!(!name.starts_with("var("), "got `{}`", name);
+    assert_eq!(name, reference.to_string_value());
+  }
+
+  /// A variable the author named is used as written, and reading it twice
+  /// answers the same text -- it is derived from nothing, so there is nothing to
+  /// keep between the reads.
+  #[test]
+  fn an_author_named_variable_is_used_as_written() {
+    let mut reference = theme_ref();
+    let state = plain_state();
+
+    assert_eq!(
+      reference.get("--brand-color", &state).as_css_var(),
+      Some("var(--brand-color)")
+    );
+    assert_eq!(
+      reference.get("--brand-color", &state).as_css_var(),
+      Some("var(--brand-color)")
+    );
+  }
+
+  /// A clone shares the derived names with the value it was cloned from, which
+  /// is what makes the factory that hands out references cheap.
+  #[test]
+  fn a_clone_shares_the_names_already_derived() {
+    let mut reference = theme_ref();
+    let state = plain_state();
+
+    let Some(original) = reference
+      .get("primary", &state)
+      .as_css_var()
+      .map(str::to_string)
+    else {
+      panic!("the read named no variable");
+    };
+
+    let mut clone = reference.clone();
+
+    assert_eq!(
+      clone.get("primary", &state).as_css_var(),
+      Some(original.as_str())
+    );
+  }
+
+  /// The debug options reach the derivation through the state, so the same key
+  /// under a debug project names a readable variable.
+  #[test]
+  fn the_project_options_reach_the_derivation() {
+    let mut reference = theme_ref();
+    let debug_state = StateManager::for_test(
+      None,
+      StyleXStateOptions::default()
+        .with_debug(true)
+        .with_enable_debug_class_names(true),
+    );
+
+    let answer = reference.get("primary", &debug_state);
+    let Some(name) = answer.as_css_var() else {
+      panic!("the read named no variable");
+    };
+
+    assert!(name.starts_with("var(--primary-x"), "got `{}`", name);
+  }
+}

--- a/crates/stylex-state/src/tests/theme_ref_test.rs
+++ b/crates/stylex-state/src/tests/theme_ref_test.rs
@@ -296,14 +296,16 @@ mod theme_reference {
   #[test]
   fn the_to_string_key_answers_the_group_s_own_name() {
     let mut reference = theme_ref();
-    let expected = reference.to_string_value();
 
     let ThemeRefResult::ToString(name) = reference.get("toString", &plain_state()) else {
       panic!("`toString` did not answer the group's own name");
     };
 
-    assert_eq!(name, expected);
-    assert!(name.starts_with('x'), "got `{}`", name);
+    // The literal is the group hash of `BASE` under `PREFIX`, pinned at the top
+    // of this file against Babel. Reading `to_string_value` for the expectation
+    // would let both halves be wrong together.
+    assert_eq!(name, "xop34xu");
+    assert_eq!(name, reference.to_string_value());
   }
 
   /// The marker key answers that the value stands in for a group rather than
@@ -325,17 +327,16 @@ mod theme_reference {
     let mut reference = theme_ref();
     let state = plain_state();
 
+    // The literal is what `var_group_member` is pinned to against Babel at the
+    // top of this file. Re-deriving it here would only prove the reference
+    // calls the derivation, not that either one is right.
     assert_eq!(
       reference.get("primary", &state).as_css_var(),
-      Some(
-        var_group_member(
-          "vars.stylex.js//vars",
-          "x",
-          "primary",
-          VarNaming::of(&state)
-        )
-        .as_str()
-      )
+      Some("var(--x1ineb92)")
+    );
+    assert_eq!(
+      reference.get("primary", &state).as_css_var(),
+      Some(var_group_member(super::BASE, super::PREFIX, "primary", VarNaming::of(&state)).as_str())
     );
   }
 
@@ -377,6 +378,7 @@ mod theme_reference {
     };
 
     assert!(!name.starts_with("var("), "got `{}`", name);
+    assert_eq!(name, "xop34xu");
     assert_eq!(name, reference.to_string_value());
   }
 

--- a/guidelines/STRUCTURE.md
+++ b/guidelines/STRUCTURE.md
@@ -157,8 +157,14 @@ Four lists hold the crate names and must agree: `test:coverage:workspace` in the
 root `package.json`, `EXCLUDED_CRATES` in `scripts/coverage-missing.sh`, the
 `case` in `scripts/packages/test/coverage.sh`, and `EXCLUDED` in
 `scripts/git/crate-coverage-runner.test.mjs`, which asserts that `case` starts
-no cargo for a name it holds. Nothing compares the four, so a row taken off
-three of them fails in the pre-push hook rather than where it was edited.
+no cargo for a name it holds. The first two spell a crate by its Cargo package
+name and the last two by its directory name, which differ by more than the
+hyphens: `stylex-rs-compiler` is the crate `stylex_compiler_rs`.
+
+`scripts/git/coverage-exclusions.test.mjs` compares the four and names the list
+that disagrees, so a row taken off three of them fails where it was edited. It
+also refuses a row for a crate this workspace does not hold, which is what a
+rename or a deletion leaves behind. Edit the four together.
 
 This section says why a crate is off the gate. Each row is permanent, with the
 reason stated, or temporary, with the ticket that removes it named. Do not add a

--- a/guidelines/STRUCTURE.md
+++ b/guidelines/STRUCTURE.md
@@ -153,13 +153,18 @@ file).
 
 ### Excluded from Coverage
 
-Three lists hold the crate names and must agree: `test:coverage:workspace` in
-the root `package.json`, `EXCLUDED_CRATES` in `scripts/coverage-missing.sh`, and
-the `case` in `scripts/packages/test/coverage.sh`. This section says why a crate
-is off the gate. Each row is permanent, with the reason stated, or temporary,
-with the ticket that removes it named. Do not add a row without one of the two.
-A new crate joins the gate at full coverage when it is created. A temporary row
-must say why the coverage could not travel with the code.
+Four lists hold the crate names and must agree: `test:coverage:workspace` in the
+root `package.json`, `EXCLUDED_CRATES` in `scripts/coverage-missing.sh`, the
+`case` in `scripts/packages/test/coverage.sh`, and `EXCLUDED` in
+`scripts/git/crate-coverage-runner.test.mjs`, which asserts that `case` starts
+no cargo for a name it holds. Nothing compares the four, so a row taken off
+three of them fails in the pre-push hook rather than where it was edited.
+
+This section says why a crate is off the gate. Each row is permanent, with the
+reason stated, or temporary, with the ticket that removes it named. Do not add a
+row without one of the two. A new crate joins the gate at full coverage when it
+is created. A temporary row must say why the coverage could not travel with the
+code.
 
 Permanent:
 
@@ -168,18 +173,14 @@ Permanent:
 - `stylex_test_parser` -- test fixture parser
 - `stylex_transform` -- SWC transform, tested through snapshot tests
 
-Both temporary crates came out of the transform, which is itself off the gate.
-The transform's tests had covered them, and the new crate boundary stopped that
-coverage counting for them. Both tickets sit in the `split-transform-crate`
-tracker (see [issue-tracker.md](../docs/agents/issue-tracker.md)).
+The temporary crate came out of the transform, which is itself off the gate.
+The transform's tests had covered it, and the new crate boundary stopped that
+coverage counting for it. Its ticket sits in the `split-transform-crate` tracker
+(see [issue-tracker.md](../docs/agents/issue-tracker.md)).
 
 Temporary:
 
-- `stylex_state` -- covered through the transform until direct tests exist.
-  Ticket `11-cover-the-state-crate` removes this row. The row also excludes
-  the crate's `resolution` module, which was a crate on the gate and is still
-  at 100%: the ticket that removes the row must keep it there.
-- `stylex_evaluator` -- the same, for the evaluator moved out of the transform.
+- `stylex_evaluator` -- covered through the transform until direct tests exist.
   Ticket `15-cover-the-evaluator-crate` removes this row.
 
 ## Key Config Files

--- a/guidelines/STRUCTURE.md
+++ b/guidelines/STRUCTURE.md
@@ -153,18 +153,24 @@ file).
 
 ### Excluded from Coverage
 
-Four lists hold the crate names and must agree: `test:coverage:workspace` in the
+Five lists hold the crate names and must agree: `test:coverage:workspace` in the
 root `package.json`, `EXCLUDED_CRATES` in `scripts/coverage-missing.sh`, the
-`case` in `scripts/packages/test/coverage.sh`, and `EXCLUDED` in
+`case` in `scripts/packages/test/coverage.sh`, `EXCLUDED` in
 `scripts/git/crate-coverage-runner.test.mjs`, which asserts that `case` starts
-no cargo for a name it holds. The first two spell a crate by its Cargo package
-name and the last two by its directory name, which differ by more than the
-hyphens: `stylex-rs-compiler` is the crate `stylex_compiler_rs`.
+no cargo for a name it holds, and the rows below. `case` and `EXCLUDED` spell a
+crate by its directory name and the other three by its Cargo package name, which
+differ by more than the hyphens: `stylex-rs-compiler` is the crate
+`stylex_compiler_rs`.
 
-`scripts/git/coverage-exclusions.test.mjs` compares the four and names the list
-that disagrees, so a row taken off three of them fails where it was edited. It
+`scripts/git/coverage-exclusions.test.mjs` compares the five and names the list
+that disagrees, so a row taken off four of them fails where it was edited. It
 also refuses a row for a crate this workspace does not hold, which is what a
-rename or a deletion leaves behind. Edit the four together.
+rename or a deletion leaves behind. Edit the five together.
+
+A crate can also fall off the gate without a row anywhere:
+`scripts/packages/test/coverage.sh` measures nothing for a crate that has no
+tests and nothing for one with no `src/lib.rs`. The five lists are the
+_declared_ exclusions, not the whole of what goes unmeasured.
 
 This section says why a crate is off the gate. Each row is permanent, with the
 reason stated, or temporary, with the ticket that removes it named. Do not add a

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "node scripts/git/install-hooks.mjs",
     "test": "turbo run test --continue",
     "test:coverage": "turbo run test:coverage --continue",
-    "test:coverage:workspace": "cargo +nightly llvm-cov nextest --workspace --all-features --exclude stylex_logs --exclude stylex_compiler_rs --exclude stylex_test_parser --exclude stylex_transform --exclude stylex_state --exclude stylex_evaluator --fail-uncovered-lines 0 --fail-uncovered-regions 0 --fail-under-functions 0 --ignore-filename-regex '(tests?|benches?|examples)/'",
+    "test:coverage:workspace": "cargo +nightly llvm-cov nextest --workspace --all-features --exclude stylex_logs --exclude stylex_compiler_rs --exclude stylex_test_parser --exclude stylex_transform --exclude stylex_evaluator --fail-uncovered-lines 0 --fail-uncovered-regions 0 --fail-under-functions 0 --ignore-filename-regex '(tests?|benches?|examples)/'",
     "test:crates:workspace": "turbo run test:crates:workspace:regular test:crates:workspace:doc --filter=// --continue",
     "test:crates:workspace:doc": "cargo test --doc --workspace --all-features",
     "test:crates:workspace:regular": "cargo nextest run --workspace --all-features --profile ci",

--- a/scripts/coverage-missing.sh
+++ b/scripts/coverage-missing.sh
@@ -54,16 +54,17 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Crates excluded from workspace coverage. Three lists must agree: this one, the
-# `test:coverage:workspace` script in the root package.json, and the `case` in
-# scripts/packages/test/coverage.sh. A row is either permanent or names the
-# ticket that removes it -- see "Excluded from Coverage" in guidelines/STRUCTURE.md.
+# Crates excluded from workspace coverage. Four lists must agree: this one, the
+# `test:coverage:workspace` script in the root package.json, the `case` in
+# scripts/packages/test/coverage.sh, and `EXCLUDED` in
+# scripts/git/crate-coverage-runner.test.mjs, which asserts that `case`. A row is
+# either permanent or names the ticket that removes it -- see "Excluded from
+# Coverage" in guidelines/STRUCTURE.md.
 EXCLUDED_CRATES=(
   stylex_logs        # permanent
   stylex_compiler_rs # permanent
   stylex_test_parser # permanent
   stylex_transform   # permanent
-  stylex_state       # temporary, removed by ticket 11
   stylex_evaluator   # temporary, removed by ticket 15
 )
 WORKSPACE_EXCLUDES=()

--- a/scripts/coverage-missing.sh
+++ b/scripts/coverage-missing.sh
@@ -54,11 +54,12 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Crates excluded from workspace coverage. Four lists must agree: this one, the
+# Crates excluded from workspace coverage. Five lists must agree: this one, the
 # `test:coverage:workspace` script in the root package.json, the `case` in
-# scripts/packages/test/coverage.sh, and `EXCLUDED` in
-# scripts/git/crate-coverage-runner.test.mjs, which asserts that `case`.
-# scripts/git/coverage-exclusions.test.mjs compares all four and names the one
+# scripts/packages/test/coverage.sh, `EXCLUDED` in
+# scripts/git/crate-coverage-runner.test.mjs, which asserts that `case`, and the
+# rows under "Excluded from Coverage" in guidelines/STRUCTURE.md.
+# scripts/git/coverage-exclusions.test.mjs compares all five and names the one
 # that disagrees. A row is either permanent or names the ticket that removes it
 # -- see "Excluded from Coverage" in guidelines/STRUCTURE.md.
 EXCLUDED_CRATES=(
@@ -141,7 +142,10 @@ if [ -n "$package" ]; then
   scope_value="${package//_/-}"
   echo "==> Coverage for crate: $package"
 else
-  scope=(--workspace "${WORKSPACE_EXCLUDES[@]}")
+  # `${a[@]}` on an empty array is an unbound variable under bash 3.2 with
+  # `set -u`, and this list only ever shrinks -- ticket 15 takes the last
+  # temporary row off it.
+  scope=(--workspace ${WORKSPACE_EXCLUDES[@]+"${WORKSPACE_EXCLUDES[@]}"})
   scope_mode="workspace"
   scope_value=""
   for crate in "${EXCLUDED_CRATES[@]}"; do

--- a/scripts/coverage-missing.sh
+++ b/scripts/coverage-missing.sh
@@ -57,9 +57,10 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Crates excluded from workspace coverage. Four lists must agree: this one, the
 # `test:coverage:workspace` script in the root package.json, the `case` in
 # scripts/packages/test/coverage.sh, and `EXCLUDED` in
-# scripts/git/crate-coverage-runner.test.mjs, which asserts that `case`. A row is
-# either permanent or names the ticket that removes it -- see "Excluded from
-# Coverage" in guidelines/STRUCTURE.md.
+# scripts/git/crate-coverage-runner.test.mjs, which asserts that `case`.
+# scripts/git/coverage-exclusions.test.mjs compares all four and names the one
+# that disagrees. A row is either permanent or names the ticket that removes it
+# -- see "Excluded from Coverage" in guidelines/STRUCTURE.md.
 EXCLUDED_CRATES=(
   stylex_logs        # permanent
   stylex_compiler_rs # permanent

--- a/scripts/git/coverage-exclusions.test.mjs
+++ b/scripts/git/coverage-exclusions.test.mjs
@@ -18,6 +18,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 import {
+  SOURCES,
   findExclusionFaults,
   readCratePackageNames,
   readExclusionLists,
@@ -39,8 +40,9 @@ const CRATES = [
 /**
  * A tree holding the four lists, each given the names it should carry.
  *
- * @param {{workspace?: string[], missing?: string[], runner?: string[], suite?: string[]}} lists
- *   package names for the first two, directory names for the last two
+ * @param {{workspace?: string[], missing?: string[], runner?: string[], suite?: string[],
+ *   guidelines?: string[]}} lists package names for all but `runner` and `suite`,
+ *   which hold directory names
  * @returns {string} the tree's root
  */
 function createTree(lists = {}) {
@@ -49,6 +51,7 @@ function createTree(lists = {}) {
     missing = ['stylex_logs'],
     runner = ['stylex-logs'],
     suite = ['stylex-logs'],
+    guidelines = ['stylex_logs'],
   } = lists;
 
   const root = makeTemporaryDirectory('stylex-coverage-exclusions-');
@@ -82,12 +85,26 @@ function createTree(lists = {}) {
     `const EXCLUDED = [\n${suite.map(name => `  '${name}',\n`).join('')}];\n`
   );
 
+  writeText(
+    path.join(root, 'guidelines/STRUCTURE.md'),
+    [
+      '### Excluded from Coverage',
+      '',
+      'Permanent:',
+      '',
+      ...guidelines.map(name => `- \`${name}\` -- permanent`),
+      '',
+      '## Key Config Files',
+      '',
+    ].join('\n')
+  );
+
   return root;
 }
 
 // ── The rule ─────────────────────────────────────────────────────────────────
 
-void test('four lists naming one crate agree', () => {
+void test('five lists naming one crate agree', () => {
   assert.deepEqual(findExclusionFaults(createTree()), []);
 });
 
@@ -100,14 +117,15 @@ void test('the two spellings of one crate are read as one crate', () => {
     missing: ['stylex_compiler_rs'],
     runner: ['stylex-rs-compiler'],
     suite: ['stylex-rs-compiler'],
+    guidelines: ['stylex_compiler_rs'],
   });
 
   assert.deepEqual(findExclusionFaults(root), []);
 });
 
 void test('a row taken off one list is a fault naming that list', () => {
-  // The regression this suite exists for, in the direction it happened: three
-  // lists lost the row and the fourth kept it.
+  // The regression this suite exists for, in the direction it happened: four
+  // lists lost the row and the fifth kept it.
   const root = createTree({
     workspace: ['stylex_logs'],
     missing: ['stylex_logs'],
@@ -134,6 +152,7 @@ void test('a row missing from one list is a fault naming that list', () => {
     missing: ['stylex_logs', 'stylex_state'],
     runner: ['stylex-logs', 'stylex-state'],
     suite: ['stylex-logs'],
+    guidelines: ['stylex_logs', 'stylex_state'],
   });
 
   assert.deepEqual(findExclusionFaults(root), [
@@ -149,6 +168,7 @@ void test('a row for a crate the workspace does not hold is a fault', () => {
     missing: ['stylex_departed'],
     runner: ['stylex-departed'],
     suite: ['stylex-departed'],
+    guidelines: ['stylex_departed'],
   });
 
   assert.deepEqual(findExclusionFaults(root), [
@@ -156,6 +176,7 @@ void test('a row for a crate the workspace does not hold is a fault', () => {
     'scripts/coverage-missing.sh excludes `stylex_departed`, which is no crate in this workspace',
     'scripts/packages/test/coverage.sh excludes `stylex-departed`, which is no crate directory',
     'scripts/git/crate-coverage-runner.test.mjs excludes `stylex-departed`, which is no crate directory',
+    'guidelines/STRUCTURE.md excludes `stylex_departed`, which is no crate in this workspace',
   ]);
 });
 
@@ -167,6 +188,29 @@ void test('a list written in the wrong spelling is a fault', () => {
   assert.deepEqual(findExclusionFaults(root), [
     'scripts/packages/test/coverage.sh excludes `stylex_logs`, which is no crate directory',
     'scripts/packages/test/coverage.sh does not exclude `stylex_logs`, which package.json does',
+  ]);
+});
+
+void test('a row left behind in the guidelines is a fault naming the guidelines', () => {
+  // The drift this module's own commit performed by hand: the four machine
+  // lists lost the row and the prose that explains it kept it.
+  const root = createTree({ guidelines: ['stylex_logs', 'stylex_state'] });
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'guidelines/STRUCTURE.md excludes `stylex_state`, which package.json does not',
+  ]);
+});
+
+void test('a guidelines section that names no crate is a fault, never an empty list', () => {
+  const root = createTree();
+
+  writeText(
+    path.join(root, 'guidelines/STRUCTURE.md'),
+    '### Excluded from Coverage\n\nThe rows moved elsewhere.\n\n## Key Config Files\n'
+  );
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'guidelines/STRUCTURE.md has an `Excluded from Coverage` section that names no crate',
   ]);
 });
 
@@ -188,8 +232,99 @@ void test('a list whose file is gone is a fault', () => {
   const root = makeTemporaryDirectory('stylex-coverage-exclusions-empty-');
   const faults = findExclusionFaults(root);
 
-  assert.equal(faults.length, 4);
+  assert.equal(faults.length, SOURCES.length);
   assert.ok(faults.every(fault => fault.endsWith('is missing')));
+});
+
+// ── What a wrap of a list past the line width leaves behind ─────────────
+
+void test('a name in a second arm of the case is read', () => {
+  const root = createTree();
+
+  // The `case` is at 86 columns with five names on it. One more wraps it, and
+  // a second arm is the natural way to wrap. Reading only the first arm made
+  // the row invisible and reported four agreeing lists.
+  writeText(
+    path.join(root, 'scripts/packages/test/coverage.sh'),
+    'case "$crate_name" in\n' +
+      '  stylex-logs)\n    exit 0\n    ;;\n' +
+      '  stylex-state)\n    exit 0\n    ;;\n' +
+      'esac\n'
+  );
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'scripts/packages/test/coverage.sh excludes `stylex_state`, which package.json does not',
+  ]);
+});
+
+void test('a case arm continued with a backslash is read', () => {
+  const root = createTree({
+    workspace: ['stylex_logs', 'stylex_state'],
+    missing: ['stylex_logs', 'stylex_state'],
+    guidelines: ['stylex_logs', 'stylex_state'],
+  });
+
+  writeText(
+    path.join(root, 'scripts/packages/test/coverage.sh'),
+    'case "${crate_name}" in\n  stylex-logs|\\\n    stylex-state)\n    exit 0\n    ;;\nesac\n'
+  );
+
+  // The `case` and `package.json` now agree; the two lists left behind are the
+  // fault, which is what a reader has to be told to edit.
+  assert.deepEqual(findExclusionFaults(root), [
+    'scripts/git/crate-coverage-runner.test.mjs does not exclude `stylex_state`, ' +
+      'which package.json does',
+  ]);
+});
+
+void test('two names on one row of the shell array are two rows', () => {
+  const root = createTree({
+    workspace: ['stylex_logs', 'stylex_state'],
+    guidelines: ['stylex_logs', 'stylex_state'],
+  });
+
+  writeText(
+    path.join(root, 'scripts/coverage-missing.sh'),
+    'EXCLUDED_CRATES=(\n  stylex_logs stylex_state\n)\n'
+  );
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'scripts/packages/test/coverage.sh does not exclude `stylex_state`, which package.json does',
+    'scripts/git/crate-coverage-runner.test.mjs does not exclude `stylex_state`, ' +
+      'which package.json does',
+  ]);
+});
+
+void test('an exclude written with an equals sign is a row', () => {
+  const root = createTree();
+
+  writeJson(path.join(root, 'package.json'), {
+    scripts: {
+      'test:coverage:workspace':
+        'cargo +nightly llvm-cov nextest --workspace --exclude=stylex_logs',
+    },
+  });
+
+  assert.deepEqual(findExclusionFaults(root), []);
+});
+
+void test('a manifest that will not parse is a named fault, not a crash', () => {
+  const root = createTree();
+
+  writeText(path.join(root, 'package.json'), '{ "scripts": ');
+
+  assert.deepEqual(findExclusionFaults(root), ['package.json is not readable JSON']);
+});
+
+void test('an apostrophe in a comment is not a crate name', () => {
+  const root = createTree();
+
+  writeText(
+    path.join(root, 'scripts/git/crate-coverage-runner.test.mjs'),
+    "const EXCLUDED = [\n  // the transform's own crates stay off\n  'stylex-logs',\n];\n"
+  );
+
+  assert.deepEqual(findExclusionFaults(root), []);
 });
 
 // ── Against the real repository ───────────────────────────────────────────────
@@ -210,6 +345,6 @@ void test('every crate in this repository declares a package name', () => {
   assert.ok(names.has('stylex-state'), '`stylex-state` was not read');
 });
 
-void test("this repository's four lists agree", () => {
+void test("this repository's five lists agree", () => {
   assert.deepEqual(findExclusionFaults(repoRoot), []);
 });

--- a/scripts/git/coverage-exclusions.test.mjs
+++ b/scripts/git/coverage-exclusions.test.mjs
@@ -1,0 +1,215 @@
+/**
+ * Asserts that the four lists of crates excluded from coverage agree, and that
+ * every name on them is a crate this workspace holds.
+ *
+ * The lists are copies of one decision kept by hand, in two spellings, and
+ * nothing compared them. Taking `stylex_state` off three of the four left
+ * `pnpm test`, `pnpm lint:check` and the coverage gate itself green, and failed
+ * in the pre-push hook against a list nobody had thought to edit. The rule is
+ * stated here so the fault is named where it is made.
+ *
+ * Most cases run against a synthetic tree, so the suite states a rule rather
+ * than a snapshot of today's lists. The last case runs against the real
+ * repository, which is what makes the rule load-bearing.
+ */
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  findExclusionFaults,
+  readCratePackageNames,
+  readExclusionLists,
+} from './lib/coverage-exclusions.mjs';
+import { makeTemporaryDirectory, repoRoot, writeJson, writeText } from './lib/test-harness.mjs';
+
+/**
+ * The crates a synthetic tree holds: a directory name paired with the Cargo
+ * package name it declares. The two differ by more than the hyphens for one of
+ * them, which is the whole reason the lists cannot be compared as text.
+ */
+const CRATES = [
+  ['stylex-logs', 'stylex_logs'],
+  ['stylex-rs-compiler', 'stylex_compiler_rs'],
+  ['stylex-state', 'stylex_state'],
+  ['stylex-state-index', 'stylex_state_index'],
+];
+
+/**
+ * A tree holding the four lists, each given the names it should carry.
+ *
+ * @param {{workspace?: string[], missing?: string[], runner?: string[], suite?: string[]}} lists
+ *   package names for the first two, directory names for the last two
+ * @returns {string} the tree's root
+ */
+function createTree(lists = {}) {
+  const {
+    workspace = ['stylex_logs'],
+    missing = ['stylex_logs'],
+    runner = ['stylex-logs'],
+    suite = ['stylex-logs'],
+  } = lists;
+
+  const root = makeTemporaryDirectory('stylex-coverage-exclusions-');
+
+  for (const [directory, name] of CRATES) {
+    writeText(path.join(root, 'crates', directory, 'Cargo.toml'), `[package]\nname = "${name}"\n`);
+  }
+
+  writeJson(path.join(root, 'package.json'), {
+    scripts: {
+      'test:coverage:workspace': [
+        'cargo +nightly llvm-cov nextest --workspace --all-features',
+        ...workspace.map(name => `--exclude ${name}`),
+        '--fail-uncovered-lines 0',
+      ].join(' '),
+    },
+  });
+
+  writeText(
+    path.join(root, 'scripts/coverage-missing.sh'),
+    `EXCLUDED_CRATES=(\n${missing.map(name => `  ${name} # permanent\n`).join('')})\n`
+  );
+
+  writeText(
+    path.join(root, 'scripts/packages/test/coverage.sh'),
+    `case "$crate_name" in\n  ${runner.join('|')})\n    exit 0\n    ;;\nesac\n`
+  );
+
+  writeText(
+    path.join(root, 'scripts/git/crate-coverage-runner.test.mjs'),
+    `const EXCLUDED = [\n${suite.map(name => `  '${name}',\n`).join('')}];\n`
+  );
+
+  return root;
+}
+
+// ── The rule ─────────────────────────────────────────────────────────────────
+
+void test('four lists naming one crate agree', () => {
+  assert.deepEqual(findExclusionFaults(createTree()), []);
+});
+
+void test('the two spellings of one crate are read as one crate', () => {
+  // `stylex-rs-compiler` is the crate `stylex_compiler_rs`. Comparing the lists
+  // as text would call this a disagreement, which is why the directory names
+  // are resolved through each crate's own manifest.
+  const root = createTree({
+    workspace: ['stylex_compiler_rs'],
+    missing: ['stylex_compiler_rs'],
+    runner: ['stylex-rs-compiler'],
+    suite: ['stylex-rs-compiler'],
+  });
+
+  assert.deepEqual(findExclusionFaults(root), []);
+});
+
+void test('a row taken off one list is a fault naming that list', () => {
+  // The regression this suite exists for, in the direction it happened: three
+  // lists lost the row and the fourth kept it.
+  const root = createTree({
+    workspace: ['stylex_logs'],
+    missing: ['stylex_logs'],
+    runner: ['stylex-logs'],
+    suite: ['stylex-logs', 'stylex-state'],
+  });
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'scripts/git/crate-coverage-runner.test.mjs excludes `stylex_state`, which package.json does not',
+  ]);
+});
+
+void test('a row added to one list is a fault naming that list', () => {
+  const root = createTree({ missing: ['stylex_logs', 'stylex_state'] });
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'scripts/coverage-missing.sh excludes `stylex_state`, which package.json does not',
+  ]);
+});
+
+void test('a row missing from one list is a fault naming that list', () => {
+  const root = createTree({
+    workspace: ['stylex_logs', 'stylex_state'],
+    missing: ['stylex_logs', 'stylex_state'],
+    runner: ['stylex-logs', 'stylex-state'],
+    suite: ['stylex-logs'],
+  });
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'scripts/git/crate-coverage-runner.test.mjs does not exclude `stylex_state`, which package.json does',
+  ]);
+});
+
+void test('a row for a crate the workspace does not hold is a fault', () => {
+  // A crate that was renamed or deleted leaves a row behind that excludes
+  // nothing, and every list agreeing on it hides that.
+  const root = createTree({
+    workspace: ['stylex_departed'],
+    missing: ['stylex_departed'],
+    runner: ['stylex-departed'],
+    suite: ['stylex-departed'],
+  });
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'package.json excludes `stylex_departed`, which is no crate in this workspace',
+    'scripts/coverage-missing.sh excludes `stylex_departed`, which is no crate in this workspace',
+    'scripts/packages/test/coverage.sh excludes `stylex-departed`, which is no crate directory',
+    'scripts/git/crate-coverage-runner.test.mjs excludes `stylex-departed`, which is no crate directory',
+  ]);
+});
+
+void test('a list written in the wrong spelling is a fault', () => {
+  // A directory-name list given a package name, which is the mistake the two
+  // spellings invite.
+  const root = createTree({ runner: ['stylex_logs'] });
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'scripts/packages/test/coverage.sh excludes `stylex_logs`, which is no crate directory',
+    'scripts/packages/test/coverage.sh does not exclude `stylex_logs`, which package.json does',
+  ]);
+});
+
+// ── What happens when a list moves ────────────────────────────────────────────
+
+void test('a list that cannot be read is a fault, never an empty list', () => {
+  // An empty list agrees with nothing and disagrees with nothing, so a parser
+  // that answered one would turn a reshuffled file into a green suite.
+  const root = createTree();
+
+  writeText(path.join(root, 'scripts/coverage-missing.sh'), '# the array moved elsewhere\n');
+
+  assert.deepEqual(findExclusionFaults(root), [
+    'scripts/coverage-missing.sh has no `EXCLUDED_CRATES` array to read',
+  ]);
+});
+
+void test('a list whose file is gone is a fault', () => {
+  const root = makeTemporaryDirectory('stylex-coverage-exclusions-empty-');
+  const faults = findExclusionFaults(root);
+
+  assert.equal(faults.length, 4);
+  assert.ok(faults.every(fault => fault.endsWith('is missing')));
+});
+
+// ── Against the real repository ───────────────────────────────────────────────
+
+void test('every list in this repository is readable', () => {
+  // Read apart from the comparison below, so a file that moved reads as a
+  // parser that needs updating rather than as a list that disagrees.
+  for (const list of readExclusionLists(repoRoot)) {
+    assert.equal(list.fault, null, `${list.name}: ${list.fault}`);
+    assert.ok(list.names.length > 0, `${list.name} names no crate`);
+  }
+});
+
+void test('every crate in this repository declares a package name', () => {
+  const names = readCratePackageNames(repoRoot);
+
+  assert.ok(names.size > 0, 'no crate manifest was read');
+  assert.ok(names.has('stylex-state'), '`stylex-state` was not read');
+});
+
+void test("this repository's four lists agree", () => {
+  assert.deepEqual(findExclusionFaults(repoRoot), []);
+});

--- a/scripts/git/crate-coverage-runner.test.mjs
+++ b/scripts/git/crate-coverage-runner.test.mjs
@@ -31,6 +31,10 @@ const script = path.join(repoRoot, 'scripts/packages/test/coverage.sh');
  * The crates that the script must never measure. A fourth copy of the list the
  * `case` in the script holds -- see "Excluded from Coverage" in
  * guidelines/STRUCTURE.md for what each row is and which ticket removes it.
+ *
+ * `scripts/git/coverage-exclusions.test.mjs` compares this list with the other
+ * four and names the one that disagrees, so a row edited here alone fails
+ * there rather than in the pre-push hook.
  */
 const EXCLUDED = [
   'stylex-evaluator',

--- a/scripts/git/crate-coverage-runner.test.mjs
+++ b/scripts/git/crate-coverage-runner.test.mjs
@@ -27,12 +27,15 @@ import { repoRoot } from './lib/test-harness.mjs';
 
 const script = path.join(repoRoot, 'scripts/packages/test/coverage.sh');
 
-/** The crates that the script must never measure. */
+/**
+ * The crates that the script must never measure. A fourth copy of the list the
+ * `case` in the script holds -- see "Excluded from Coverage" in
+ * guidelines/STRUCTURE.md for what each row is and which ticket removes it.
+ */
 const EXCLUDED = [
   'stylex-evaluator',
   'stylex-logs',
   'stylex-rs-compiler',
-  'stylex-state',
   'stylex-test-parser',
   'stylex-transform',
 ];
@@ -130,9 +133,14 @@ void test(
   'a crate whose name only contains an excluded name is measured',
   { skip: NEEDS_BASH },
   () => {
-    // The list matches a whole name. A crate called `stylex-state-index` is not
-    // `stylex-state`, and it is on the gate.
-    const { invocations } = runInCrate({ files: A_MEASURABLE_CRATE, name: 'stylex-state-index' });
+    // The list matches a whole name. A crate whose name only begins with an
+    // excluded one is a different crate, and it stays on the gate. The pair that
+    // made this matter was `stylex-state` and `stylex-state-index`, until ticket
+    // 11 took the first of them off the list.
+    const { invocations } = runInCrate({
+      files: A_MEASURABLE_CRATE,
+      name: 'stylex-transform-index',
+    });
 
     assert.equal(invocations.length, 1);
   }

--- a/scripts/git/lib/coverage-exclusions.mjs
+++ b/scripts/git/lib/coverage-exclusions.mjs
@@ -1,14 +1,19 @@
 /**
- * Reads the four lists of crates excluded from coverage, and says where they
+ * Reads the five lists of crates excluded from coverage, and says where they
  * disagree.
  *
- * The lists are hand-kept copies of one decision, in two spellings. Two of them
- * hold Cargo package names -- the root `test:coverage:workspace` script and
+ * The lists are hand-kept copies of one decision, in two spellings. Three of
+ * them hold Cargo package names -- the root `test:coverage:workspace` script,
  * `EXCLUDED_CRATES` in `scripts/coverage-missing.sh`, because both hand the
- * names to cargo. The other two hold crate directory names -- the `case` in
- * `scripts/packages/test/coverage.sh`, which reads the name off `PWD`, and
+ * names to cargo, and the rows under "Excluded from Coverage" in
+ * `guidelines/STRUCTURE.md`, which is where a reader is sent to find out why a
+ * crate is off the gate. The other two hold crate directory names -- the `case`
+ * in `scripts/packages/test/coverage.sh`, which reads the name off `PWD`, and
  * `EXCLUDED` in the suite that asserts that `case`. The two spellings are not
  * the same string: `stylex-rs-compiler` is the crate `stylex_compiler_rs`.
+ *
+ * The docs count as a list because they drift the same way: this module's own
+ * commit edited those rows by hand, and nothing would have said so.
  *
  * Nothing compared them until now. Taking one row off three of the four left
  * every check green and failed in the pre-push hook, which is the shape this
@@ -46,6 +51,12 @@ export const SOURCES = [
     spelling: 'directory',
     read: readJsArray,
   },
+  {
+    name: 'guidelines/STRUCTURE.md',
+    file: 'guidelines/STRUCTURE.md',
+    spelling: 'package',
+    read: readGuidelineRows,
+  },
 ];
 
 /**
@@ -67,13 +78,26 @@ function firstMatch(contents, pattern, description) {
 
 /** Every `--exclude <name>` the root coverage script passes to cargo. */
 function readWorkspaceScript(contents) {
-  const script = JSON.parse(contents).scripts?.['test:coverage:workspace'];
+  let manifest;
+
+  // A manifest that will not parse is a list that cannot be read, not a crash:
+  // `readExclusionLists` rethrows anything that is not an `UnreadableList`, so
+  // without this the suite dies with a parser stack instead of a named fault.
+  try {
+    manifest = JSON.parse(contents);
+  } catch {
+    throw new UnreadableList('is not readable JSON');
+  }
+
+  const script = manifest.scripts?.['test:coverage:workspace'];
 
   if (typeof script !== 'string') {
     throw new UnreadableList('has no `test:coverage:workspace` script to read');
   }
 
-  const names = [...script.matchAll(/--exclude\s+(\S+)/g)].map(match => match[1]);
+  // `--exclude name` and `--exclude=name` are the same flag to cargo, so a row
+  // written the second way has to count as a row here too.
+  const names = [...script.matchAll(/--exclude[\s=]+(\S+)/g)].map(match => match[1]);
 
   if (names.length === 0) {
     throw new UnreadableList('has a `test:coverage:workspace` that excludes nothing');
@@ -82,35 +106,91 @@ function readWorkspaceScript(contents) {
   return names;
 }
 
-/** The `EXCLUDED_CRATES=( … )` array, without the comment on each row. */
+/**
+ * The `EXCLUDED_CRATES=( … )` array, without the comment on each row.
+ *
+ * Split on whitespace rather than on newlines, because the shell does: two
+ * names on one row are two rows to bash, and reading them as one produced a
+ * fault naming a crate spelled `stylex_logs stylex_evaluator`. The body is
+ * taken up to the first `)` that stands at the end of a line, so a `(` inside a
+ * row comment cannot end the array early.
+ */
 function readShellArray(contents) {
-  const body = firstMatch(contents, /EXCLUDED_CRATES=\(([^)]*)\)/, '`EXCLUDED_CRATES` array');
+  const body = firstMatch(
+    contents,
+    /EXCLUDED_CRATES=\(([\s\S]*?)\n?\)\s*$/m,
+    '`EXCLUDED_CRATES` array'
+  );
 
   return body
     .split('\n')
-    .map(line => line.replace(/#.*$/, '').trim())
-    .filter(line => line.length > 0);
+    .flatMap(line => line.replace(/#.*$/, '').trim().split(/\s+/))
+    .map(name => name.replace(/^["']|["']$/g, ''))
+    .filter(name => name.length > 0);
 }
 
-/** The one alternation of the `case` that exits before measuring. */
+/**
+ * Every alternation of the `case` that exits before measuring.
+ *
+ * Every arm, not the first one: reading only the first made a name in a second
+ * arm invisible, so a crate genuinely off the per-crate gate could sit on the
+ * other three lists and the comparison would still report agreement. That is
+ * the one answer this module must never give, and a wrap of the arm past the
+ * 100-column line width is the likeliest way to reach it.
+ */
 function readShellCase(contents) {
-  const alternation = firstMatch(
+  const body = firstMatch(
     contents,
-    /case\s+"\$crate_name"\s+in\s*\n\s*([^)\n]+)\)/,
+    /case\s+"\$\{?crate_name\}?"\s+in\s*\n([\s\S]*?)\nesac/,
     '`case` over the crate name'
   );
 
-  return alternation
-    .split('|')
+  // A row continued with a trailing `\` is one row to the shell, so it is
+  // joined back before the arms are read -- otherwise the half in front of the
+  // break is dropped, which is the same invisible row by another spelling.
+  const names = [...body.replace(/\\\n\s*/g, '').matchAll(/^([^\n()]+?)\)\s*$/gm)]
+    .flatMap(match => match[1].split('|'))
     .map(name => name.trim())
-    .filter(name => name.length > 0);
+    .filter(name => name.length > 0 && name !== '*');
+
+  if (names.length === 0) {
+    throw new UnreadableList('has a `case` over the crate name that names no crate');
+  }
+
+  return names;
 }
 
 /** The `const EXCLUDED = [ … ]` array the runner suite asserts that `case` with. */
 function readJsArray(contents) {
   const body = firstMatch(contents, /const EXCLUDED = \[([^\]]*)\]/, '`EXCLUDED` array');
 
-  return [...body.matchAll(/'([^']+)'/g)].map(match => match[1]);
+  // Either quote style, and never through a comment: a `//` note holding an
+  // apostrophe used to be read back as a crate name.
+  return [...body.replace(/\/\/[^\n]*/g, '').matchAll(/['"]([^'"]+)['"]/g)].map(match => match[1]);
+}
+
+/**
+ * The `` - `name` -- reason `` rows under "Excluded from Coverage", across both
+ * the permanent and the temporary heading.
+ *
+ * Anchored at the start of a line, so the crate names spelled inline in the
+ * prose above the rows -- which are examples, not decisions -- are not read as
+ * rows.
+ */
+function readGuidelineRows(contents) {
+  const section = firstMatch(
+    contents,
+    /### Excluded from Coverage\n([\s\S]*?)\n## /,
+    '`Excluded from Coverage` section'
+  );
+
+  const names = [...section.matchAll(/^- `([A-Za-z0-9_]+)`/gm)].map(match => match[1]);
+
+  if (names.length === 0) {
+    throw new UnreadableList('has an `Excluded from Coverage` section that names no crate');
+  }
+
+  return names;
 }
 
 /**
@@ -148,7 +228,7 @@ export function readCratePackageNames(root) {
 }
 
 /**
- * The four lists as they are written, each with the faults reading it raised.
+ * The five lists as they are written, each with the faults reading it raised.
  *
  * @param {string} root
  * @returns {{name: string, spelling: string, names: string[], fault: string|null}[]}
@@ -179,7 +259,7 @@ export function readExclusionLists(root) {
 }
 
 /**
- * Everything wrong with the four lists, one sentence each: a list that cannot
+ * Everything wrong with the five lists, one sentence each: a list that cannot
  * be read, a name that no crate answers to, and any pair that disagrees once
  * both are read as package names.
  *
@@ -222,8 +302,8 @@ export function findExclusionFaults(root) {
   }
 
   // Compared against the first readable list rather than pairwise, so a row
-  // taken off three of four reads as three faults naming the one that kept it,
-  // instead of six naming each other.
+  // taken off four of five reads as four faults naming the one that kept it,
+  // instead of twenty naming each other.
   const [reference, ...rest] = asPackageNames;
 
   if (reference === undefined) {

--- a/scripts/git/lib/coverage-exclusions.mjs
+++ b/scripts/git/lib/coverage-exclusions.mjs
@@ -1,0 +1,251 @@
+/**
+ * Reads the four lists of crates excluded from coverage, and says where they
+ * disagree.
+ *
+ * The lists are hand-kept copies of one decision, in two spellings. Two of them
+ * hold Cargo package names -- the root `test:coverage:workspace` script and
+ * `EXCLUDED_CRATES` in `scripts/coverage-missing.sh`, because both hand the
+ * names to cargo. The other two hold crate directory names -- the `case` in
+ * `scripts/packages/test/coverage.sh`, which reads the name off `PWD`, and
+ * `EXCLUDED` in the suite that asserts that `case`. The two spellings are not
+ * the same string: `stylex-rs-compiler` is the crate `stylex_compiler_rs`.
+ *
+ * Nothing compared them until now. Taking one row off three of the four left
+ * every check green and failed in the pre-push hook, which is the shape this
+ * module exists to turn into a named fault.
+ *
+ * Not a `*.test.mjs` file, so `pnpm test:scripts` does not run it as a suite.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Where each list lives, and how it spells a crate. */
+export const SOURCES = [
+  {
+    name: 'package.json',
+    file: 'package.json',
+    spelling: 'package',
+    read: readWorkspaceScript,
+  },
+  {
+    name: 'scripts/coverage-missing.sh',
+    file: 'scripts/coverage-missing.sh',
+    spelling: 'package',
+    read: readShellArray,
+  },
+  {
+    name: 'scripts/packages/test/coverage.sh',
+    file: 'scripts/packages/test/coverage.sh',
+    spelling: 'directory',
+    read: readShellCase,
+  },
+  {
+    name: 'scripts/git/crate-coverage-runner.test.mjs',
+    file: 'scripts/git/crate-coverage-runner.test.mjs',
+    spelling: 'directory',
+    read: readJsArray,
+  },
+];
+
+/**
+ * Raised when a list cannot be found at all. A parser that answered an empty
+ * list instead would make every other list agree with it, which is the one
+ * answer this module must never give.
+ */
+class UnreadableList extends Error {}
+
+function firstMatch(contents, pattern, description) {
+  const match = contents.match(pattern);
+
+  if (match === null) {
+    throw new UnreadableList(`has no ${description} to read`);
+  }
+
+  return match[1];
+}
+
+/** Every `--exclude <name>` the root coverage script passes to cargo. */
+function readWorkspaceScript(contents) {
+  const script = JSON.parse(contents).scripts?.['test:coverage:workspace'];
+
+  if (typeof script !== 'string') {
+    throw new UnreadableList('has no `test:coverage:workspace` script to read');
+  }
+
+  const names = [...script.matchAll(/--exclude\s+(\S+)/g)].map(match => match[1]);
+
+  if (names.length === 0) {
+    throw new UnreadableList('has a `test:coverage:workspace` that excludes nothing');
+  }
+
+  return names;
+}
+
+/** The `EXCLUDED_CRATES=( … )` array, without the comment on each row. */
+function readShellArray(contents) {
+  const body = firstMatch(contents, /EXCLUDED_CRATES=\(([^)]*)\)/, '`EXCLUDED_CRATES` array');
+
+  return body
+    .split('\n')
+    .map(line => line.replace(/#.*$/, '').trim())
+    .filter(line => line.length > 0);
+}
+
+/** The one alternation of the `case` that exits before measuring. */
+function readShellCase(contents) {
+  const alternation = firstMatch(
+    contents,
+    /case\s+"\$crate_name"\s+in\s*\n\s*([^)\n]+)\)/,
+    '`case` over the crate name'
+  );
+
+  return alternation
+    .split('|')
+    .map(name => name.trim())
+    .filter(name => name.length > 0);
+}
+
+/** The `const EXCLUDED = [ … ]` array the runner suite asserts that `case` with. */
+function readJsArray(contents) {
+  const body = firstMatch(contents, /const EXCLUDED = \[([^\]]*)\]/, '`EXCLUDED` array');
+
+  return [...body.matchAll(/'([^']+)'/g)].map(match => match[1]);
+}
+
+/**
+ * Every crate directory under `crates/`, paired with the Cargo package name it
+ * declares. Read rather than derived, because the two spellings differ by more
+ * than the hyphens.
+ *
+ * @param {string} root
+ * @returns {Map<string, string>} directory name -> package name
+ */
+export function readCratePackageNames(root) {
+  const crates = path.join(root, 'crates');
+
+  if (!fs.existsSync(crates)) {
+    return new Map();
+  }
+
+  const names = new Map();
+
+  for (const directory of fs.readdirSync(crates)) {
+    const manifest = path.join(crates, directory, 'Cargo.toml');
+
+    if (!fs.existsSync(manifest)) {
+      continue;
+    }
+
+    const declared = fs.readFileSync(manifest, 'utf8').match(/^name\s*=\s*"([^"]+)"/m);
+
+    if (declared !== null) {
+      names.set(directory, declared[1]);
+    }
+  }
+
+  return names;
+}
+
+/**
+ * The four lists as they are written, each with the faults reading it raised.
+ *
+ * @param {string} root
+ * @returns {{name: string, spelling: string, names: string[], fault: string|null}[]}
+ */
+export function readExclusionLists(root) {
+  return SOURCES.map(source => {
+    const file = path.join(root, source.file);
+
+    if (!fs.existsSync(file)) {
+      return { name: source.name, spelling: source.spelling, names: [], fault: 'is missing' };
+    }
+
+    try {
+      return {
+        name: source.name,
+        spelling: source.spelling,
+        names: source.read(fs.readFileSync(file, 'utf8')),
+        fault: null,
+      };
+    } catch (error) {
+      if (error instanceof UnreadableList) {
+        return { name: source.name, spelling: source.spelling, names: [], fault: error.message };
+      }
+
+      throw error;
+    }
+  });
+}
+
+/**
+ * Everything wrong with the four lists, one sentence each: a list that cannot
+ * be read, a name that no crate answers to, and any pair that disagrees once
+ * both are read as package names.
+ *
+ * @param {string} root
+ * @returns {string[]}
+ */
+export function findExclusionFaults(root) {
+  const lists = readExclusionLists(root);
+  const packageNames = readCratePackageNames(root);
+  const declared = new Set(packageNames.values());
+  const faults = [];
+
+  const asPackageNames = [];
+
+  for (const list of lists) {
+    if (list.fault !== null) {
+      faults.push(`${list.name} ${list.fault}`);
+      continue;
+    }
+
+    const resolved = new Set();
+
+    for (const name of list.names) {
+      const packageName = list.spelling === 'directory' ? packageNames.get(name) : name;
+
+      if (packageName === undefined) {
+        faults.push(`${list.name} excludes \`${name}\`, which is no crate directory`);
+        continue;
+      }
+
+      if (!declared.has(packageName)) {
+        faults.push(`${list.name} excludes \`${name}\`, which is no crate in this workspace`);
+        continue;
+      }
+
+      resolved.add(packageName);
+    }
+
+    asPackageNames.push({ name: list.name, packages: resolved });
+  }
+
+  // Compared against the first readable list rather than pairwise, so a row
+  // taken off three of four reads as three faults naming the one that kept it,
+  // instead of six naming each other.
+  const [reference, ...rest] = asPackageNames;
+
+  if (reference === undefined) {
+    return faults;
+  }
+
+  for (const list of rest) {
+    for (const missing of difference(reference.packages, list.packages)) {
+      faults.push(`${list.name} does not exclude \`${missing}\`, which ${reference.name} does`);
+    }
+
+    for (const extra of difference(list.packages, reference.packages)) {
+      faults.push(`${list.name} excludes \`${extra}\`, which ${reference.name} does not`);
+    }
+  }
+
+  return faults;
+}
+
+/** The names `left` holds and `right` does not, ordered so a fault list is stable. */
+function difference(left, right) {
+  return [...left]
+    .filter(name => !right.has(name))
+    .toSorted((one, other) => one.localeCompare(other));
+}

--- a/scripts/packages/test/coverage.sh
+++ b/scripts/packages/test/coverage.sh
@@ -11,7 +11,9 @@ crate_name="${PWD##*/}"
 # Kept in step with the two workspace lists in `package.json` and
 # `scripts/coverage-missing.sh`, and with `EXCLUDED` in
 # `scripts/git/crate-coverage-runner.test.mjs`, which asserts this `case` starts
-# no cargo for a name it holds. This list holds crate directory names, so a
+# no cargo for a name it holds. `scripts/git/coverage-exclusions.test.mjs`
+# compares all four and names the one that disagrees. This list holds crate
+# directory names, so a
 # name can differ from the Cargo package name by more than the hyphens:
 # stylex-rs-compiler is the crate stylex_compiler_rs. Why each crate is off the
 # gate, and which rows a ticket removes, is in "Excluded from Coverage" in

--- a/scripts/packages/test/coverage.sh
+++ b/scripts/packages/test/coverage.sh
@@ -9,13 +9,15 @@ script_dir="$(cd -P "$(dirname "$0")" && pwd -P)"
 crate_name="${PWD##*/}"
 
 # Kept in step with the two workspace lists in `package.json` and
-# `scripts/coverage-missing.sh`. This list holds crate directory names, so a
+# `scripts/coverage-missing.sh`, and with `EXCLUDED` in
+# `scripts/git/crate-coverage-runner.test.mjs`, which asserts this `case` starts
+# no cargo for a name it holds. This list holds crate directory names, so a
 # name can differ from the Cargo package name by more than the hyphens:
 # stylex-rs-compiler is the crate stylex_compiler_rs. Why each crate is off the
 # gate, and which rows a ticket removes, is in "Excluded from Coverage" in
 # guidelines/STRUCTURE.md.
 case "$crate_name" in
-  stylex-evaluator|stylex-logs|stylex-rs-compiler|stylex-state|stylex-test-parser|stylex-transform)
+  stylex-evaluator|stylex-logs|stylex-rs-compiler|stylex-test-parser|stylex-transform)
     exit 0
     ;;
 esac

--- a/scripts/packages/test/coverage.sh
+++ b/scripts/packages/test/coverage.sh
@@ -9,12 +9,13 @@ script_dir="$(cd -P "$(dirname "$0")" && pwd -P)"
 crate_name="${PWD##*/}"
 
 # Kept in step with the two workspace lists in `package.json` and
-# `scripts/coverage-missing.sh`, and with `EXCLUDED` in
+# `scripts/coverage-missing.sh`, with `EXCLUDED` in
 # `scripts/git/crate-coverage-runner.test.mjs`, which asserts this `case` starts
-# no cargo for a name it holds. `scripts/git/coverage-exclusions.test.mjs`
-# compares all four and names the one that disagrees. This list holds crate
-# directory names, so a
-# name can differ from the Cargo package name by more than the hyphens:
+# no cargo for a name it holds, and with the rows under "Excluded from Coverage"
+# in `guidelines/STRUCTURE.md`. `scripts/git/coverage-exclusions.test.mjs`
+# compares all five and names the one that disagrees. This list holds crate
+# directory names, so a name can differ from the Cargo package name by more
+# than the hyphens:
 # stylex-rs-compiler is the crate stylex_compiler_rs. Why each crate is off the
 # gate, and which rows a ticket removes, is in "Excluded from Coverage" in
 # guidelines/STRUCTURE.md.


### PR DESCRIPTION
## Description

This pull request makes several improvements and refactorings to the `stylex-state` crate, focusing on code clarity, efficiency, and test coverage. The changes include significant refactoring of internal logic in `state_manager.rs`, simplification of code paths, and the addition of a comprehensive new test suite for binding queries.

**Refactoring and Simplification:**

* The logic for releasing a member in `CallExpressionState::release_member` was rewritten for clarity and efficiency, ensuring correct decrement and removal behavior without unnecessary lookups or allocations.
* The update logic for JSX spread attribute replacements was simplified to directly find and update the relevant entry, improving both readability and performance.
* The file suffix matching logic was rewritten to avoid unnecessary allocations and clarify intent, improving performance for import resolution.

**Bug Fixes and Correctness:**

* The logic for generating normalized file paths and short filenames was corrected to ensure consistent path normalization across platforms and to avoid panics or incorrect results.
* The logic for handling style injection and metadata was simplified, always setting up injection imports and removing unnecessary checks, which makes the code more robust and easier to maintain.

**Test Coverage:**

* A new test suite `binding_queries_test.rs` was added, providing thorough coverage of binding queries, including reassignment, mutation, scope handling, rebinding, and filename caching. This ensures correctness and guards against regressions in binding-related logic.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
