### PR TITLE
fix(unplugin): serve the placeholder stylesheet under Vite's bundled dev server

### DIFF
--- a/packages/unplugin/CONTEXT.md
+++ b/packages/unplugin/CONTEXT.md
@@ -53,6 +53,16 @@ development a third form applies: the served path, base-less, because that is
 what HMR payloads carry.
 _Avoid_: css url, link path, asset url
 
+**Served stylesheet**:
+The marker stylesheet under Vite's bundled dev server, where imported CSS is
+compiled into JavaScript and never requested on its own. The import is
+redirected to a runtime module that links the stylesheet from the dev server,
+and a middleware renders it from the file and the current rules on each
+request; one hot event asks the browser to refetch it. Only exists when
+`experimental.bundledDev` is on; every other Vite path keeps the stylesheet in
+the module graph.
+_Avoid_: virtual stylesheet, external CSS, link mode
+
 **Bundler source**:
 An asset's content object. webpack and Rspack each declare their own
 incompatible `Source`, so the shared injection helper is generic over it: under

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -361,34 +361,26 @@ The plugin replaces the marker with the generated StyleX CSS during the build.
 > such as PostCSS or Lightning CSS transpilation never run over them. Use
 > [`transformCss`](#transformcss) to run your own processing over the rules.
 > In development the rules are put into the stylesheet before the pipeline
-> runs, so there it sees everything: the regular dev server inlines them at the
-> marker, and Vite's bundled dev server serves the whole stylesheet itself, as
-> described next.
+> runs, so there it sees everything. The bundled mode below uses Vite's
+> built-in CSS preprocessing, not other plugins' CSS transform hooks.
 
 > [!NOTE]
 > **Vite's bundled dev server** (`experimental.bundledDev`)
 >
-> Bundled serve hands the module graph to Rolldown and turns every imported
-> stylesheet into JavaScript, so there is no CSS request for the plugin to
-> answer and no module graph to invalidate. In that mode the stylesheet that
-> carries the marker is taken out of the bundle: its import becomes a small
-> runtime module that links the stylesheet from the dev server at the same
-> position in the cascade, and the server renders it from the current file
-> contents and the current rules on every request. PostCSS, Lightning CSS and
-> `@import` run over it as usual. Edits to StyleX modules, to shared variables
-> and themes, to the stylesheet itself and to anything it `@import`s refetch
-> the stylesheet over HMR. Whether the edit itself stays a hot update is
-> Rolldown's call, as for any module: one with no accepting boundary, such as
-> a plain module outside a framework's refresh runtime, reloads the page.
+> The plugin serves the marker stylesheet with current rules and Vite's
+> built-in CSS preprocessing (PostCSS, Lightning CSS and `@import`). Edits to
+> StyleX modules, shared variables and themes, the stylesheet and its imports
+> refetch the stylesheet over HMR. Rolldown decides whether the module edit
+> itself is a hot update or a reload.
 >
-> Two things stay fixed for the life of the server: which stylesheets carry the
-> marker, since Rolldown resolves an import once, and where the stylesheet sits
-> in the cascade, so adding or removing the marker or the import needs a
-> restart. The marker has to sit in a plain stylesheet imported from
-> JavaScript: a CSS module or a stylesheet used as a build entry is left to
-> Rolldown and only gets the rules known when it is bundled. Assets referenced
-> with `url()` from the marker stylesheet are not rewritten or served in this
-> mode; keep them in `public/` or in a stylesheet without the marker.
+> Limits in this mode:
+>
+> - The marker must be in a plain stylesheet that JavaScript imports. A CSS
+>   module or a build entry gets only the rules known at bundle time.
+> - Restart after adding or removing a marker or its stylesheet import.
+> - Other Vite plugins' CSS transform hooks do not run over this stylesheet.
+> - `url()` references are not rewritten or served. Keep those assets in
+>   `public/` or in a stylesheet without the marker.
 
 > [!WARNING]
 > Farm does not support `useCssPlaceholder` yet. Its plugin adapter never

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -360,8 +360,35 @@ The plugin replaces the marker with the generated StyleX CSS during the build.
 > So the rules are minified along with everything else, but per-module steps
 > such as PostCSS or Lightning CSS transpilation never run over them. Use
 > [`transformCss`](#transformcss) to run your own processing over the rules.
-> The dev server has no bundle step and inlines the rules in the stylesheet, so
-> there the pipeline sees everything.
+> In development the rules are put into the stylesheet before the pipeline
+> runs, so there it sees everything: the regular dev server inlines them at the
+> marker, and Vite's bundled dev server serves the whole stylesheet itself, as
+> described next.
+
+> [!NOTE]
+> **Vite's bundled dev server** (`experimental.bundledDev`)
+>
+> Bundled serve hands the module graph to Rolldown and turns every imported
+> stylesheet into JavaScript, so there is no CSS request for the plugin to
+> answer and no module graph to invalidate. In that mode the stylesheet that
+> carries the marker is taken out of the bundle: its import becomes a small
+> runtime module that links the stylesheet from the dev server at the same
+> position in the cascade, and the server renders it from the current file
+> contents and the current rules on every request. PostCSS, Lightning CSS and
+> `@import` run over it as usual. Edits to StyleX modules, to shared variables
+> and themes, to the stylesheet itself and to anything it `@import`s refetch
+> the stylesheet over HMR. Whether the edit itself stays a hot update is
+> Rolldown's call, as for any module: one with no accepting boundary, such as
+> a plain module outside a framework's refresh runtime, reloads the page.
+>
+> Two things stay fixed for the life of the server: which stylesheets carry the
+> marker, since Rolldown resolves an import once, and where the stylesheet sits
+> in the cascade, so adding or removing the marker or the import needs a
+> restart. The marker has to sit in a plain stylesheet imported from
+> JavaScript: a CSS module or a stylesheet used as a build entry is left to
+> Rolldown and only gets the rules known when it is bundled. Assets referenced
+> with `url()` from the marker stylesheet are not rewritten or served in this
+> mode; keep them in `public/` or in a stylesheet without the marker.
 
 > [!WARNING]
 > Farm does not support `useCssPlaceholder` yet. Its plugin adapter never

--- a/packages/unplugin/__tests__/bundledDevCss.test.ts
+++ b/packages/unplugin/__tests__/bundledDevCss.test.ts
@@ -1,0 +1,370 @@
+import { once } from 'node:events';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer as createHttpServer } from 'node:http';
+import path from 'node:path';
+
+import { createLogger, createServer } from 'vite';
+import type { Connect } from 'vite';
+import { afterEach, expect, test, vi } from 'vitest';
+
+import createBundledDevCss from '../src/utils/bundledDevCss';
+
+const marker = '/* @stylex-placeholder */';
+const cleanups: (() => Promise<void>)[] = [];
+const errorHandler: Connect.ErrorHandleFunction = (error: unknown, _req, res, _next) => {
+  res.statusCode = 500;
+  res.end(error instanceof Error ? error.message : 'Unknown stylesheet error');
+};
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).toReversed()) await cleanup();
+});
+
+async function fixture(
+  files: Record<string, string>,
+  renderRules: (file: string) => Promise<string> = async () => '.generated{color:red}',
+  base = '/'
+) {
+  const root = await mkdtemp(path.join(process.cwd(), '.stylex-bundled-http-'));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  await Promise.all(
+    Object.entries(files).map(([file, source]) => writeFile(path.join(root, file), source))
+  );
+  const css = createBundledDevCss(marker, renderRules);
+  const logger = createLogger('silent');
+  const info = vi.spyOn(logger, 'info');
+  const server = await createServer({
+    root,
+    base,
+    configFile: false,
+    logLevel: 'silent',
+    customLogger: logger,
+    experimental: { bundledDev: true },
+    server: { middlewareMode: true },
+    plugins: [
+      {
+        name: 'bundled-css-fixture',
+        configResolved: config => css.configure(config),
+        configureServer(devServer) {
+          css.configureServer(devServer);
+          devServer.middlewares.use((_req, res) => {
+            res.statusCode = 418;
+            res.end('fixture fallthrough');
+          });
+          devServer.middlewares.use(errorHandler);
+        },
+      },
+    ],
+  });
+  cleanups.push(() => server.close());
+  const http = createHttpServer(server.middlewares);
+  http.listen(0, '127.0.0.1');
+  await once(http, 'listening');
+  cleanups.push(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        http.close(error => (error ? reject(error) : resolve()));
+        http.closeAllConnections();
+      })
+  );
+  const address = http.address();
+  if (!address || typeof address === 'string') throw new Error('Missing HTTP fixture address');
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  async function runtime(file: string): Promise<string> {
+    const resolved = await css.resolveId.call(
+      {
+        environment: { config: { isBundled: true } },
+        resolve: async id => ({ id: path.join(root, id) }),
+      },
+      file,
+      path.join(root, 'main.js')
+    );
+    if (!resolved) throw new Error(`Stylesheet was not redirected: ${file}`);
+    const code = css.load(resolved.id);
+    if (!code) throw new Error(`Runtime was not loaded: ${file}`);
+    return code;
+  }
+
+  async function href(file: string): Promise<string> {
+    const code = await runtime(file);
+    const match = /const href = (.+);/.exec(code);
+    if (!match) throw new Error('Runtime has no stylesheet href');
+    const value: unknown = JSON.parse(match[1]!);
+    if (typeof value !== 'string') throw new Error('Stylesheet href is not a string');
+    return value;
+  }
+
+  return { root, css, server, origin, runtime, href, info };
+}
+
+test('replaces imported dependencies when the served stylesheet changes', async () => {
+  const { root, server, origin, href } = await fixture({
+    'global.css': `@import './old.css';\n${marker}`,
+    'old.css': '.old{color:blue}',
+    'new.css': '.new{color:green}',
+  });
+  const url = origin + (await href('global.css'));
+  expect(await (await fetch(url)).text()).toContain('.old');
+  await writeFile(path.join(root, 'global.css'), `@import './new.css';\n${marker}`);
+  expect(await (await fetch(url)).text()).toContain('.new');
+
+  const send = vi.spyOn(server.ws, 'send');
+  server.watcher.emit('change', path.join(root, 'old.css'));
+  expect(send).not.toHaveBeenCalled();
+  server.watcher.emit('change', path.join(root, 'new.css'));
+  expect(send).toHaveBeenCalledWith({ type: 'custom', event: 'stylex:css-refresh' });
+});
+
+test('loads a runtime that links the served stylesheet and subscribes to refreshes', async () => {
+  const { runtime } = await fixture({ 'global.css': marker });
+  const code = await runtime('global.css');
+
+  expect(code).toContain('const href = "/global.css?stylex-css"');
+  expect(code).toContain("document.createElement('link')");
+  expect(code).toContain("link.rel = 'stylesheet'");
+  expect(code).toContain('hot.on("stylex:css-refresh", refresh)');
+  expect(code).toContain('hot.prune(');
+});
+
+test('bundles the stylesheet runtime instead of the authored marker stylesheet', async () => {
+  const root = await mkdtemp(path.join(process.cwd(), '.stylex-bundled-import-'));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  await Promise.all([
+    writeFile(
+      path.join(root, 'index.html'),
+      '<html><body><script type="module" src="/main.js"></script></body></html>'
+    ),
+    writeFile(path.join(root, 'main.js'), "import './global.css';\nconsole.log('fixture ready');"),
+    writeFile(path.join(root, 'global.css'), `.authored-only{color:purple}\n${marker}`),
+  ]);
+  const css = createBundledDevCss(marker, async () => '.generated{color:red}');
+  const server = await createServer({
+    root,
+    configFile: false,
+    logLevel: 'silent',
+    experimental: { bundledDev: true },
+    server: { host: '127.0.0.1', port: 0 },
+    plugins: [
+      {
+        name: 'bundled-css-import-fixture',
+        configResolved: config => css.configure(config),
+        configureServer: devServer => css.configureServer(devServer),
+        resolveId: {
+          order: 'pre',
+          handler(id, importer) {
+            return css.resolveId.call(this, id, importer);
+          },
+        },
+        load: id => css.load(id),
+      },
+    ],
+  });
+  cleanups.push(() => server.close());
+  await server.listen();
+  const address = server.httpServer?.address();
+  if (!address || typeof address === 'string') throw new Error('Missing bundled server address');
+  const origin = `http://127.0.0.1:${address.port}`;
+  let html = '';
+  await vi.waitFor(
+    async () => {
+      html = await (await fetch(origin)).text();
+      expect(html).not.toContain('__vite_is_fallback_page__');
+      expect(html).toContain('<script');
+    },
+    { timeout: 5000 }
+  );
+  const scripts = [...html.matchAll(/<script[^>]+src="([^"]+)"/g)].map(match => match[1]!);
+  expect(scripts.length).toBeGreaterThan(0);
+  const bundle = (
+    await Promise.all(scripts.map(async src => (await fetch(new URL(src, origin))).text()))
+  ).join('\n');
+
+  expect(bundle).toContain('/global.css?stylex-css');
+  expect(bundle).toContain('stylex:css-refresh');
+  expect(bundle).not.toContain('.authored-only');
+  expect(bundle).not.toContain(marker);
+  const stylesheet = await (await fetch(`${origin}/global.css?stylex-css`)).text();
+  expect(stylesheet).toContain('.authored-only');
+  expect(stylesheet).toContain('.generated{color:red}');
+});
+
+test('serves CSS with no-store, ETag, HEAD and conditional GET support', async () => {
+  const { origin, href } = await fixture({ 'global.css': `.before{margin:0}\n${marker}` });
+  const url = origin + (await href('global.css'));
+  const response = await fetch(url);
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get('content-type')).toContain('text/css');
+  expect(response.headers.get('cache-control')).toBe('no-store');
+  expect(await response.text()).toContain('.generated{color:red}');
+  const etag = response.headers.get('etag');
+  expect(etag).toBeTruthy();
+
+  const head = await fetch(url, { method: 'HEAD' });
+  expect(head.status).toBe(200);
+  expect(head.headers.get('etag')).toBe(etag);
+  expect(await head.text()).toBe('');
+
+  const unchanged = await fetch(url, { headers: { 'If-None-Match': etag! } });
+  expect(unchanged.status).toBe(304);
+  expect(await unchanged.text()).toBe('');
+});
+
+test('serves encoded stylesheet paths under a base and after a parent router strips it', async () => {
+  const { origin, href } = await fixture({ 'global #1.css': marker }, undefined, '/app/');
+  const stylesheet = await href('global #1.css');
+
+  expect(stylesheet).toBe('/app/global%20%231.css?stylex-css');
+  expect(await (await fetch(origin + stylesheet)).text()).toContain('.generated{color:red}');
+  // Connect parent routers pass a URL with the mount prefix already removed.
+  expect(await (await fetch(origin + stylesheet.slice('/app'.length))).text()).toContain(
+    '.generated{color:red}'
+  );
+});
+
+test('passes requests without the stylesheet query or a known path to the next middleware', async () => {
+  const { origin, href } = await fixture({ 'global.css': marker });
+  await href('global.css');
+
+  for (const pathname of ['/global.css', '/missing.css?stylex-css']) {
+    const response = await fetch(origin + pathname);
+    expect(response.status).toBe(418);
+    expect(await response.text()).toBe('fixture fallthrough');
+  }
+});
+
+test('forwards asynchronous rendering errors to Connect error middleware', async () => {
+  const { origin, href } = await fixture({ 'global.css': marker }, async () => {
+    throw new Error('Rule rendering failed');
+  });
+  const response = await fetch(origin + (await href('global.css')));
+
+  expect(response.status).toBe(500);
+  expect(await response.text()).toBe('Rule rendering failed');
+});
+
+test('rereads the stylesheet and current rules on every request without watcher invalidation', async () => {
+  let rules = '.generated{color:red}';
+  const { root, origin, href } = await fixture(
+    { 'global.css': `.old{margin:0}\n${marker}` },
+    async () => rules
+  );
+  const url = origin + (await href('global.css'));
+  const original = await (await fetch(url)).text();
+  expect(original).toContain('.old');
+  expect(original).toContain('color:red');
+
+  rules = '.generated{color:blue}';
+  await writeFile(path.join(root, 'global.css'), `.new{margin:1px}\n${marker}`);
+  const changed = await (await fetch(url)).text();
+  expect(changed).toContain('.new');
+  expect(changed).toContain('color:blue');
+  expect(changed).not.toContain('.old');
+  expect(changed).not.toContain('color:red');
+});
+
+test('rewatches served stylesheets on restart after their marker cache was invalidated', async () => {
+  const { root, server, href } = await fixture({ 'global.css': marker });
+  await href('global.css');
+  server.watcher.emit('change', path.join(root, 'global.css'));
+
+  await server.restart();
+
+  await vi.waitFor(() => {
+    expect(server.watcher.getWatched()[root]).toContain('global.css');
+  });
+});
+
+test('keeps a shared import active until no served stylesheet imports it', async () => {
+  const { root, server, origin, href } = await fixture({
+    'first.css': `@import './shared.css';\n${marker}`,
+    'second.css': `@import './shared.css';\n${marker}`,
+    'shared.css': '.shared{color:blue}',
+  });
+  const first = origin + (await href('first.css'));
+  const second = origin + (await href('second.css'));
+  await (await fetch(first)).text();
+  await (await fetch(second)).text();
+  await writeFile(path.join(root, 'first.css'), marker);
+  await (await fetch(first)).text();
+
+  const send = vi.spyOn(server.ws, 'send');
+  server.watcher.emit('change', path.join(root, 'shared.css'));
+  expect(send).toHaveBeenCalledWith({ type: 'custom', event: 'stylex:css-refresh' });
+
+  await writeFile(path.join(root, 'second.css'), marker);
+  await (await fetch(second)).text();
+  send.mockClear();
+  server.watcher.emit('change', path.join(root, 'shared.css'));
+  expect(send).not.toHaveBeenCalled();
+});
+
+test('refreshes when an active imported file is deleted and recreated', async () => {
+  const { root, server, origin, href } = await fixture({
+    'global.css': `@import './shared.css';\n${marker}`,
+    'shared.css': '.shared{color:blue}',
+  });
+  await (await fetch(origin + (await href('global.css')))).text();
+
+  const send = vi.spyOn(server.ws, 'send');
+  for (const event of ['unlink', 'add']) {
+    send.mockClear();
+    server.watcher.emit(event, path.join(root, 'shared.css'));
+    expect(send).toHaveBeenCalledWith({ type: 'custom', event: 'stylex:css-refresh' });
+  }
+});
+
+test('renders concurrent requests independently without restoring stale import dependencies', async () => {
+  const started = Promise.withResolvers<undefined>();
+  const release = Promise.withResolvers<string>();
+  let firstRequest = true;
+  const { root, server, origin, href } = await fixture(
+    {
+      'global.css': `@import './old.css';\n${marker}`,
+      'old.css': '.old{color:blue}',
+      'new.css': '.new{color:green}',
+    },
+    async () => {
+      if (!firstRequest) return '.generated{color:green}';
+      firstRequest = false;
+      started.resolve(undefined);
+      return release.promise;
+    }
+  );
+  const url = origin + (await href('global.css'));
+  const earlier = fetch(url);
+
+  try {
+    await started.promise;
+    await writeFile(path.join(root, 'global.css'), `@import './new.css';\n${marker}`);
+    // The earlier request remains blocked; a fresh request must not share its render.
+    const latest = await fetch(url, { signal: AbortSignal.timeout(2000) });
+    const body = await latest.text();
+    expect(body).toContain('.new');
+    expect(body).toContain('.generated{color:green}');
+  } finally {
+    release.resolve('.generated{color:red}');
+  }
+  expect(await (await earlier).text()).toContain('.generated{color:red}');
+
+  const send = vi.spyOn(server.ws, 'send');
+  server.watcher.emit('change', path.join(root, 'old.css'));
+  expect(send).not.toHaveBeenCalled();
+  server.watcher.emit('change', path.join(root, 'new.css'));
+  expect(send).toHaveBeenCalledWith({ type: 'custom', event: 'stylex:css-refresh' });
+});
+
+test('logs bundled mode and each newly served stylesheet once', async () => {
+  const { info, href } = await fixture({ 'first.css': marker, 'second.css': marker });
+  expect(info).toHaveBeenCalledWith(expect.stringContaining('bundled dev server'));
+  info.mockClear();
+
+  await href('first.css');
+  await href('first.css');
+  await href('second.css');
+
+  expect(info).toHaveBeenCalledTimes(2);
+  expect(info).toHaveBeenCalledWith(expect.stringContaining('serving /first.css'));
+  expect(info).toHaveBeenCalledWith(expect.stringContaining('serving /second.css'));
+});

--- a/packages/unplugin/__tests__/bundledDevCssResolve.test.ts
+++ b/packages/unplugin/__tests__/bundledDevCssResolve.test.ts
@@ -1,0 +1,99 @@
+import * as fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createServer, resolveConfig } from 'vite';
+import { afterEach, expect, test, vi } from 'vitest';
+
+import createBundledDevCss from '../src/utils/bundledDevCss';
+
+vi.mock('node:fs/promises', { spy: true });
+
+afterEach(() => vi.restoreAllMocks());
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'stylex-marker-resolve-'));
+  const file = path.join(root, 'style.css');
+  await fs.writeFile(file, '@stylex;');
+  const server = await createServer({
+    root,
+    configFile: false,
+    logLevel: 'silent',
+    server: { middlewareMode: true, watch: null },
+  });
+  const helper = createBundledDevCss('@stylex;', async () => '');
+  helper.configure(
+    await resolveConfig(
+      {
+        root,
+        configFile: false,
+        logLevel: 'silent',
+        experimental: { bundledDev: true },
+      },
+      'serve'
+    )
+  );
+  helper.configureServer(server);
+  return {
+    file,
+    server,
+    resolve: () =>
+      helper.resolveId.call(
+        {
+          environment: { config: { isBundled: true } },
+          resolve: async () => ({ id: file }),
+        },
+        './style.css',
+        path.join(root, 'main.js')
+      ),
+    async close() {
+      await server.close();
+      await fs.rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+test('shares marker detection across concurrent imports of one stylesheet', async () => {
+  const app = await fixture();
+  const read = vi.spyOn(fs, 'readFile');
+  const watch = vi.spyOn(app.server.watcher, 'add');
+  try {
+    const results = await Promise.all([app.resolve(), app.resolve(), app.resolve()]);
+    expect(results[0]).not.toBeNull();
+    expect(results).toEqual([results[0], results[0], results[0]]);
+    expect(read.mock.calls.filter(([file]) => file === app.file)).toHaveLength(1);
+    expect(watch.mock.calls.filter(([file]) => file === app.file)).toHaveLength(1);
+  } finally {
+    await app.close();
+  }
+});
+
+test.each(['change', 'unlink'])('does not cache a marker read invalidated by %s', async event => {
+  const app = await fixture();
+  const stale = Promise.withResolvers<string>();
+  const read = vi.spyOn(fs, 'readFile').mockReturnValueOnce(stale.promise);
+  try {
+    const first = app.resolve();
+    await vi.waitFor(() => expect(read).toHaveBeenCalledWith(app.file, 'utf8'));
+    app.server.watcher.emit(event, app.file);
+    await fs.writeFile(app.file, 'body { margin: 0; }');
+    expect(await app.resolve()).toBeNull();
+    stale.resolve('@stylex;');
+    expect(await first).toBeNull();
+    expect(await app.resolve()).toBeNull();
+  } finally {
+    stale.resolve('@stylex;');
+    await app.close();
+  }
+});
+
+test('retries marker detection after a failed read', async () => {
+  const app = await fixture();
+  vi.spyOn(fs, 'readFile').mockRejectedValueOnce(new Error('temporarily unavailable'));
+  try {
+    expect(await app.resolve()).toBeNull();
+    expect(await app.resolve()).not.toBeNull();
+  } finally {
+    await app.close();
+  }
+});

--- a/packages/unplugin/__tests__/vite.test.ts
+++ b/packages/unplugin/__tests__/vite.test.ts
@@ -443,6 +443,37 @@ async function measureFailedRefreshRetries(): Promise<{
 }
 
 describe('Vite', () => {
+  test.each(['direct', 'direct&v=1', 'v=1&direct'])(
+    'injects rules into a linked stylesheet with query %s',
+    async query => {
+      const server = await createPlaceholderDevServer('.stylex-vite-direct-');
+      try {
+        await server.transformRequest('/main.js');
+        const result = await server.transformRequest(`/global.css?${query}`);
+        expect(result?.code).toContain('color:red');
+        expect(result?.code).not.toContain(placeholder);
+      } finally {
+        await server.close();
+      }
+    }
+  );
+
+  test.each(['inline', 'url', 'raw', 'direct&inline', 'url&direct', 'direct&raw', 'direct=value'])(
+    'does not inject rules into a stylesheet with alternate query %s',
+    async query => {
+      const server = await createPlaceholderDevServer('.stylex-vite-query-');
+      try {
+        await server.transformRequest('/main.js');
+        const result = await server.transformRequest(`/global.css?${query}`);
+        expect(result).not.toBeNull();
+        expect(result?.code).not.toContain('color:red');
+        expect(result?.code.includes(placeholder)).toBe(!query.includes('url'));
+      } finally {
+        await server.close();
+      }
+    }
+  );
+
   test('resolves imported defineConsts at-rules before transforming placeholder CSS', async () => {
     const transformCss = vi.fn<(css: string) => string>(rejectUnresolvedAtRules);
 

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -60,6 +60,8 @@ function shouldTransformStyleXFile(id: string, normalizedOptions: NormalizedOpti
 const { writeFile, mkdir, readFile, readdir } = promises;
 
 const PLUGIN_NAME = 'unplugin-stylex-rs';
+const DIRECT_REQUEST_RE = /(?:\?|&)direct(?:&|$)/;
+const SPECIAL_CSS_QUERY_RE = /(?:\?|&)(?:inline|url|raw)(?:[=&]|$)/;
 
 /**
  * How many times in a row a dev CSS refresh may fail before the plugin stops
@@ -754,10 +756,15 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         // Only handle CSS files with useCssPlaceholder
         if (!normalizedOptions.useCssPlaceholder) return null;
         // A stylesheet the browser fetched through `<link>` arrives with the
-        // `?direct` query the dev server adds; every other query (`?inline`,
-        // `?url`, `?raw`) asks for something other than the stylesheet.
-        const [cssFile = id, query] = id.split('?');
-        if (!cssFile.endsWith('.css') || (query !== undefined && query !== 'direct')) {
+        // `direct` flag Vite adds alongside any existing cache-busting query.
+        // Alternate imports (`inline`, `url`, `raw`) keep their own semantics.
+        const queryStart = id.indexOf('?');
+        const cssFile = queryStart === -1 ? id : id.slice(0, queryStart);
+        if (
+          !cssFile.endsWith('.css') ||
+          SPECIAL_CSS_QUERY_RE.test(id) ||
+          (queryStart !== -1 && !DIRECT_REQUEST_RE.test(id))
+        ) {
           return null;
         }
 

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -12,6 +12,7 @@ import type { Connect } from 'vite';
 import type { HotPayload, ModuleNode, ViteDevServer } from 'vite';
 
 import type { UnpluginStylexRSOptions } from './types';
+import createBundledDevCss from './utils/bundledDevCss';
 import {
   BUILD_CSS_PLACEHOLDER,
   injectIntoCssTargets,
@@ -159,10 +160,12 @@ async function invalidateAndCollectCssModules(
     return cssModules;
   }
 
-  // `mod.id` is `string | null`, so the guard both filters non-CSS modules and
-  // narrows the type for the read below.
+  // `mod.file` is the id without its query, so a stylesheet the browser
+  // fetched through `<link>` (registered as `style.css?direct`) is matched
+  // along with one imported from JavaScript. It is `string | null`, so the
+  // guard both filters non-CSS modules and narrows the type for the read.
   const allCssModules = Array.from(server.moduleGraph.urlToModuleMap.values()).filter(
-    mod => mod.id?.endsWith('.css') ?? false
+    mod => mod.file?.endsWith('.css') ?? false
   );
 
   // Check each CSS module for the placeholder
@@ -171,17 +174,17 @@ async function invalidateAndCollectCssModules(
   await Promise.all(
     allCssModules.map(async mod => {
       try {
-        // Skip modules without a valid id
-        if (!mod.id) return;
+        // Skip modules without a valid file
+        if (!mod.file) return;
 
         // Whether a stylesheet holds the marker only changes when the file
         // does, and the watcher already reports that, so this is read once
         // rather than on every refresh.
-        let holdsMarker = carriesMarker.get(mod.id);
+        let holdsMarker = carriesMarker.get(mod.file);
 
         if (holdsMarker === undefined) {
-          holdsMarker = (await promises.readFile(mod.id, 'utf8')).includes(placeholder);
-          carriesMarker.set(mod.id, holdsMarker);
+          holdsMarker = (await promises.readFile(mod.file, 'utf8')).includes(placeholder);
+          carriesMarker.set(mod.file, holdsMarker);
         }
 
         if (holdsMarker) {
@@ -190,7 +193,7 @@ async function invalidateAndCollectCssModules(
         }
       } catch (e) {
         // Log read errors for debugging HMR issues
-        console.debug(`[stylex-unplugin] Failed to read CSS file "${mod.id}":`, e);
+        console.debug(`[stylex-unplugin] Failed to read CSS file "${mod.file}":`, e);
       }
     })
   );
@@ -413,6 +416,22 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
   // same process (e.g. Next.js client/server, or several Vite dev servers)
   // don't clobber each other's dev-server reference or invalidation flag.
   let viteDevServer: ViteDevServer | null = null;
+  // The rules as the dev server puts them at the marker. Rules that still
+  // carry an unresolved `defineConsts` at-rule cannot be served; a comment
+  // stands in until a later transform resolves them and refreshes the sheet.
+  async function renderDevRules(collectedCSS: string | null | undefined, id: string) {
+    if (!collectedCSS?.trim() || hasUnresolvedDefineConstAtRule(collectedCSS)) {
+      return '/* StyleX styles will load after transformation */';
+    }
+    return transformStyleXCSS(collectedCSS, id, normalizedOptions);
+  }
+
+  // Vite's bundled dev server, where the marker stylesheet is served by the
+  // plugin rather than bundled. Renders the rules collected so far for one
+  // stylesheet; no-op everywhere else.
+  const bundledDevCss = createBundledDevCss(normalizedOptions.useCssPlaceholder, file =>
+    renderDevRules(getStyleXRules(stylexRules, transformedOptions), file)
+  );
   // Counts the transforms that contributed StyleX rules. A refresh is owed
   // whenever this moves past the revision the last one covered, which is what
   // makes late modules -- anything behind a dynamic import -- reach the browser.
@@ -449,24 +468,38 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
       // `unhandledRejection` and take the dev server down over a failed CSS
       // refresh. `void` alone would silence the lint without handling anything.
       void (async () => {
-        // Find all CSS modules that actually contain the placeholder
-        const cssModules = await invalidateAndCollectCssModules(
-          server,
-          normalizedOptions.useCssPlaceholder,
-          cssMarkerCache
-        );
+        if (bundledDevCss.enabled) {
+          // No module graph to invalidate under bundled serve: the browser is
+          // told to refetch the served stylesheet instead.
+          bundledDevCss.refresh();
+        } else {
+          // Find all CSS modules that actually contain the placeholder
+          const cssModules = await invalidateAndCollectCssModules(
+            server,
+            normalizedOptions.useCssPlaceholder,
+            cssMarkerCache
+          );
 
-        // Send update to trigger HMR
-        if (cssModules.length > 0) {
-          server.ws.send({
-            type: 'update',
-            updates: cssModules.map(mod => ({
-              type: 'css-update' as const,
-              acceptedPath: mod.url,
-              path: mod.url,
-              timestamp: Date.now(),
-            })),
-          });
+          // Send update to trigger HMR. Both kinds go out for each stylesheet:
+          // one reached through `<link>` is swapped in place by a `css-update`,
+          // while one imported from JavaScript lives in a `<style>` element
+          // that only a `js-update` of its module re-injects. The graph does
+          // not tell the two apart (a linked stylesheet is registered as a
+          // `js` node too), and the client ignores the kind with no target.
+          if (cssModules.length > 0) {
+            const timestamp = Date.now();
+            server.ws.send({
+              type: 'update',
+              updates: cssModules.flatMap(mod =>
+                (['css-update', 'js-update'] as const).map(type => ({
+                  type,
+                  acceptedPath: mod.url,
+                  path: mod.url,
+                  timestamp,
+                }))
+              ),
+            });
+          }
         }
 
         // Only now is the revision genuinely covered. Recording it before the
@@ -513,6 +546,9 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
   const placeholderGenerateBundle = {
     order: 'post' as const,
     async handler(this: PlaceholderBundleContext, _options: unknown, bundle: OutputBundleLike) {
+      // Bundled serve emits no stylesheet asset to inject into; the marker
+      // stylesheet is served outside the bundle there.
+      if (bundledDevCss.enabled) return;
       await injectPlaceholderIntoBundle(
         this,
         bundle,
@@ -679,6 +715,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
       },
 
       configResolved(config) {
+        bundledDevCss.configure(config);
         // An SSR bundle emits no stylesheet of its own, so a missing injection
         // target there is expected rather than a misconfiguration.
         viteIsSsrBuild = !!config.build.ssr;
@@ -695,16 +732,39 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         config.optimizeDeps.exclude.push('@stylexjs/open-props');
       },
 
+      // `pre` because Vite's own resolver answers relative imports first in
+      // the default order, and the marker stylesheet has to be claimed before
+      // that under bundled serve.
+      resolveId: {
+        order: 'pre',
+        handler(id, importer) {
+          // Gated synchronously: this runs for every import in every mode.
+          if (!bundledDevCss.enabled) return null;
+          return bundledDevCss.resolveId.call(this, id, importer);
+        },
+      },
+
       // Load CSS files to replace placeholder before Vite's CSS processing
       async load(id) {
+        // The runtime that links a served stylesheet under bundled serve. Any
+        // other id, including the stylesheet as another environment sees it,
+        // takes the regular path below.
+        const runtime = bundledDevCss.load(id);
+        if (runtime) return runtime;
         // Only handle CSS files with useCssPlaceholder
         if (!normalizedOptions.useCssPlaceholder) return null;
-        if (!id.endsWith('.css')) return null;
+        // A stylesheet the browser fetched through `<link>` arrives with the
+        // `?direct` query the dev server adds; every other query (`?inline`,
+        // `?url`, `?raw`) asks for something other than the stylesheet.
+        const [cssFile = id, query] = id.split('?');
+        if (!cssFile.endsWith('.css') || (query !== undefined && query !== 'direct')) {
+          return null;
+        }
 
         // Read the CSS file
         let cssContent: string;
         try {
-          cssContent = await promises.readFile(id, 'utf-8');
+          cssContent = await promises.readFile(cssFile, 'utf-8');
         } catch {
           return null;
         }
@@ -735,15 +795,11 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
           collectedCSS = getStyleXRules(stylexRules, transformedOptions);
         }
 
-        // Determine replacement CSS based on whether usable CSS exists yet
-        let replacementCSS: string;
-        if (!collectedCSS?.trim() || hasUnresolvedDefineConstAtRule(collectedCSS)) {
-          replacementCSS = '/* StyleX styles will load after transformation */';
-        } else {
-          replacementCSS = await transformStyleXCSS(collectedCSS, id, normalizedOptions);
-        }
-
-        return replaceFirstMarker(cssContent, normalizedOptions.useCssPlaceholder, replacementCSS);
+        return replaceFirstMarker(
+          cssContent,
+          normalizedOptions.useCssPlaceholder,
+          await renderDevRules(collectedCSS, id)
+        );
       },
 
       generateBundle: placeholderGenerateBundle,
@@ -788,6 +844,8 @@ export const unpluginFactory: UnpluginFactory<UnpluginStylexRSOptions | undefine
         refreshedRulesRevision = rulesRevision;
         cssRefreshFailures = 0;
         cssMarkerCache.clear();
+
+        bundledDevCss.configureServer(server);
 
         // Editing a stylesheet is the only thing that can add or remove its
         // marker, so the cached answer is dropped for exactly that file.

--- a/packages/unplugin/src/utils/bundledDevCss.ts
+++ b/packages/unplugin/src/utils/bundledDevCss.ts
@@ -1,0 +1,317 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { Connect, ResolvedConfig, ViteDevServer } from 'vite';
+
+import { replaceFirstMarker } from './cssPlaceholder';
+
+// The runtime id ends in `.js` so that no CSS pipeline, Vite's own included,
+// claims the module by its extension.
+const RUNTIME_ID_PREFIX = '\0stylex:stylesheet:';
+const RUNTIME_ID_SUFFIX = '.js';
+// The query that tells the served stylesheet apart from any other request
+// for the same path, and the hot event that asks the browser to refetch it.
+const STYLESHEET_QUERY = 'stylex-css';
+const REFRESH_EVENT = 'stylex:css-refresh';
+
+// A CSS module exports its class map; turning one into the runtime would
+// leave that import undefined.
+const CSS_MODULE_RE = /\.module\.css$/;
+
+interface ResolveContext {
+  /** Vite's per-environment context; absent on hosts without environments. */
+  environment?: { config: { isBundled: boolean } };
+  resolve: (
+    id: string,
+    importer?: string,
+    options?: { skipSelf: boolean }
+  ) => Promise<{ id: string } | null>;
+}
+
+interface ResolvedRuntime {
+  id: string;
+  moduleSideEffects: true;
+}
+
+export interface BundledDevCss {
+  /** Whether the current Vite config is a bundled dev server with a marker. */
+  readonly enabled: boolean;
+  configure: (config: ResolvedConfig) => void;
+  configureServer: (server: ViteDevServer) => void;
+  resolveId: (
+    this: ResolveContext,
+    id: string,
+    importer: string | undefined
+  ) => Promise<ResolvedRuntime | null>;
+  load: (id: string) => string | null;
+  /** Asks every connected browser to refetch the stylesheet. */
+  refresh: () => void;
+}
+
+// What Vite's `normalizePath` does: the watcher reports native paths, while
+// resolver ids and the CSS pipeline's dependency list use forward slashes.
+function normalizePath(file: string): string {
+  return path.sep === '\\' ? file.replaceAll('\\', '/') : file;
+}
+
+// The browser side. Runs once per page: it adds one `<link>` where the
+// stylesheet import sits in module order, so the cascade keeps the position
+// the import gave it, and swaps that link for a fresh one on every refresh
+// event. A swap only takes effect once the new sheet has loaded, and only if
+// no newer swap started meanwhile, so a slow fetch cannot roll back a fast one.
+function runtimeModule(href: string): string {
+  return `
+const href = ${JSON.stringify(href)};
+const hot = import.meta.hot;
+let link = hot?.data.link;
+let sequence = 0;
+if (!link) {
+  link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  document.head.appendChild(link);
+}
+function refresh() {
+  const current = ++sequence;
+  const next = link.cloneNode();
+  next.href = href + '&v=' + current + '-' + Date.now();
+  next.onload = () => {
+    if (current !== sequence) {
+      next.remove();
+      return;
+    }
+    link.remove();
+    link = next;
+  };
+  next.onerror = () => next.remove();
+  link.after(next);
+}
+// Without a hot context the link stays as a plain stylesheet.
+if (hot) {
+  hot.on(${JSON.stringify(REFRESH_EVENT)}, refresh);
+  hot.accept();
+  hot.dispose(() => {
+    sequence += 1;
+    hot.data.link = link;
+    hot.off(${JSON.stringify(REFRESH_EVENT)}, refresh);
+  });
+  hot.prune(() => link.remove());
+}
+`;
+}
+
+/**
+ * Serves the placeholder stylesheet under Vite's bundled dev server, where
+ * imported CSS is compiled into JavaScript and never requested on its own.
+ * The import of a stylesheet that carries the marker resolves to a runtime
+ * module that links the stylesheet from the dev server instead, a middleware
+ * renders it from the file and the rules on every request, and one hot event
+ * asks the browser to refetch it. The README's `useCssPlaceholder` section
+ * has the rationale and the limits.
+ *
+ * Only the bundled client environment is redirected; any other environment
+ * that imports the stylesheet keeps the regular path. `renderRules` produces
+ * the transformed rules to put at the marker; Vite's CSS pipeline then runs
+ * over the whole stylesheet, without a url resolver, so `url()` references
+ * are left as written.
+ */
+export default function createBundledDevCss(
+  marker: string | false,
+  renderRules: (file: string) => Promise<string>
+): BundledDevCss {
+  let config: ResolvedConfig | null = null;
+  let server: ViteDevServer | null = null;
+  let enabled = false;
+
+  // Whether a stylesheet carries the marker, by absolute path. Both answers
+  // are kept and an edit drops the entry, so a file is read once per version.
+  const carriesMarker = new Map<string, boolean>();
+  // Served marker files by absolute path, with the href each is served under,
+  // and the reverse lookup the middleware needs.
+  const hrefByFile = new Map<string, string>();
+  const fileByPathname = new Map<string, string>();
+  // Files the stylesheets `@import`, as Vite's CSS pipeline reports them.
+  const imported = new Set<string>();
+
+  function refresh(): void {
+    server?.ws.send({ type: 'custom', event: REFRESH_EVENT });
+  }
+
+  // The dev server watcher does not cover the project root under bundled
+  // serve, Rolldown watches the graph instead, so every file whose contents
+  // matter here is added by hand. Rolldown never sees them: the stylesheet
+  // is not in its graph, which is the point.
+  function watchImported(file: string): void {
+    if (imported.has(file)) return;
+    imported.add(file);
+    server?.watcher.add(file);
+  }
+
+  // A deleted file loses what was learned from its contents. Its href stays:
+  // the bundle keeps linking it, and a file written back under the same
+  // path is served again as if nothing happened.
+  function forget(file: string): void {
+    carriesMarker.delete(file);
+    imported.delete(file);
+  }
+
+  function hrefFor(root: string, base: string, file: string): string {
+    const relative = normalizePath(path.relative(root, file));
+    // Outside the root the conventional `/@fs/` form is kept as is, so the
+    // href reads like any other Vite URL for the same file.
+    const served = relative.startsWith('../') ? `@fs/${normalizePath(file)}` : relative;
+    // Per segment, so `#` and `?` in a file name cannot cut the href short;
+    // the `@fs/` prefix itself is kept literal.
+    return (
+      base +
+      served
+        .split('/')
+        .map((segment, index) =>
+          index === 0 && segment === '@fs' ? segment : encodeURIComponent(segment)
+        )
+        .join('/')
+    );
+  }
+
+  function serveStylesheet(
+    req: Parameters<Connect.NextHandleFunction>[0],
+    res: Parameters<Connect.NextHandleFunction>[1],
+    next: Connect.NextFunction
+  ): void {
+    // The base is still on the URL here: this runs ahead of Vite's own base
+    // middleware, and the hrefs were built with the base for that reason.
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    // A parent router in middleware mode strips its mount path before this
+    // runs, so an href is also matched by its tail.
+    const file =
+      fileByPathname.get(url.pathname) ??
+      [...fileByPathname].find(([href]) => href.endsWith(url.pathname))?.[1];
+    if (!file || !config || !marker || !url.searchParams.has(STYLESHEET_QUERY)) {
+      next();
+      return;
+    }
+
+    const resolvedConfig = config;
+    const resolvedMarker = marker;
+
+    // Connect does not forward async rejections, hence the explicit catch.
+    void (async () => {
+      // Vite is imported on demand: this module is bundled into the chunk
+      // every host entry shares, and a static import would make webpack,
+      // Rspack and esbuild users load Vite (ESM-only since Vite 8) at plugin
+      // load. The module loader caches the namespace after the first call.
+      const [{ preprocessCSS, send }, source, rules] = await Promise.all([
+        import('vite'),
+        readFile(file, 'utf8'),
+        renderRules(file),
+      ]);
+      const stylesheet = replaceFirstMarker(source, resolvedMarker, rules);
+      const result = await preprocessCSS(stylesheet, file, resolvedConfig);
+      for (const dependency of result.deps ?? []) watchImported(normalizePath(dependency));
+
+      // Vite's own responder: content type, ETag with `304` on a match, and
+      // `HEAD` handling.
+      send(req, res, result.code, 'css', { cacheControl: 'no-store' });
+      // `next` is Connect's error handler here, not a completion callback:
+      // forwarding the rejection to it is the documented middleware contract.
+      // oxlint-disable-next-line promise/no-callback-in-promise
+    })().catch(next);
+  }
+
+  return {
+    get enabled() {
+      return enabled;
+    },
+
+    configure(resolved) {
+      config = resolved;
+      // The client environment's own flag rather than the experimental
+      // option that seeds it: `environments.client.isBundled` can turn
+      // bundled serve on or off independently. Optional all the way down,
+      // since `environments` only exists from Vite 6.
+      enabled =
+        !!marker &&
+        resolved.command === 'serve' &&
+        resolved.environments?.client?.isBundled === true;
+    },
+
+    configureServer(devServer) {
+      if (!enabled) return;
+      server = devServer;
+
+      // A restarted server brings a fresh watcher, so everything learned on
+      // the previous one is registered again.
+      const known = [...carriesMarker.keys(), ...imported];
+      if (known.length > 0) devServer.watcher.add(known);
+
+      devServer.watcher.on('change', changed => {
+        const file = normalizePath(changed);
+        // An edit is the one thing that can change whether a file carries
+        // the marker, so the cached answer goes; a served file is refetched.
+        carriesMarker.delete(file);
+        if (hrefByFile.has(file) || imported.has(file)) refresh();
+      });
+      devServer.watcher.on('unlink', changed => forget(normalizePath(changed)));
+      devServer.watcher.on('add', added => {
+        if (hrefByFile.has(normalizePath(added))) refresh();
+      });
+      devServer.middlewares.use(serveStylesheet);
+    },
+
+    // Redirects the import of a stylesheet that carries the marker to the
+    // runtime module. Stylesheets reached through `@import` stay with Vite:
+    // they end up inlined into the importing stylesheet either way. So does a
+    // stylesheet used as an entry, which has no module to link it from.
+    async resolveId(id, importer) {
+      if (
+        !enabled ||
+        !marker ||
+        !config ||
+        !importer ||
+        !id.endsWith('.css') ||
+        CSS_MODULE_RE.test(id) ||
+        importer.endsWith('.css') ||
+        !this.environment?.config.isBundled
+      ) {
+        return null;
+      }
+
+      const resolved = await this.resolve(id, importer, { skipSelf: true });
+      if (!resolved || !path.isAbsolute(resolved.id)) return null;
+
+      const file = normalizePath(resolved.id);
+      let holdsMarker = carriesMarker.get(file);
+      if (holdsMarker === undefined) {
+        try {
+          holdsMarker = (await readFile(file, 'utf8')).includes(marker);
+        } catch {
+          return null;
+        }
+        carriesMarker.set(file, holdsMarker);
+        // Watched either way: only an edit can change the answer.
+        server?.watcher.add(file);
+      }
+      if (!holdsMarker) return null;
+
+      if (!hrefByFile.has(file)) {
+        const href = hrefFor(config.root, config.base, file);
+        hrefByFile.set(file, href);
+        fileByPathname.set(href, file);
+      }
+
+      return { id: RUNTIME_ID_PREFIX + file + RUNTIME_ID_SUFFIX, moduleSideEffects: true };
+    },
+
+    load(id) {
+      if (!id.startsWith(RUNTIME_ID_PREFIX) || !id.endsWith(RUNTIME_ID_SUFFIX)) return null;
+
+      const file = id.slice(RUNTIME_ID_PREFIX.length, -RUNTIME_ID_SUFFIX.length);
+      const href = hrefByFile.get(file);
+      if (!href) return null;
+
+      return runtimeModule(`${href}?${STYLESHEET_QUERY}`);
+    },
+
+    refresh,
+  };
+}

--- a/packages/unplugin/src/utils/bundledDevCss.ts
+++ b/packages/unplugin/src/utils/bundledDevCss.ts
@@ -13,6 +13,7 @@ const RUNTIME_ID_SUFFIX = '.js';
 // for the same path, and the hot event that asks the browser to refetch it.
 const STYLESHEET_QUERY = 'stylex-css';
 const REFRESH_EVENT = 'stylex:css-refresh';
+const LOG_PREFIX = '[stylex-unplugin]';
 
 // A CSS module exports its class map; turning one into the runtime would
 // leave that import undefined.
@@ -126,25 +127,35 @@ export default function createBundledDevCss(
   // Whether a stylesheet carries the marker, by absolute path. Both answers
   // are kept and an edit drops the entry, so a file is read once per version.
   const carriesMarker = new Map<string, boolean>();
+  // Only marker detection is shared; stylesheet rendering must stay fresh.
+  const pendingReads = new Map<string, Promise<boolean>>();
   // Served marker files by absolute path, with the href each is served under,
   // and the reverse lookup the middleware needs.
   const hrefByFile = new Map<string, string>();
   const fileByPathname = new Map<string, string>();
   // Files the stylesheets `@import`, as Vite's CSS pipeline reports them.
-  const imported = new Set<string>();
+  const importsByFile = new Map<string, Set<string>>();
+  const latestRender = new Map<string, symbol>();
 
   function refresh(): void {
     server?.ws.send({ type: 'custom', event: REFRESH_EVENT });
   }
 
-  // The dev server watcher does not cover the project root under bundled
-  // serve, Rolldown watches the graph instead, so every file whose contents
-  // matter here is added by hand. Rolldown never sees them: the stylesheet
-  // is not in its graph, which is the point.
-  function watchImported(file: string): void {
-    if (imported.has(file)) return;
-    imported.add(file);
-    server?.watcher.add(file);
+  function isImported(file: string): boolean {
+    for (const imports of importsByFile.values()) {
+      if (imports.has(file)) return true;
+    }
+    return false;
+  }
+
+  // Bundled serve delegates graph watching to Rolldown. These stylesheets
+  // are outside that graph, so register all known inputs with Vite's watcher.
+  function watchedFiles(): string[] {
+    const files = new Set([...hrefByFile.keys(), ...carriesMarker.keys(), ...pendingReads.keys()]);
+    for (const imports of importsByFile.values()) {
+      for (const file of imports) files.add(file);
+    }
+    return [...files];
   }
 
   // A deleted file loses what was learned from its contents. Its href stays:
@@ -152,7 +163,9 @@ export default function createBundledDevCss(
   // path is served again as if nothing happened.
   function forget(file: string): void {
     carriesMarker.delete(file);
-    imported.delete(file);
+    pendingReads.delete(file);
+    importsByFile.delete(file);
+    latestRender.delete(file);
   }
 
   function hrefFor(root: string, base: string, file: string): string {
@@ -178,24 +191,34 @@ export default function createBundledDevCss(
     res: Parameters<Connect.NextHandleFunction>[1],
     next: Connect.NextFunction
   ): void {
+    // Most requests do not belong to us. Avoid URL parsing and href scanning
+    // until the cheap gate passes, then validate the actual query parameter.
+    if (!config || !marker || !req.url?.includes(STYLESHEET_QUERY)) {
+      next();
+      return;
+    }
     // The base is still on the URL here: this runs ahead of Vite's own base
     // middleware, and the hrefs were built with the base for that reason.
-    const url = new URL(req.url ?? '/', 'http://localhost');
+    const url = new URL(req.url, 'http://localhost');
     // A parent router in middleware mode strips its mount path before this
     // runs, so an href is also matched by its tail.
     const file =
       fileByPathname.get(url.pathname) ??
       [...fileByPathname].find(([href]) => href.endsWith(url.pathname))?.[1];
-    if (!file || !config || !marker || !url.searchParams.has(STYLESHEET_QUERY)) {
+    if (!file || !url.searchParams.has(STYLESHEET_QUERY)) {
       next();
       return;
     }
 
     const resolvedConfig = config;
     const resolvedMarker = marker;
+    const render = Symbol('stylesheet render');
+    latestRender.set(file, render);
 
     // Connect does not forward async rejections, hence the explicit catch.
     void (async () => {
+      // Never cache or share this render: a later request may need rules or
+      // source recorded after an earlier request started.
       // Vite is imported on demand: this module is bundled into the chunk
       // every host entry shares, and a static import would make webpack,
       // Rspack and esbuild users load Vite (ESM-only since Vite 8) at plugin
@@ -207,7 +230,16 @@ export default function createBundledDevCss(
       ]);
       const stylesheet = replaceFirstMarker(source, resolvedMarker, rules);
       const result = await preprocessCSS(stylesheet, file, resolvedConfig);
-      for (const dependency of result.deps ?? []) watchImported(normalizePath(dependency));
+      // A slow older response must not restore imports removed by a newer one.
+      if (latestRender.get(file) === render) {
+        const imports = new Set<string>();
+        for (const dependency of result.deps ?? []) {
+          const imported = normalizePath(dependency);
+          imports.add(imported);
+          server?.watcher.add(imported);
+        }
+        importsByFile.set(file, imports);
+      }
 
       // Vite's own responder: content type, ETag with `304` on a match, and
       // `HEAD` handling.
@@ -233,6 +265,11 @@ export default function createBundledDevCss(
         !!marker &&
         resolved.command === 'serve' &&
         resolved.environments?.client?.isBundled === true;
+      if (enabled) {
+        resolved.logger.info(
+          `${LOG_PREFIX} bundled dev server: marker stylesheets are served outside the bundle`
+        );
+      }
     },
 
     configureServer(devServer) {
@@ -241,7 +278,7 @@ export default function createBundledDevCss(
 
       // A restarted server brings a fresh watcher, so everything learned on
       // the previous one is registered again.
-      const known = [...carriesMarker.keys(), ...imported];
+      const known = watchedFiles();
       if (known.length > 0) devServer.watcher.add(known);
 
       devServer.watcher.on('change', changed => {
@@ -249,11 +286,17 @@ export default function createBundledDevCss(
         // An edit is the one thing that can change whether a file carries
         // the marker, so the cached answer goes; a served file is refetched.
         carriesMarker.delete(file);
-        if (hrefByFile.has(file) || imported.has(file)) refresh();
+        pendingReads.delete(file);
+        if (hrefByFile.has(file) || isImported(file)) refresh();
       });
-      devServer.watcher.on('unlink', changed => forget(normalizePath(changed)));
+      devServer.watcher.on('unlink', changed => {
+        const file = normalizePath(changed);
+        if (hrefByFile.has(file) || isImported(file)) refresh();
+        forget(file);
+      });
       devServer.watcher.on('add', added => {
-        if (hrefByFile.has(normalizePath(added))) refresh();
+        const file = normalizePath(added);
+        if (hrefByFile.has(file) || isImported(file)) refresh();
       });
       devServer.middlewares.use(serveStylesheet);
     },
@@ -281,15 +324,29 @@ export default function createBundledDevCss(
 
       const file = normalizePath(resolved.id);
       let holdsMarker = carriesMarker.get(file);
-      if (holdsMarker === undefined) {
+      while (holdsMarker === undefined) {
+        let pending = pendingReads.get(file);
+        if (!pending) {
+          // Watch before reading, so an edit during the read invalidates it.
+          server?.watcher.add(file);
+          const read = readFile(file, 'utf8').then(source => {
+            const answer = source.includes(marker);
+            if (pendingReads.get(file) === read) carriesMarker.set(file, answer);
+            return answer;
+          });
+          pendingReads.set(file, read);
+          pending = read;
+        }
         try {
-          holdsMarker = (await readFile(file, 'utf8')).includes(marker);
+          await pending;
         } catch {
           return null;
+        } finally {
+          if (pendingReads.get(file) === pending) pendingReads.delete(file);
         }
-        carriesMarker.set(file, holdsMarker);
-        // Watched either way: only an edit can change the answer.
-        server?.watcher.add(file);
+        // An invalidated read cannot publish its answer; retry or use the
+        // answer of the newer read instead of resurrecting stale cache state.
+        holdsMarker = carriesMarker.get(file);
       }
       if (!holdsMarker) return null;
 
@@ -297,6 +354,7 @@ export default function createBundledDevCss(
         const href = hrefFor(config.root, config.base, file);
         hrefByFile.set(file, href);
         fileByPathname.set(href, file);
+        config.logger.info(`${LOG_PREFIX} serving ${href} outside the bundle`);
       }
 
       return { id: RUNTIME_ID_PREFIX + file + RUNTIME_ID_SUFFIX, moduleSideEffects: true };


### PR DESCRIPTION
## Description

Under Vite's `experimental.bundledDev`, Rolldown compiles every imported stylesheet into JavaScript, so the placeholder stylesheet never gets the StyleX rules and nothing refreshes it. The stylesheet that carries the marker is now taken out of the bundle: its import resolves to a small runtime module that links it from the dev server, a middleware renders it from the file and the current rules, and one hot event refetches it when rules or the stylesheet change. Only the bundled client environment is redirected; other environments, SSR included, keep the regular path.

Two regular-dev fixes ride along: a marker stylesheet referenced only by a `<link>` in the HTML is now matched (it is registered as a `?direct` module), and the late-rules refresh sends both update kinds so linked and imported stylesheets are both reached.

Verified in a headless Chromium: first paint, style edits, `defineVars` and `createTheme` edits, modules added after the initial build, lazily bundled modules, stylesheet and `@import` partial edits, a non-root base, an out-of-root stylesheet, a server restart, regular dev, and a production build whose CSS is byte-identical to the unpatched plugin.

## Fixes

Fixes #1301

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document

🤖 Generated with [Claude Code](https://claude.com/claude-code)
