### PR TITLE
Fix dynamic style entry handling and improve diagnostics

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "type": "lldb",
       "request": "launch",
       "name": "Debug",
-      "program": "${workspaceFolder}/crates/stylex-test-parser/target/debug/test-parser",
+      "program": "${workspaceFolder}/target/debug/stylex-test-parser",
       "args": [],
       "cwd": "${workspaceFolder}/crates/stylex-test-parser",
       "sourceLanguages": ["rust"],

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ ctor = "1.0.7"
 derive_more = { version = "2.1.1", features = ["display"] }
 env_logger = "0.11.10"
 fancy-regex = "0.19.0"
-glob = { version = "0.3.3" }
 # Root collation for the pseudo-key comparator. Six of its crates are new to
 # this workspace; the other 26 in its tree already arrive through SWC's
 # `idna_adapter`. `crates/stylex-css/src/utils/pre_rule.rs` costs the choice
@@ -94,9 +93,7 @@ glob = { version = "0.3.3" }
 icu_collator = { version = "2.3.1", features = ["unstable"] }
 indexmap = { version = "2.14.0", features = ["serde"] }
 insta = { version = "1.47.2" }
-lazy_static = "1.5.0"
 log = "0.4.32"
-md5 = { version = "0.8.0" }
 # The allocator for the one published target `swc_malloc` leaves on the system
 # one: `x86_64-unknown-linux-musl`. This entry is where the reason is written
 # down; `crates/stylex-rs-compiler/src/lib.rs` declares it and points here.
@@ -135,7 +132,6 @@ path-clean = { version = "1.0.1" }
 phf = { version = "0.14.0" }
 pretty_env_logger = "0.5.0"
 radix_fmt = { version = "1.0.0" }
-rust_decimal = { version = "1.42.0", features = ["serde"] }
 rustc-hash = "2.1.2"
 serde = "1.0.228"
 serde_json = "1.0.150"

--- a/crates/stylex-css-parser/src/lib.rs
+++ b/crates/stylex-css-parser/src/lib.rs
@@ -87,6 +87,12 @@ pub enum CssParseError {
 /// Result type for CSS parsing operations
 pub type CssResult<T> = std::result::Result<T, CssParseError>;
 
+/// The logger the suites read messages back from. Shared, because the whole
+/// crate's unit tests run in one process and `log` takes one logger per process.
+#[cfg(test)]
+#[path = "tests/capturing_logger.rs"]
+mod capturing_logger;
+
 #[cfg(test)]
 mod lib_tests {
   use super::*;

--- a/crates/stylex-css-parser/src/tests/capturing_logger.rs
+++ b/crates/stylex-css-parser/src/tests/capturing_logger.rs
@@ -1,0 +1,67 @@
+//! A logger the tests can read back, so a reporting path is covered by an
+//! assertion rather than by a coverage exclusion.
+//!
+//! A `log` macro builds its message only when `log::max_level` admits it, so
+//! every argument of every message is unexecuted code until a logger is in
+//! place. Reading the message back then makes the message itself the subject of
+//! a case.
+//!
+//! Both the level and the messages are per thread, because the harness runs
+//! tests in parallel and one global level would let one case decide what
+//! another one sees. `log::max_level` stays wide open; the per-thread level is
+//! what [`Log::enabled`] answers from.
+//!
+//! The same helper as `stylex_diagnostics`'s. `log` takes one logger for the
+//! whole process and every test binary is a process of its own, so each crate
+//! that reads its messages back holds its own copy.
+
+use std::cell::RefCell;
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+thread_local! {
+  static LEVEL: RefCell<LevelFilter> = const { RefCell::new(LevelFilter::Off) };
+  static MESSAGES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+struct CapturingLogger;
+
+impl Log for CapturingLogger {
+  fn enabled(&self, metadata: &Metadata) -> bool {
+    LEVEL.with_borrow(|level| metadata.level() <= *level)
+  }
+
+  fn log(&self, record: &Record) {
+    if !self.enabled(record.metadata()) {
+      return;
+    }
+
+    MESSAGES.with_borrow_mut(|messages| messages.push(record.args().to_string()));
+  }
+
+  fn flush(&self) {}
+}
+
+/// Installs the logger, on the first case that reads a message back.
+///
+/// A second call answers `Err`, which is the expected reply once the logger is
+/// in place.
+fn install() {
+  if log::set_boxed_logger(Box::new(CapturingLogger)).is_ok() {
+    log::set_max_level(LevelFilter::Trace);
+  }
+}
+
+/// Runs `body` with this thread logging at `level`, and hands back everything
+/// it wrote.
+pub(crate) fn logged_at<T>(level: Level, body: impl FnOnce() -> T) -> Vec<String> {
+  install();
+
+  LEVEL.with_borrow_mut(|current| *current = level.to_level_filter());
+  MESSAGES.with_borrow_mut(Vec::clear);
+
+  body();
+
+  LEVEL.with_borrow_mut(|current| *current = LevelFilter::Off);
+  MESSAGES.with_borrow(Clone::clone)
+}

--- a/crates/stylex-css-parser/src/tests/token_parser_coverage_test.rs
+++ b/crates/stylex-css-parser/src/tests/token_parser_coverage_test.rs
@@ -1,8 +1,10 @@
 use super::*;
 use crate::{
+  capturing_logger::logged_at,
   css_types::{Scale, TransformFunction},
   token_types::{SimpleToken, TokenList},
 };
+use log::Level;
 
 // ── helper: build a TokenList directly (bypasses the CSS tokenizer) ──────────
 
@@ -379,21 +381,51 @@ fn label_method_returns_label() {
 // debug() method
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// `debug` writes what it parsed and how it ended. Both messages are built from
+/// the parse, and a `log` macro builds nothing while no logger admits the level,
+/// so the case reads the two messages back.
 #[test]
 fn debug_method_success() {
-  // debug on a successful parse
   let parser = tokens::ident();
-  let result = parser.debug("foo");
-  assert!(result.is_ok());
-  assert!(matches!(result.unwrap(), SimpleToken::Ident(_)));
+  let label = parser.label().to_string();
+  let mut result = None;
+
+  let messages = logged_at(Level::Debug, || result = Some(parser.debug("foo")));
+
+  assert!(matches!(result, Some(Ok(SimpleToken::Ident(_)))));
+  // The label is in every assertion, so the case answers for its own parse.
+  assert!(
+    messages
+      .iter()
+      .any(|message| message == &format!("Parsing 'foo' with parser '{label}'")),
+    "the input and the parser must be named, got {messages:?}"
+  );
+  assert!(
+    messages
+      .iter()
+      .any(|message| message.starts_with(&format!("✅ SUCCESS: Parser '{label}' matched."))),
+    "a parse that succeeded must say so, got {messages:?}"
+  );
 }
 
+/// The same for a parse that fails: the message carries the position it stopped
+/// at and the error it stopped with.
 #[test]
 fn debug_method_failure() {
-  // the Err arm of the match inside debug
   let parser = tokens::colon();
-  let result = parser.debug("foo"); // ident is not a colon
-  assert!(result.is_err());
+  let label = parser.label().to_string();
+  let mut result = None;
+
+  // An ident is not a colon.
+  let messages = logged_at(Level::Debug, || result = Some(parser.debug("foo")));
+
+  assert!(matches!(result, Some(Err(_))));
+  assert!(
+    messages
+      .iter()
+      .any(|message| message.starts_with(&format!("❌ FAILED: Parser '{label}' failed at token "))),
+    "a parse that failed must say so, got {messages:?}"
+  );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1801,19 +1833,59 @@ fn always_make_label_non_unit_type_returns_always_fmt() {
 }
 
 // ── debug_log_result ─────────────────────────────────────────────────────────
-// debug_log_result only calls log::debug!, so we just ensure both branches
-// are reachable (both arms call debug! which is a no-op without a logger).
+// Both arms build a message out of their arguments, and a `log` macro builds
+// nothing while no logger admits the level. The cases below read the message
+// back, so they measure the arguments and not only the arm that was taken.
 
 #[test]
 fn debug_log_result_success_branch() {
-  // success = true → logs SUCCESS message; must not panic
-  debug_log_result(true, "TestParser", 3, "");
+  let messages = logged_at(Level::Debug, || debug_log_result(true, "TestParser", 3, ""));
+
+  assert_eq!(
+    messages,
+    vec!["✅ SUCCESS: Parser 'TestParser' matched. Consumed 3 tokens.".to_string()]
+  );
 }
 
 #[test]
 fn debug_log_result_failure_branch() {
-  // success = false → logs FAILED message; must not panic
-  debug_log_result(false, "TestParser", 0, "some error");
+  let messages = logged_at(Level::Debug, || {
+    debug_log_result(false, "TestParser", 0, "some error")
+  });
+
+  assert_eq!(
+    messages,
+    vec!["❌ FAILED: Parser 'TestParser' failed at token 0. Error: some error".to_string()]
+  );
+}
+
+/// Nothing is written while the level does not admit a debug message, which is
+/// every build that does not ask for one.
+#[test]
+fn debug_log_result_writes_nothing_at_a_higher_level() {
+  let messages = logged_at(Level::Warn, || debug_log_result(true, "TestParser", 1, ""));
+
+  assert!(messages.is_empty());
+}
+
+/// A label and an error far larger than any real one, and a token count at the
+/// top of its type: the message is built from whatever it is handed.
+#[test]
+fn debug_log_result_carries_an_enormous_label_and_error() {
+  let label = "L".repeat(100_000);
+  let error = "E".repeat(100_000);
+
+  let messages = logged_at(Level::Debug, || {
+    debug_log_result(false, &label, usize::MAX, &error)
+  });
+
+  assert_eq!(
+    messages,
+    vec![format!(
+      "❌ FAILED: Parser '{label}' failed at token {}. Error: {error}",
+      usize::MAX
+    )]
+  );
 }
 
 // ── build_parse_with_context_error ───────────────────────────────────────────

--- a/crates/stylex-css-parser/src/tests/token_types_coverage_test.rs
+++ b/crates/stylex-css-parser/src/tests/token_types_coverage_test.rs
@@ -330,6 +330,55 @@ fn parse_nested_or_panic_panics_when_nested_parse_errors() {
   });
 }
 
+/// The guard writes the error before it stops the build, and that message is
+/// the only account of what went wrong. It is built from the error, which a
+/// `log` macro does not build while no logger admits the level.
+///
+/// `catch_unwind` rather than `should_panic`: the message has to be asserted
+/// after the panic, which a `should_panic` case never reaches.
+#[test]
+fn a_nested_parse_error_is_written_before_it_stops_the_build() {
+  use cssparser::{ParseError, ParseErrorKind, SourceLocation};
+  use log::Level;
+
+  use crate::capturing_logger::logged_at;
+
+  let mut stopped = None;
+
+  let messages = logged_at(Level::Error, || {
+    stopped = Some(std::panic::catch_unwind(|| {
+      super::handle_nested_block_result(Err(ParseError {
+        kind: ParseErrorKind::Custom(()),
+        location: SourceLocation { line: 2, column: 7 },
+      }))
+    }));
+  });
+
+  assert!(
+    matches!(stopped, Some(Err(_))),
+    "a nested parse error must stop the build"
+  );
+  assert!(
+    messages
+      .iter()
+      .any(|message| message.starts_with("Error parsing nested content: ")),
+    "the error must be written before the build stops, got {messages:?}"
+  );
+}
+
+/// The same guard on the answer it is given almost every time. Nothing is
+/// written and nothing stops.
+#[test]
+fn a_nested_block_that_parsed_writes_nothing() {
+  use log::Level;
+
+  use crate::capturing_logger::logged_at;
+
+  let messages = logged_at(Level::Error, || super::handle_nested_block_result(Ok(())));
+
+  assert!(messages.is_empty());
+}
+
 // ---------------------------------------------------------------------------
 // leading_f64(): the paths where there is no number to read
 // ---------------------------------------------------------------------------

--- a/crates/stylex-diagnostics/CONTEXT.md
+++ b/crates/stylex-diagnostics/CONTEXT.md
@@ -48,6 +48,16 @@ can be matched against it by structure; syntax contexts are normalized on the
 query side instead.
 _Avoid_: seen module, cached source, parsed source
 
+**Source candidate**:
+One place the text of the **memoized module** may come from: the file on disk,
+the text the compiler was given, or the module printed back out from its AST.
+Tried in that order, and the first that parses is the one memoized. A file whose
+content is not the JavaScript the compiler was fed -- a single-file component,
+an `.mdx`, a name edited since the read -- therefore degrades to the next
+candidate rather than leaving the diagnostic with no frame. Where no candidate
+supplies a text, a module made of the refused expression alone is the answer.
+_Avoid_: source fallback, source chain, text source
+
 **Framed declaration**:
 The binding a refusal is _about_, recorded so its frame names the line that
 binding was declared on rather than the line it was read from — the line an

--- a/crates/stylex-diagnostics/src/code_frame.rs
+++ b/crates/stylex-diagnostics/src/code_frame.rs
@@ -15,7 +15,7 @@ use swc_config::is_module::IsModule;
 use swc_core::{
   atoms::Atom,
   common::{
-    DUMMY_SP, EqIgnoreSpan, FileName, Mark, SourceMap, Span, Spanned, SyntaxContext,
+    DUMMY_SP, EqIgnoreSpan, FileName, Mark, SourceFile, SourceMap, Span, Spanned, SyntaxContext,
     errors::{Handler, *},
     util::take::Take,
   },
@@ -134,6 +134,23 @@ impl CodeFrame {
   /// it replaces. A long-lived process transforming five thousand modules pays
   /// fifty thousand name comparisons where it used to accumulate fifty thousand
   /// source files.
+  /// The file already registered for `file_name` whose text is `source`, if the
+  /// shared map holds one.
+  ///
+  /// `get_source_file` answers with the first file registered under the name,
+  /// which after a candidate failed to parse is a text nothing quotes. Asking
+  /// for the content as well is what keeps a watch-mode process from appending
+  /// one copy of such a file per save. The scan is the same one
+  /// `get_source_file` makes, with a content compare on the names that match.
+  fn registered_source_file(&self, file_name: &FileName, source: &str) -> Option<Arc<SourceFile>> {
+    self
+      .source_map
+      .files()
+      .iter()
+      .find(|file| *file.name == *file_name && file.src.as_str() == source)
+      .cloned()
+  }
+
   fn register_source_once(&self, file_name: &FileName, source: &str) {
     if self.source_map.get_source_file(file_name).is_some() {
       return;
@@ -473,7 +490,7 @@ fn get_key_span_from_source_code_impl(
   // `dev` build quadratic in the size of a file that is one long list of them.
   let span = match state.key_span_index() {
     Some(index) => index.resolve(&query),
-    None => return Err(missing_memoized_module(state)),
+    None => return Err(no_module_to_quote(state)),
   };
 
   state
@@ -609,17 +626,19 @@ fn with_memoized_module<T>(
 
   match state.get_seen_module_source_code() {
     Some((module, _)) => Ok(visit(module)),
-    None => Err(missing_memoized_module(state)),
+    None => Err(no_module_to_quote(state)),
   }
 }
 
-/// The error for "the module should have been memoized by now".
+/// The answer when the frame has no module to quote, named by the file it was
+/// looking for.
 ///
-/// Both callers reach it only after [`memoize_module`] returned `Ok`, which
-/// either found a memoized module or stored one, so neither is reachable in
-/// practice. It stays an error rather than a panic because the getters' types
-/// cannot say so, and a diagnostic aid must never be the reason a build stops.
-fn missing_memoized_module(state: &impl DiagnosticState) -> Error {
+/// Raised where no candidate text parsed, and again where a memoized module is
+/// asked for after [`memoize_module`] returned `Ok`. That second case is not
+/// reachable in practice -- the call either found a memoized module or stored
+/// one -- but it stays an error rather than a panic, because the getters' types
+/// cannot say so and a diagnostic aid must never be the reason a build stops.
+fn no_module_to_quote(state: &impl DiagnosticState) -> Error {
   anyhow::anyhow!("Failed to parse source file: {}", state.get_filename())
 }
 
@@ -640,35 +659,85 @@ fn memoize_module(
   if let Some((_, Some(source_code))) = state.get_seen_module_source_code() {
     // Registered once, not once per lookup -- see `register_source_once`.
     code_frame.register_source_once(file_name, source_code);
-  } else {
-    let source_code = get_source_code(wrapped_expression, state, file_name);
 
-    // Through the same reuse `register_source_once` applies, rather than around
-    // it. `new_source_file` never deduplicates -- it appends -- and this map is
-    // a process-global `OnceLock` that is never cleared, so registering here on
-    // every compile is how a watch-mode process accumulated one full copy of
-    // each module per save. Comparing the content is the load-bearing part: an
-    // edited file still gets a fresh registration, and only an unchanged one is
-    // reused.
-    let source_file = match code_frame.source_map.get_source_file(file_name) {
-      Some(existing) if existing.src.as_str() == source_code => existing,
-      _ => code_frame
-        .source_map
-        .new_source_file(Arc::new(file_name.clone()), source_code.clone()),
-    };
-
-    let program = parse_and_normalize_program(
-      &source_file,
-      code_frame,
-      state.get_filename(),
-      target_expression,
-    )
-    .ok_or_else(|| anyhow::anyhow!("Failed to parse source file: {}", state.get_filename()))?;
-
-    state.set_seen_module_source_code(expect_module(&program), Some(source_code));
+    return Ok(());
   }
 
+  let mut authored_text_found = false;
+
+  for candidate in source_code_candidates(state) {
+    // Made here rather than in the list, so a text that a better candidate
+    // makes unnecessary is never built. Printing the memoized module is a deep
+    // clone of it, which a file read before it usually makes unnecessary.
+    let Some(source_code) = candidate.source_code(state, file_name) else {
+      continue;
+    };
+
+    authored_text_found = true;
+
+    if try_memoize_source(source_code, target_expression, state, file_name, code_frame) {
+      return Ok(());
+    }
+  }
+
+  if authored_text_found {
+    return Err(no_module_to_quote(state));
+  }
+
+  // No authored text can be read, so the frame quotes a module made of the
+  // expression alone. Such a module always parses, which is what keeps an
+  // answer available. The outcome is not examined for that reason: a state that
+  // kept nothing is reported by the caller that asks for the module back.
+  let synthesized = print_module(create_module(wrapped_expression), None);
+
+  let _ = try_memoize_source(synthesized, target_expression, state, file_name, code_frame);
+
   Ok(())
+}
+
+/// Registers `source_code` with `code_frame`, parses it and memoizes the module
+/// on `state`. `false` when the text does not parse, so the caller can go on to
+/// the next candidate.
+fn try_memoize_source(
+  source_code: String,
+  target_expression: &Expr,
+  state: &mut impl DiagnosticState,
+  file_name: &FileName,
+  code_frame: &CodeFrame,
+) -> bool {
+  // Through the same reuse `register_source_once` applies, rather than around
+  // it. `new_source_file` never deduplicates -- it appends -- and this map is
+  // a process-global `OnceLock` that is never cleared, so registering here on
+  // every compile is how a watch-mode process accumulated one full copy of
+  // each module per save. Comparing the content is the load-bearing part: an
+  // edited file still gets a fresh registration, and only an unchanged one is
+  // reused.
+  let source_file = match code_frame.registered_source_file(file_name, &source_code) {
+    Some(existing) => existing,
+    None => code_frame
+      .source_map
+      .new_source_file(Arc::new(file_name.clone()), source_code),
+  };
+
+  let program = parse_and_normalize_program(
+    &source_file,
+    code_frame,
+    state.get_filename(),
+    target_expression,
+  );
+
+  // A candidate that does not parse stays in the map, and the next one is
+  // registered beside it. A span is resolved by position, so the file that did
+  // parse is still the one a frame is quoted from.
+  let Some(program) = program else {
+    return false;
+  };
+
+  // The state keeps the file the frame registered, so the text it hands back
+  // later is that same allocation and not a copy of it.
+  state.set_seen_module_source_code(expect_module(&program), Some(source_file));
+
+  true
 }
 
 /// The module of a program [`parse_and_normalize_program`] returned.
@@ -684,49 +753,73 @@ fn expect_module(program: &Program) -> &Module {
   }
 }
 
-/// The text of the module the frame quotes from.
+/// Where the text of the module the frame quotes may come from.
+enum SourceCandidate {
+  /// The file on disk, as `useRealFileForSource` permits.
+  Disk,
+  /// The text the compiler was given for the file.
+  Given,
+  /// The memoized module, printed back out from its AST.
+  PrintedModule,
+}
+
+impl SourceCandidate {
+  /// The text, or `None` where this source cannot supply one -- a file that is
+  /// not there, or a name no file can be read from.
+  fn source_code(&self, state: &impl DiagnosticState, file_name: &FileName) -> Option<String> {
+    match self {
+      Self::Disk => read_source_file(file_name).ok(),
+      Self::Given => state.input_source_text().map(str::to_owned),
+      Self::PrintedModule => {
+        let (module, _) = state.get_seen_module_source_code()?;
+
+        Some(print_module(
+          module.clone(),
+          Some(
+            Config::default()
+              .with_minify(false)
+              .with_omit_last_semi(false)
+              .with_reduce_escaped_newline(false)
+              .with_inline_script(false),
+          ),
+        ))
+      },
+    }
+  }
+}
+
+/// The sources the module the frame quotes may come from, best first.
 ///
 /// While `useRealFileForSource` is on, the file on disk comes first and the
 /// text the compiler was given is the fallback for a file that is not there.
 /// Both keep the authored layout, which is the only one a `file:line` may be
 /// measured against. When the option is off, no file is opened and a module
 /// memoized without its text is printed back out, as the option documents.
-/// Failing all of that, the frame quotes a module synthesized around the
-/// expression itself. There is always an answer.
 ///
-/// The memoized *text* is not a case here: the only caller reaches this after
-/// finding there is none.
-fn get_source_code(
-  wrapped_expression: &Expr,
-  state: &impl DiagnosticState,
-  file_name: &FileName,
-) -> String {
-  if state.reads_source_from_disk() {
-    if let Ok(source) = read_source_file(file_name) {
-      return source;
-    }
+/// A list rather than one source because `filename` can name a host file whose
+/// content is not the JavaScript the compiler was fed -- a single-file
+/// component, an `.mdx`, a `?query`-suffixed name that still resolves on disk,
+/// or a file edited since the read. [`memoize_module`] takes the first
+/// candidate that parses, so such a file degrades to the text the compiler
+/// holds instead of leaving the diagnostic with no frame. Where no candidate
+/// supplies a text at all, that caller synthesizes a module from the expression
+/// itself, which is how an answer stays available.
+///
+/// The memoized *text* is not a candidate here: the only caller reaches this
+/// after finding there is none.
+fn source_code_candidates(state: &impl DiagnosticState) -> SmallVec<[SourceCandidate; 3]> {
+  let mut candidates = SmallVec::new();
 
-    if let Some(text) = state.input_source_text() {
-      return text.to_owned();
-    }
+  if state.reads_source_from_disk() {
+    candidates.push(SourceCandidate::Disk);
+    candidates.push(SourceCandidate::Given);
   }
 
   // A module printed back out from its AST lays its lines out differently from
-  // the authored file, so it is quoted only when no authored text is allowed.
-  if let Some((module, _)) = state.get_seen_module_source_code() {
-    return print_module(
-      module.clone(),
-      Some(
-        Config::default()
-          .with_minify(false)
-          .with_omit_last_semi(false)
-          .with_reduce_escaped_newline(false)
-          .with_inline_script(false),
-      ),
-    );
-  }
+  // the authored file, so it is quoted only after every authored text.
+  candidates.push(SourceCandidate::PrintedModule);
 
-  print_module(create_module(wrapped_expression), None)
+  candidates
 }
 
 /// Parses source code into a Program AST and normalizes it

--- a/crates/stylex-diagnostics/src/code_frame.rs
+++ b/crates/stylex-diagnostics/src/code_frame.rs
@@ -684,11 +684,16 @@ fn expect_module(program: &Program) -> &Module {
   }
 }
 
-/// The text of the module the frame quotes from, in the order it is worth
-/// trying: the text the compiler was given, then a module memoized without its
-/// text printed back out, then the file on disk. Failing all three, a module
-/// synthesized around the expression itself -- which is why there is always an
-/// answer.
+/// The text of the module the frame quotes from.
+///
+/// While `useRealFileForSource` is on, the file on disk comes first and the
+/// text the compiler was given is the fallback for a file that is not there.
+/// Both keep the authored layout, which is the only one a `file:line` may be
+/// measured against. When the option is off, no file is opened and a module
+/// memoized without its text is printed back out, as the option documents.
+/// Failing all of that, a
+/// module synthesized around the expression itself -- which is why there is
+/// always an answer.
 ///
 /// The memoized *text* is not a case here: the only caller reaches this after
 /// finding there is none.
@@ -697,17 +702,18 @@ fn get_source_code(
   state: &impl DiagnosticState,
   file_name: &FileName,
 ) -> String {
-  // The text the compiler was given is the layout the author sees, so it is
-  // the first choice: a module printed back out from its AST lays its lines
-  // out differently, and a `file:line` measured against it names the wrong
-  // line for every key after the first one the printer reflowed.
-  if let Some(text) = state.input_source_text() {
-    return text.to_owned();
+  if state.reads_source_from_disk() {
+    if let Ok(source) = read_source_file(file_name) {
+      return source;
+    }
+
+    if let Some(text) = state.input_source_text() {
+      return text.to_owned();
+    }
   }
 
-  // Reached only where the caller found no memoized text, so a module memoized
-  // here has none either and has to be printed back out to give the frame
-  // something to quote.
+  // A module printed back out from its AST lays its lines out differently from
+  // the authored file, so it is quoted only when no authored text is allowed.
   if let Some((module, _)) = state.get_seen_module_source_code() {
     return print_module(
       module.clone(),
@@ -719,10 +725,6 @@ fn get_source_code(
           .with_inline_script(false),
       ),
     );
-  }
-
-  if let Ok(source) = read_source_file(file_name) {
-    return source;
   }
 
   print_module(create_module(wrapped_expression), None)

--- a/crates/stylex-diagnostics/src/code_frame.rs
+++ b/crates/stylex-diagnostics/src/code_frame.rs
@@ -691,9 +691,8 @@ fn expect_module(program: &Program) -> &Module {
 /// Both keep the authored layout, which is the only one a `file:line` may be
 /// measured against. When the option is off, no file is opened and a module
 /// memoized without its text is printed back out, as the option documents.
-/// Failing all of that, a
-/// module synthesized around the expression itself -- which is why there is
-/// always an answer.
+/// Failing all of that, the frame quotes a module synthesized around the
+/// expression itself. There is always an answer.
 ///
 /// The memoized *text* is not a case here: the only caller reaches this after
 /// finding there is none.

--- a/crates/stylex-diagnostics/src/code_frame.rs
+++ b/crates/stylex-diagnostics/src/code_frame.rs
@@ -685,9 +685,10 @@ fn expect_module(program: &Program) -> &Module {
 }
 
 /// The text of the module the frame quotes from, in the order it is worth
-/// trying: a module memoized without its text printed back out, then the file
-/// on disk. Failing both, a module synthesized around the expression itself --
-/// which is why there is always an answer.
+/// trying: the text the compiler was given, then a module memoized without its
+/// text printed back out, then the file on disk. Failing all three, a module
+/// synthesized around the expression itself -- which is why there is always an
+/// answer.
 ///
 /// The memoized *text* is not a case here: the only caller reaches this after
 /// finding there is none.
@@ -696,6 +697,14 @@ fn get_source_code(
   state: &impl DiagnosticState,
   file_name: &FileName,
 ) -> String {
+  // The text the compiler was given is the layout the author sees, so it is
+  // the first choice: a module printed back out from its AST lays its lines
+  // out differently, and a `file:line` measured against it names the wrong
+  // line for every key after the first one the printer reflowed.
+  if let Some(text) = state.input_source_text() {
+    return text.to_owned();
+  }
+
   // Reached only where the caller found no memoized text, so a module memoized
   // here has none either and has to be printed back out to give the frame
   // something to quote.

--- a/crates/stylex-diagnostics/src/lib.rs
+++ b/crates/stylex-diagnostics/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
-
 //! How StyleX shows an author where a refusal happened.
 //!
 //! A code frame quotes the offending line back out of the file the author

--- a/crates/stylex-diagnostics/src/state.rs
+++ b/crates/stylex-diagnostics/src/state.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use swc_core::common::SourceFile;
 use swc_core::ecma::ast::Module;
 
 use stylex_state_index::key_span_index::KeySpanIndex;
@@ -31,7 +34,12 @@ pub trait DiagnosticState {
 
   /// Memoizes that re-parsed source, so the next diagnostic in the same file
   /// does not read and parse it again.
-  fn set_seen_module_source_code(&mut self, module: &Module, source_code: Option<String>);
+  ///
+  /// The text comes as the source file it was parsed from, which the frame has
+  /// already registered. Holding that file rather than a `String` keeps the
+  /// module text to one allocation per file: the state and the source map share
+  /// it. A module memoized without its text passes `None`.
+  fn set_seen_module_source_code(&mut self, module: &Module, source_file: Option<Arc<SourceFile>>);
 
   /// The text the compiler was given for this file, when the entry point
   /// recorded it.

--- a/crates/stylex-diagnostics/src/state.rs
+++ b/crates/stylex-diagnostics/src/state.rs
@@ -33,6 +33,15 @@ pub trait DiagnosticState {
   /// does not read and parse it again.
   fn set_seen_module_source_code(&mut self, module: &Module, source_code: Option<String>);
 
+  /// The text the compiler was given for this file, when the entry point
+  /// recorded it.
+  ///
+  /// The authored layout is the only one a `file:line` may be measured
+  /// against. A module printed back out from its AST lays its lines out
+  /// differently, and a file read from disk can be older than the text a
+  /// bundler handed in.
+  fn input_source_text(&self) -> Option<&str>;
+
   /// Where every style namespace key of the memoized source is written, built
   /// on first use.
   fn key_span_index(&self) -> Option<&KeySpanIndex>;

--- a/crates/stylex-diagnostics/src/state.rs
+++ b/crates/stylex-diagnostics/src/state.rs
@@ -44,6 +44,10 @@ pub trait DiagnosticState {
   /// Whether the frame may read the file on disk, as `useRealFileForSource`
   /// asks. When the option is off, the frame quotes what the compiler holds in
   /// memory and opens no file.
+  ///
+  /// The flag gates [`DiagnosticState::input_source_text`] as well, not the
+  /// disk read alone: with the option off, the module the compiler memoized is
+  /// the one source the frame is allowed to name.
   fn reads_source_from_disk(&self) -> bool;
 
   /// Where every style namespace key of the memoized source is written, built

--- a/crates/stylex-diagnostics/src/state.rs
+++ b/crates/stylex-diagnostics/src/state.rs
@@ -36,11 +36,15 @@ pub trait DiagnosticState {
   /// The text the compiler was given for this file, when the entry point
   /// recorded it.
   ///
-  /// The authored layout is the only one a `file:line` may be measured
-  /// against. A module printed back out from its AST lays its lines out
-  /// differently, and a file read from disk can be older than the text a
-  /// bundler handed in.
+  /// It keeps the authored layout, which a module printed back out from its
+  /// AST does not, so it is what a `file:line` is measured against when the
+  /// file itself is not on disk.
   fn input_source_text(&self) -> Option<&str>;
+
+  /// Whether the frame may read the file on disk, as `useRealFileForSource`
+  /// asks. When the option is off, the frame quotes what the compiler holds in
+  /// memory and opens no file.
+  fn reads_source_from_disk(&self) -> bool;
 
   /// Where every style namespace key of the memoized source is written, built
   /// on first use.

--- a/crates/stylex-diagnostics/src/tests/code_frame_test.rs
+++ b/crates/stylex-diagnostics/src/tests/code_frame_test.rs
@@ -873,6 +873,45 @@ fn a_module_memoized_without_its_text_is_printed_back_out() {
   assert_eq!(framed_line(&target, &mut state), Some(1));
 }
 
+/// The authored text wins over a module printed back out. A debug build
+/// memoizes the module without its text at module entry, and the printer lays a
+/// one-line namespace out over three lines, so every key after it moved to a
+/// later line than the one the author wrote it on. The compiler was given the
+/// text, and that text is what a `file:line` has to be measured against.
+#[test]
+fn a_key_is_framed_on_the_authored_line_when_the_module_is_memoized_without_text() {
+  let source = "\
+export const styles = create({
+  root: { color: 'red' },
+  other: { display: 'flex' },
+});
+";
+  let mut state = StateDouble::for_file("/nonexistent/authored.tsx").with_input_source(source);
+  let call = compiled_create_call();
+
+  // The parse and the lookup both mint marks, so both run inside the globals.
+  let line = GLOBALS.set(&Globals::default(), || {
+    let frame = CodeFrame::new();
+    let source_file = frame
+      .source_map
+      .new_source_file(Arc::new(FileName::Anon), source.to_owned());
+    let program =
+      match parse_and_normalize_program(&source_file, &frame, "authored.tsx", &reference("c")) {
+        Some(program) => program,
+        None => panic!("the fixture must parse"),
+      };
+
+    state.set_seen_module_source_code(expect_module(&program), None);
+
+    match key_span_for(&call, "other", &mut state) {
+      Ok((code_frame, span)) => code_frame.try_get_span_line_number(span),
+      Err(error) => panic!("failed to get the key span: {error}"),
+    }
+  });
+
+  assert_eq!(line, Some(3));
+}
+
 /// The panic boundary every span lookup sits behind: a panic inside it is an
 /// ordinary "no code frame", never the end of the compilation.
 #[test]

--- a/crates/stylex-diagnostics/src/tests/code_frame_test.rs
+++ b/crates/stylex-diagnostics/src/tests/code_frame_test.rs
@@ -9,7 +9,9 @@ use std::{
 };
 
 use swc_core::atoms::Atom;
-use swc_core::common::{BytePos, DUMMY_SP, FileName, GLOBALS, Globals, Span, SyntaxContext};
+use swc_core::common::{
+  BytePos, DUMMY_SP, FileName, GLOBALS, Globals, SourceFile, SourceMap, Span, SyntaxContext,
+};
 use swc_core::ecma::ast::{
   ArrowExpr, ArrowFunctionBody, BindingIdent, CallExpr, Callee, Expr, ExprOrSpread, Ident,
   ImportDecl, ImportNamedSpecifier, ImportSpecifier, Module, ModuleDecl, ModuleItem, Pat, Program,
@@ -102,6 +104,15 @@ fn write_fixture(name: &str, source: &str) -> TempFixture {
   }
 
   TempFixture { dir, path }
+}
+
+/// The text a state memoizes, as the source file the frame hands it. Registered
+/// in a map of its own, so a case can memoize a text the shared map has never
+/// seen.
+fn memoized_source_file(source: &str) -> Arc<SourceFile> {
+  let source_map = SourceMap::default();
+
+  source_map.new_source_file(Arc::new(FileName::Anon), source.to_owned())
 }
 
 fn compiled_create_call() -> CallExpr {
@@ -1251,7 +1262,7 @@ fn a_cached_answer_is_quoted_from_the_memoized_text() {
   let mut state = StateDouble::for_file(format!("memoized_only_{}.tsx", id));
   let target = reference("c");
 
-  state.set_seen_module_source_code(&create_module(&target), Some(source.to_owned()));
+  state.set_seen_module_source_code(&create_module(&target), Some(memoized_source_file(source)));
   state
     .diagnostic_memo_mut()
     .insert_cached_span(compute_cache_key(&target), DUMMY_SP);
@@ -1362,4 +1373,33 @@ fn a_program_that_is_not_a_module_stops_the_memoization() {
     body: Vec::new(),
     shebang: None,
   }));
+}
+
+/// A `filename` that names a host file whose content is not the JavaScript the
+/// compiler was fed -- a single-file component, an `.mdx`, a stale watch-mode
+/// read. The disk text is preferred but does not parse, so the frame keeps the
+/// text the compiler was given instead of losing the frame completely.
+#[test]
+fn a_file_that_does_not_parse_falls_back_to_the_given_text() {
+  let given = "\
+export const styles = create({
+  root: { color: 'red' },
+  other: { display: 'flex' },
+});
+";
+  let path = write_fixture(
+    "not_javascript.mdx",
+    "# A document\n\nThis is prose, and 1 + = is not an expression.\n",
+  );
+  let mut state = state_for_fixture(&path).with_input_source(given);
+  let call = compiled_create_call();
+
+  let line = GLOBALS.set(&Globals::default(), || {
+    match key_span_for(&call, "other", &mut state) {
+      Ok((code_frame, span)) => code_frame.try_get_span_line_number(span),
+      Err(error) => panic!("failed to get the key span: {error}"),
+    }
+  });
+
+  assert_eq!(line, Some(3));
 }

--- a/crates/stylex-diagnostics/src/tests/code_frame_test.rs
+++ b/crates/stylex-diagnostics/src/tests/code_frame_test.rs
@@ -873,6 +873,23 @@ fn a_module_memoized_without_its_text_is_printed_back_out() {
   assert_eq!(framed_line(&target, &mut state), Some(1));
 }
 
+/// Memoizes `source` the way a debug build does at module entry: parsed, and
+/// without its text. Must run inside the globals, because the parse mints
+/// marks.
+fn memoize_without_text(state: &mut StateDouble, source: &str) {
+  let frame = CodeFrame::new();
+  let source_file = frame
+    .source_map
+    .new_source_file(Arc::new(FileName::Anon), source.to_owned());
+  let program =
+    match parse_and_normalize_program(&source_file, &frame, "memoized.tsx", &reference("c")) {
+      Some(program) => program,
+      None => panic!("the fixture must parse"),
+    };
+
+  state.set_seen_module_source_code(expect_module(&program), None);
+}
+
 /// The authored text wins over a module printed back out. A debug build
 /// memoizes the module without its text at module entry, and the printer lays a
 /// one-line namespace out over three lines, so every key after it moved to a
@@ -889,19 +906,8 @@ export const styles = create({
   let mut state = StateDouble::for_file("/nonexistent/authored.tsx").with_input_source(source);
   let call = compiled_create_call();
 
-  // The parse and the lookup both mint marks, so both run inside the globals.
   let line = GLOBALS.set(&Globals::default(), || {
-    let frame = CodeFrame::new();
-    let source_file = frame
-      .source_map
-      .new_source_file(Arc::new(FileName::Anon), source.to_owned());
-    let program =
-      match parse_and_normalize_program(&source_file, &frame, "authored.tsx", &reference("c")) {
-        Some(program) => program,
-        None => panic!("the fixture must parse"),
-      };
-
-    state.set_seen_module_source_code(expect_module(&program), None);
+    memoize_without_text(&mut state, source);
 
     match key_span_for(&call, "other", &mut state) {
       Ok((code_frame, span)) => code_frame.try_get_span_line_number(span),
@@ -910,6 +916,64 @@ export const styles = create({
   });
 
   assert_eq!(line, Some(3));
+}
+
+/// The file on disk wins over the given text while `useRealFileForSource` is
+/// on, which is what the option promises: the text a bundler hands in may have
+/// been rewritten by an earlier loader, and the file is what the author sees.
+#[test]
+fn the_file_on_disk_is_quoted_before_the_given_text_when_the_option_is_on() {
+  // The same module, with a comment line before it on disk only.
+  let given = "\
+export const styles = create({
+  root: { color: 'red' },
+  other: { display: 'flex' },
+});
+";
+  let path = write_fixture("disk_first.tsx", &format!("// authored\n{given}"));
+  let mut state = state_for_fixture(&path).with_input_source(given);
+  let call = compiled_create_call();
+
+  let line = GLOBALS.set(&Globals::default(), || {
+    match key_span_for(&call, "other", &mut state) {
+      Ok((code_frame, span)) => code_frame.try_get_span_line_number(span),
+      Err(error) => panic!("failed to get the key span: {error}"),
+    }
+  });
+
+  assert_eq!(line, Some(4));
+}
+
+/// With `useRealFileForSource` off, the frame opens no file and quotes the
+/// module it holds, printed back out, as the option documents. The three
+/// sources put the key on three different lines, so the answer names the one
+/// that was read: the file on disk says 4, the given text 3, the printed module
+/// 5.
+#[test]
+fn a_memoized_module_is_printed_when_the_option_is_off() {
+  let source = "\
+export const styles = create({
+  root: { color: 'red' },
+  other: { display: 'flex' },
+});
+";
+  let path = write_fixture("printed.tsx", &format!("// authored\n{source}"));
+  let mut state = state_for_fixture(&path)
+    .with_input_source(source)
+    .with_disk_reads_off();
+  let call = compiled_create_call();
+
+  let line = GLOBALS.set(&Globals::default(), || {
+    memoize_without_text(&mut state, source);
+
+    match key_span_for(&call, "other", &mut state) {
+      Ok((code_frame, span)) => code_frame.try_get_span_line_number(span),
+      Err(error) => panic!("failed to get the key span: {error}"),
+    }
+  });
+
+  // The printer lays `root` out over three lines, so `other` moves to line 5.
+  assert_eq!(line, Some(5));
 }
 
 /// The panic boundary every span lookup sits behind: a panic inside it is an

--- a/crates/stylex-diagnostics/src/tests/state_double.rs
+++ b/crates/stylex-diagnostics/src/tests/state_double.rs
@@ -19,6 +19,9 @@ pub(crate) struct StateDouble {
   seen_module: Option<Module>,
   seen_source_code: Option<String>,
   input_source: Option<String>,
+  /// False by default, as `useRealFileForSource` defaults to on. A case sets
+  /// it to keep the frame away from the disk.
+  disk_reads_off: bool,
   key_span_index: OnceCell<KeySpanIndex>,
   memo: DiagnosticMemo,
   /// Drops the module as soon as it is stored, so the caller reads back the
@@ -39,6 +42,14 @@ impl StateDouble {
   pub(crate) fn with_input_source(self, source: impl Into<String>) -> Self {
     Self {
       input_source: Some(source.into()),
+      ..self
+    }
+  }
+
+  /// The same state with `useRealFileForSource` off, so the frame opens no file.
+  pub(crate) fn with_disk_reads_off(self) -> Self {
+    Self {
+      disk_reads_off: true,
       ..self
     }
   }
@@ -84,6 +95,10 @@ impl DiagnosticState for StateDouble {
 
   fn input_source_text(&self) -> Option<&str> {
     self.input_source.as_deref()
+  }
+
+  fn reads_source_from_disk(&self) -> bool {
+    !self.disk_reads_off
   }
 
   fn diagnostic_memo(&self) -> &DiagnosticMemo {

--- a/crates/stylex-diagnostics/src/tests/state_double.rs
+++ b/crates/stylex-diagnostics/src/tests/state_double.rs
@@ -6,8 +6,9 @@
 //! span index: it is built from the memoized module, so replacing that module
 //! has to drop it.
 
-use std::cell::OnceCell;
+use std::{cell::OnceCell, sync::Arc};
 
+use swc_core::common::SourceFile;
 use swc_core::ecma::ast::Module;
 
 use crate::{memo::DiagnosticMemo, state::DiagnosticState};
@@ -17,7 +18,7 @@ use stylex_state_index::key_span_index::KeySpanIndex;
 pub(crate) struct StateDouble {
   filename: String,
   seen_module: Option<Module>,
-  seen_source_code: Option<String>,
+  seen_source_file: Option<Arc<SourceFile>>,
   input_source: Option<String>,
   /// False by default, as `useRealFileForSource` defaults to on. A case sets
   /// it to keep the frame away from the disk.
@@ -69,16 +70,19 @@ impl DiagnosticState for StateDouble {
   }
 
   fn get_seen_module_source_code(&self) -> Option<(&Module, Option<&str>)> {
-    Some((self.seen_module.as_ref()?, self.seen_source_code.as_deref()))
+    Some((
+      self.seen_module.as_ref()?,
+      self.seen_source_file.as_ref().map(|file| file.src.as_str()),
+    ))
   }
 
-  fn set_seen_module_source_code(&mut self, module: &Module, source_code: Option<String>) {
+  fn set_seen_module_source_code(&mut self, module: &Module, source_file: Option<Arc<SourceFile>>) {
     if self.forgets_the_module {
       return;
     }
 
     self.seen_module = Some(module.clone());
-    self.seen_source_code = source_code;
+    self.seen_source_file = source_file;
     // Built from the module above, so a new module invalidates it.
     self.key_span_index = OnceCell::new();
   }

--- a/crates/stylex-diagnostics/src/tests/state_double.rs
+++ b/crates/stylex-diagnostics/src/tests/state_double.rs
@@ -18,6 +18,7 @@ pub(crate) struct StateDouble {
   filename: String,
   seen_module: Option<Module>,
   seen_source_code: Option<String>,
+  input_source: Option<String>,
   key_span_index: OnceCell<KeySpanIndex>,
   memo: DiagnosticMemo,
   /// Drops the module as soon as it is stored, so the caller reads back the
@@ -31,6 +32,14 @@ impl StateDouble {
     Self {
       filename: filename.into(),
       ..Self::default()
+    }
+  }
+
+  /// The same state, holding the text the compiler was given for the file.
+  pub(crate) fn with_input_source(self, source: impl Into<String>) -> Self {
+    Self {
+      input_source: Some(source.into()),
+      ..self
     }
   }
 
@@ -71,6 +80,10 @@ impl DiagnosticState for StateDouble {
         .key_span_index
         .get_or_init(|| KeySpanIndex::build(module)),
     )
+  }
+
+  fn input_source_text(&self) -> Option<&str> {
+    self.input_source.as_deref()
   }
 
   fn diagnostic_memo(&self) -> &DiagnosticMemo {

--- a/crates/stylex-path-resolver/src/resolvers/unit_tests.rs
+++ b/crates/stylex-path-resolver/src/resolvers/unit_tests.rs
@@ -297,7 +297,14 @@ fn try_resolve_as_module_returns_none_for_non_utf8_path() {
 }
 
 /// No-op `log` sink whose only purpose is to let `debug!` calls fire so their
-/// (lazily-evaluated) arguments are exercised. Installed once per test binary.
+/// (lazily-evaluated) arguments are exercised.
+///
+/// The message itself cannot be read back here: `src/tests.rs` installs
+/// `pretty_env_logger` from a constructor before any case runs, and `log` takes
+/// one logger per process, so a capturing logger can never be the one in place.
+/// What a case controls is the level, and the level is what decides whether the
+/// arguments run: the macro builds its `format_args!` -- and with it every
+/// argument expression -- as soon as `log::max_level()` admits the level.
 struct DebugSink;
 
 impl log::Log for DebugSink {
@@ -310,6 +317,17 @@ impl log::Log for DebugSink {
 
 static DEBUG_SINK: DebugSink = DebugSink;
 
+/// Turns debug logging on, and answers the level that was in force so the case
+/// can put it back.
+fn enable_debug_logging() -> log::LevelFilter {
+  let previous_level = log::max_level();
+
+  let _ = log::set_logger(&DEBUG_SINK);
+  log::set_max_level(log::LevelFilter::Debug);
+
+  previous_level
+}
+
 /// Same successful `/ROOT/` rewrite as above, but with debug logging enabled so
 /// the `debug!("rewrote /ROOT/ aliased path …")` in `try_resolve_aliased_path`
 /// actually formats its arguments. `debug!` is lazy — its argument expressions
@@ -318,9 +336,7 @@ static DEBUG_SINK: DebugSink = DebugSink;
 #[test]
 #[serial_test::serial]
 fn resolve_file_path_root_placeholder_rewrite_logs_at_debug() {
-  let previous_level = log::max_level();
-  let _ = log::set_logger(&DEBUG_SINK);
-  log::set_max_level(log::LevelFilter::Debug);
+  let previous_level = enable_debug_logging();
 
   let root = fixture_root("application-pnpm");
 
@@ -366,6 +382,36 @@ fn resolve_file_path_root_placeholder_without_root_dir_is_not_found() {
 
   assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
   assert!(err.to_string().contains("@consts/colors.stylex"));
+}
+
+/// The same unrewritable placeholder as above, with debug logging on, so the
+/// `debug!("skipping /ROOT/ aliased path ...")` that explains the failure
+/// formats its arguments. Without a logger the message is never built, and a
+/// resolution that fails for this reason gives the reader nothing to go on.
+#[test]
+#[serial_test::serial]
+fn resolve_file_path_root_placeholder_without_root_dir_says_why_at_debug() {
+  let previous_level = enable_debug_logging();
+
+  let root = fixture_root("application-pnpm");
+
+  let mut package_json_seen = FxHashMap::<String, PackageJsonExtended>::default();
+  let mut aliases = FxHashMap::<String, Vec<String>>::default();
+  aliases.insert("@consts/*".to_string(), vec!["/ROOT/src/*".to_string()]);
+
+  let err = resolve_file_path(
+    "@consts/colors.stylex",
+    root.join("src/pages/home.js").to_str().unwrap(),
+    root.to_str().unwrap(),
+    &aliases,
+    None,
+    &mut package_json_seen,
+  )
+  .unwrap_err();
+
+  log::set_max_level(previous_level);
+
+  assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
 }
 
 /// When a `/ROOT/` alias is rewritten against a configured `root_dir` but the

--- a/crates/stylex-rs-compiler/README.md
+++ b/crates/stylex-rs-compiler/README.md
@@ -443,7 +443,8 @@ depend on this option.
 
 - **`true` (default)**: the compiler reads the actual source file from disk when
   generating error messages and source maps. This provides accurate line numbers
-  and source context that match what you see in your editor. Style namespaces
+  and source context that match what you see in your editor. When the file is
+  not on disk, the source text given to the compiler is used. Style namespaces
   are located **by their key**, so positions resolve correctly even when the
   incoming code was already rewritten by earlier tooling (keys survive
   value-level transforms such as macro expansion).

--- a/crates/stylex-rs-compiler/README.md
+++ b/crates/stylex-rs-compiler/README.md
@@ -431,6 +431,31 @@ const { map } = transform(filename, inputCode, {
 > first. To get line-granularity output from a chain, emit the _input_ map
 > without columns.
 
+### `enableDevClassNames`
+
+**Type:** `boolean` **Default:** the value of `dev`
+
+Adds a readable name to each style namespace, so an element in the browser
+inspector says where its styles were written.
+
+The name is built from the file, the variable the `stylex.create` call is bound
+to, and the namespace: a `root` namespace of a `styles` variable in
+`MyComponent.tsx` gets `MyComponent__styles.root`. An `sx` value has no variable
+and no namespace of its own, so it gets `MyComponent__sx`. The name is added
+beside the generated class names and never replaces them.
+
+- **unset (default)**: follows `dev`. A development build names each
+  namespace; a production build adds nothing.
+- **`true`**: names each namespace, but only in a development build. `dev` must
+  also be on, because a production build never carries debug names.
+- **`false`**: adds no names, even in a development build.
+
+> [!NOTE]
+> A character that a class name cannot hold is removed from the name. So two
+> namespaces whose names differ only in such a character, `p+1` and `p1`, get
+> the same debug name. The name is a label to read and not a selector, so a
+> duplicate is harmless.
+
 ### `useRealFileForSource`
 
 **Type:** `boolean` **Default:** `true`

--- a/crates/stylex-rs-compiler/__test__/memoryLeak.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/memoryLeak.spec.ts
@@ -3,27 +3,14 @@ import { fileURLToPath } from 'node:url';
 
 import { expect, test } from 'vitest';
 
-import { runNodeScript } from './nodeScript';
+import { runNodeScriptOrThrow } from './nodeScript';
 
 const LEAK_STRING = 'ObjectRef is not unref';
 
 const distEntry = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist/index.js');
 
 function runProductionScript(script: string) {
-  const result = runNodeScript(script, { env: { ...process.env, NODE_ENV: 'production' } });
-
-  // A child that never starts has no exit code. Name that cause, because an
-  // exit code of null on its own reads as a crash of the script.
-  if (result.error) {
-    throw new Error(`subprocess did not start: ${result.error.message}`);
-  }
-
-  if (result.status !== 0) {
-    throw new Error(
-      `subprocess failed (exit ${result.status}):\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
-    );
-  }
-  return result;
+  return runNodeScriptOrThrow(script, { env: { ...process.env, NODE_ENV: 'production' } });
 }
 
 test('normalizeRsOptions does not emit napi leak warnings across many calls', () => {

--- a/crates/stylex-rs-compiler/__test__/nestedScopeDynamicStyles.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/nestedScopeDynamicStyles.spec.ts
@@ -153,6 +153,41 @@ function renderInChild({ render, source }: Case, values: readonly string[]): unk
   return results;
 }
 
+/** A module whose nested `stylex.create` gets hoisted to a generated name. */
+function hoistingSource(namespace: string): string {
+  return `
+    import * as stylex from '@stylexjs/stylex';
+    export function render(value: string) {
+      const styles = stylex.create({
+        ${namespace}: (v: string) => ({ color: v }),
+      });
+      return stylex.props(styles.${namespace}(value));
+    }
+  `;
+}
+
+describe('the name of a hoisted styles object', () => {
+  // The generated name is counted per file. A count shared between files would
+  // make the name depend on how many files the compiler saw first, so the same
+  // input would compile two ways and no output could be cached by its content.
+  test('does not depend on what was compiled before it', () => {
+    const first = compile(hoistingSource('color'));
+
+    // Another file, which takes a generated name of its own.
+    compile(hoistingSource('background'));
+
+    expect(compile(hoistingSource('color'))).toBe(first);
+  });
+
+  test('is the first free name however many files came before', () => {
+    for (let index = 0; index < 5; index += 1) {
+      compile(hoistingSource(`entry${index}`));
+    }
+
+    expect(compile(hoistingSource('color'))).toContain('const _styles = {');
+  });
+});
+
 describe('a dynamic entry in a nested scope', () => {
   test.each(Object.entries(CASES))(
     '%s: the entry is callable and the sibling is intact',

--- a/crates/stylex-rs-compiler/__test__/nestedScopeDynamicStyles.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/nestedScopeDynamicStyles.spec.ts
@@ -11,7 +11,7 @@ import { transformSync } from '@swc/core';
 import { describe, expect, test } from 'vitest';
 
 import { transform } from '../dist/index.js';
-import { runNodeScript } from './nodeScript';
+import { runNodeScriptOrThrow } from './nodeScript';
 
 /** The compiled class name object for `color: var(--x-color)`. */
 const COLOR_CLASS = { kMwMTN: 'x14rh7hd', $$css: true } as const;
@@ -143,16 +143,7 @@ function renderInChild({ render, source }: Case, values: readonly string[]): unk
     const results = ${JSON.stringify(values)}.map((value) => module.exports.${render}(value));
     process.stdout.write(JSON.stringify(results));
   `;
-  const outcome = runNodeScript(script);
-
-  if (outcome.error) {
-    throw new Error(`The child process did not start: ${outcome.error.message}`);
-  }
-
-  if (outcome.status !== 0) {
-    throw new Error(`The compiled output failed (exit ${outcome.status}):\n${outcome.stderr}`);
-  }
-
+  const outcome = runNodeScriptOrThrow(script);
   const results: unknown = JSON.parse(outcome.stdout);
 
   if (!Array.isArray(results)) {

--- a/crates/stylex-rs-compiler/__test__/nestedScopeDynamicStyles.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/nestedScopeDynamicStyles.spec.ts
@@ -1,0 +1,188 @@
+// A dynamic `stylex.create` entry declared inside a nested scope must stay a
+// function after compilation (#1303). The Rust suite holds the snapshots. This
+// suite runs the compiled output, because the report was a run-time failure:
+// `styles.color is not a function`. A snapshot cannot show that the call
+// works, only what it looks like.
+//
+// The output runs in a child process with the shipped native binding, so the
+// assertion is about `dist/*.node` and not about the Rust sources. Rebuild the
+// binding before this suite means anything.
+import { transformSync } from '@swc/core';
+import { describe, expect, test } from 'vitest';
+
+import { transform } from '../dist/index.js';
+import { runNodeScript } from './nodeScript';
+
+/** The compiled class name object for `color: var(--x-color)`. */
+const COLOR_CLASS = { kMwMTN: 'x14rh7hd', $$css: true } as const;
+/** The compiled style object for `display: flex`. */
+const BASE_STYLE = { k1xSpc: 'x78zum5', $$css: true } as const;
+
+/**
+ * How many entries the many-entry case declares of each kind.
+ *
+ * The rewrite runs once per dynamic entry. A fault that rewrites only the
+ * first entry, or only the entries before a static sibling, passes a case with
+ * two entries. The number is only "many"; no threshold is known.
+ */
+const ENTRY_COUNT = 150;
+
+/** One compiled module and the export that renders a value. */
+interface Case {
+  readonly source: string;
+  /** The path of the render function under `module.exports`. */
+  readonly render: string;
+}
+
+/** The two scopes the issue reported, each with a static sibling. */
+const CASES = {
+  namespace: {
+    render: 'Demo.render',
+    source: `
+      import * as stylex from '@stylexjs/stylex';
+      export namespace Demo {
+        const styles = stylex.create({
+          color: (value: string) => ({ color: value }),
+          base: { display: 'flex' },
+        });
+        export function render(value: string) {
+          return stylex.props(styles.base, styles.color(value));
+        }
+      }
+    `,
+  },
+  iife: {
+    render: 'render',
+    source: `
+      import * as stylex from '@stylexjs/stylex';
+      export const render = (() => {
+        const styles = stylex.create({
+          color: (value: string) => ({ color: value }),
+          base: { display: 'flex' },
+        });
+        return (value: string) => stylex.props(styles.base, styles.color(value));
+      })();
+    `,
+  },
+} as const satisfies Record<string, Case>;
+
+/** A function body with many dynamic entries, each beside a static sibling. */
+function manyEntriesCase(count: number): Case {
+  const entries = Array.from({ length: count }, (_, index) =>
+    [
+      `dynamic${index}: (value: string) => ({ color: value }),`,
+      `static${index}: { display: 'flex' },`,
+    ].join('\n')
+  ).join('\n');
+  const calls = Array.from(
+    { length: count },
+    (_, index) => `stylex.props(styles.static${index}, styles.dynamic${index}(value))`
+  ).join(',\n');
+
+  return {
+    render: 'render',
+    source: `
+      import * as stylex from '@stylexjs/stylex';
+      export function render(value: string) {
+        const styles = stylex.create({
+          ${entries}
+        });
+        return [${calls}];
+      }
+    `,
+  };
+}
+
+/** Compiles one source with the shipped binding, as a bundler would. */
+function compile(source: string): string {
+  const result = transform('MyComponent.tsx', source, {
+    dev: false,
+    runtimeInjection: false,
+    treeshakeCompensation: true,
+    unstable_moduleResolution: { type: 'commonJS' },
+  });
+
+  return result.code;
+}
+
+/**
+ * Lowers the compiled TypeScript module to a CommonJS body.
+ *
+ * The compiled output keeps the TypeScript syntax of the input, and a namespace
+ * is not erasable, so the child cannot run it as it is.
+ */
+function toCommonJs(code: string): string {
+  return transformSync(code, {
+    filename: 'MyComponent.tsx',
+    jsc: { parser: { syntax: 'typescript', tsx: true }, target: 'es2022' },
+    module: { type: 'commonjs' },
+  }).code;
+}
+
+/**
+ * Runs the compiled module in a child process and returns what its render
+ * function answered for each value.
+ *
+ * `stylex.props` is a stub that returns its arguments, so the result holds the
+ * compiled style objects themselves and the assertions can name them.
+ */
+function renderInChild({ render, source }: Case, values: readonly string[]): unknown[] {
+  const body = toCommonJs(compile(source));
+  const script = `
+    const stylex = { props: (...styles) => styles };
+    const requireForCompiled = (id) => {
+      if (id === '@stylexjs/stylex') return stylex;
+      throw new Error('The compiled module imported ' + id);
+    };
+    const module = { exports: {} };
+    new Function('require', 'module', 'exports', ${JSON.stringify(body)})(
+      requireForCompiled,
+      module,
+      module.exports
+    );
+    const results = ${JSON.stringify(values)}.map((value) => module.exports.${render}(value));
+    process.stdout.write(JSON.stringify(results));
+  `;
+  const outcome = runNodeScript(script);
+
+  if (outcome.error) {
+    throw new Error(`The child process did not start: ${outcome.error.message}`);
+  }
+
+  if (outcome.status !== 0) {
+    throw new Error(`The compiled output failed (exit ${outcome.status}):\n${outcome.stderr}`);
+  }
+
+  const results: unknown = JSON.parse(outcome.stdout);
+
+  if (!Array.isArray(results)) {
+    throw new Error(`The child process answered no array:\n${outcome.stdout}`);
+  }
+
+  return results;
+}
+
+describe('a dynamic entry in a nested scope', () => {
+  test.each(Object.entries(CASES))(
+    '%s: the entry is callable and the sibling is intact',
+    (_name, testCase) => {
+      const [red, blue] = renderInChild(testCase, ['red', 'blue']);
+
+      // Each call gives the static sibling, then the dynamic entry: the class
+      // name object and the inline variable that carries the argument.
+      expect(red).toStrictEqual([BASE_STYLE, [COLOR_CLASS, { '--x-color': 'red' }]]);
+      expect(blue).toStrictEqual([BASE_STYLE, [COLOR_CLASS, { '--x-color': 'blue' }]]);
+    }
+  );
+
+  test('a function body with many entries answers every call', () => {
+    const [results] = renderInChild(manyEntriesCase(ENTRY_COUNT), ['green']);
+
+    expect(results).toStrictEqual(
+      Array.from({ length: ENTRY_COUNT }, () => [
+        BASE_STYLE,
+        [COLOR_CLASS, { '--x-color': 'green' }],
+      ])
+    );
+  });
+});

--- a/crates/stylex-rs-compiler/__test__/nodeScript.spec.ts
+++ b/crates/stylex-rs-compiler/__test__/nodeScript.spec.ts
@@ -6,7 +6,7 @@ import { existsSync } from 'node:fs';
 
 import { describe, expect, test } from 'vitest';
 
-import { runNodeScript } from './nodeScript';
+import { runNodeScript, runNodeScriptOrThrow } from './nodeScript';
 
 /** The longest command line that Windows accepts. */
 const WINDOWS_COMMAND_LINE_LIMIT = 32_767;
@@ -112,5 +112,20 @@ describe('runNodeScript', () => {
     expect(outcome.error).toBeUndefined();
     expect(outcome.status).toBe(0);
     expect(outcome.stdout).toHaveLength(size);
+  });
+});
+
+describe('runNodeScriptOrThrow', () => {
+  test('returns the outcome of a script that exits cleanly', () => {
+    const outcome = runNodeScriptOrThrow('process.stdout.write("clean");');
+
+    expect(outcome.status).toBe(0);
+    expect(outcome.stdout).toBe('clean');
+  });
+
+  test('throws with the exit code and what the script wrote when it fails', () => {
+    expect(() =>
+      runNodeScriptOrThrow('console.error("expected failure"); process.exit(3);')
+    ).toThrow(/exit 3[\s\S]*expected failure/);
   });
 });

--- a/crates/stylex-rs-compiler/__test__/nodeScript.ts
+++ b/crates/stylex-rs-compiler/__test__/nodeScript.ts
@@ -84,3 +84,32 @@ export function runNodeScript(source: string, options: NodeScriptOptions = {}): 
     rmSync(directory, { force: true, recursive: true });
   }
 }
+
+/**
+ * Runs one JavaScript source in a child Node process and returns the outcome
+ * only when the child ran to a clean exit.
+ *
+ * A child that never started, or that ended with a signal or an exit code other
+ * than zero, throws with the cause named. An exit code of null on its own reads
+ * as a crash of the script, and a suite that asserts on the output of a
+ * healthy child should not have to tell the two apart itself.
+ */
+export function runNodeScriptOrThrow(
+  source: string,
+  options: NodeScriptOptions = {}
+): NodeScriptOutcome {
+  const outcome = runNodeScript(source, options);
+
+  if (outcome.error) {
+    throw new Error(`The child process did not start: ${outcome.error.message}`);
+  }
+
+  if (outcome.status !== 0) {
+    throw new Error(
+      `The child process failed (exit ${outcome.status}, signal ${outcome.signal}):\n` +
+        `stdout:\n${outcome.stdout}\nstderr:\n${outcome.stderr}`
+    );
+  }
+
+  return outcome;
+}

--- a/crates/stylex-rs-compiler/src/structs/mod.rs
+++ b/crates/stylex-rs-compiler/src/structs/mod.rs
@@ -43,6 +43,7 @@ pub struct StyleXOptions {
   pub debug: Option<bool>,
   pub enable_debug_class_names: Option<bool>,
   pub enable_debug_data_prop: Option<bool>,
+  /// Defaults to the value of `dev`.
   pub enable_dev_class_names: Option<bool>,
   pub enable_minified_keys: Option<bool>,
   pub inject_stylex_side_effects: Option<bool>,

--- a/crates/stylex-state-index/src/tests/key_span_index_test.rs
+++ b/crates/stylex-state-index/src/tests/key_span_index_test.rs
@@ -157,6 +157,27 @@ const styles = stylex.create({
   }
 
   #[test]
+  fn resolves_a_key_written_inside_a_typescript_namespace() {
+    let source = "\
+import * as stylex from '@stylexjs/stylex';
+export namespace Demo {
+  const styles = stylex.create({
+    color: (value: string) => ({ color: value }),
+    base: { display: 'flex' },
+  });
+  export function render() {
+    return stylex.props(styles.base, styles.color('red'));
+  }
+}
+";
+
+    assert_eq!(
+      resolved_line(source, "base", &["color", "base"], &["display"]),
+      line_of(source, "base:")
+    );
+  }
+
+  #[test]
   fn a_key_no_object_argument_spells_resolves_to_nothing() {
     let module = parse("const styles = stylex.create({ root: { color: 'red' } });");
 

--- a/crates/stylex-state/src/state_manager.rs
+++ b/crates/stylex-state/src/state_manager.rs
@@ -622,6 +622,13 @@ pub struct StateManager {
   /// whether a name is already bound in the module.
   pub bound_names: FxHashSet<String>,
 
+  /// How many module-level names each stem has given out, for
+  /// [`StateManager::next_hoisted_ident`].
+  ///
+  /// One count per file. A count shared between files would make the name of a
+  /// hoisted expression depend on how many files came before it.
+  hoisted_ident_counts: FxHashMap<&'static str, usize>,
+
   /// For each name bound by a non-import declaration (var/let/const,
   /// function/class names, params), the source spans of the scopes in which
   /// it is bound. Consumed by `get_stylex_runtime_binding` to avoid reusing
@@ -920,6 +927,7 @@ impl StateManager {
       imports: ImportState::default(),
       existing_import_sources: vec![],
       bound_names: FxHashSet::default(),
+      hoisted_ident_counts: FxHashMap::default(),
       local_rebinding_scopes: FxHashMap::default(),
       style_map: FxHashMap::default(),
       style_vars: FxHashMap::default(),
@@ -1445,6 +1453,38 @@ impl StateManager {
   /// Backed by the [`StateManager::bound_names`] pre-scan.
   pub fn has_binding(&self, name: &str) -> bool {
     self.bound_names.contains(name)
+  }
+
+  /// The next free module-level name built on `stem`, for an expression the
+  /// compiler lifts to the top of the file.
+  ///
+  /// The first name of a stem carries no number, so `temp` gives `_temp` and
+  /// then `_temp2`. A name the module already binds is passed over: the
+  /// generated declaration sits beside the author's own, and the two would
+  /// print as one name.
+  pub fn next_hoisted_ident(&mut self, stem: &'static str) -> Ident {
+    loop {
+      let count = self.hoisted_ident_counts.entry(stem).or_insert(1);
+      let ordinal = *count;
+
+      *count += 1;
+
+      let name = if ordinal < 2 {
+        format!("_{stem}")
+      } else {
+        format!("_{stem}{ordinal}")
+      };
+
+      if !self.has_binding(&name) {
+        // The declaration this name goes on is a binding of the module like any
+        // other, so anything that asks `has_binding` later reads it too.
+        let ident = Ident::from(name.as_str());
+
+        self.bound_names.insert(name);
+
+        return ident;
+      }
+    }
   }
 
   /// Whether `name` is bound by a non-import declaration whose scope encloses
@@ -2240,12 +2280,17 @@ impl StateManager {
     found
   }
 
+  /// Files the styles of one call and points the call site at `ast`.
+  ///
+  /// `fallback_ast_hash` names the object a hoisted call site was replaced by.
+  /// The caller holds that object only to hash it, so it hands over the hash
+  /// and keeps the object out of a clone the size of the whole style map.
   pub fn register_styles(
     &mut self,
     call: &CallExpr,
     style: &InjectableStylesMap,
     ast: &Expr,
-    fallback_ast: Option<&Expr>,
+    fallback_ast_hash: Option<u128>,
   ) {
     // Early return if there are no styles to process
     if style.is_empty() {
@@ -2256,10 +2301,9 @@ impl StateManager {
     let metadatas = MetaData::convert_from_injected_styles_map(style);
     let inject_var_ident = self.setup_injection_imports();
 
-    // The hashes key the injection slots and do not change per rule, so they
-    // are computed once here and not once per metadata in the loop.
+    // The hash keys the injection slots and does not change per rule, so it is
+    // computed once here and not once per metadata in the loop.
     let ast_hash = stable_hash_unspanned(ast);
-    let fallback_ast_hash = fallback_ast.map(stable_hash_unspanned);
 
     for metadata in metadatas {
       self.add_style(&metadata);
@@ -2267,7 +2311,7 @@ impl StateManager {
     }
 
     // Update all references to this call expression with the new AST
-    self.update_references(call, ast, fallback_ast);
+    self.update_references(call, ast);
   }
 
   /// Registers injected styles produced by the atoms transform.
@@ -2367,7 +2411,7 @@ impl StateManager {
     inject_var_ident
   }
 
-  fn update_references(&mut self, call: &CallExpr, ast: &Expr, _fallback_ast: Option<&Expr>) {
+  fn update_references(&mut self, call: &CallExpr, ast: &Expr) {
     if let Some(position) = self.find_call_declaration_index(call) {
       self.set_declaration_init(position, ast.clone());
     }
@@ -2400,9 +2444,9 @@ impl StateManager {
   /// to, once per declaration.
   ///
   /// `ast_hash` names the declaration the styles land in, and
-  /// `fallback_ast_hash` the object a hoisted call site was replaced by. Both
-  /// are the stable hashes of the expressions `register_styles` receives, and
-  /// it computes them once for all the rules of one call.
+  /// `fallback_ast_hash` the object a hoisted call site was replaced by.
+  /// `register_styles` hashes the first once for all the rules of one call, and
+  /// the second reaches it already hashed by its own caller.
   fn add_style_to_inject(
     &mut self,
     metadata: &MetaData,

--- a/crates/stylex-state/src/state_manager.rs
+++ b/crates/stylex-state/src/state_manager.rs
@@ -2924,6 +2924,13 @@ impl DiagnosticState for StateManager {
     self.module_source.key_span_index()
   }
 
+  fn input_source_text(&self) -> Option<&str> {
+    self
+      .input_source_file
+      .as_ref()
+      .map(|file| file.src.as_str())
+  }
+
   fn diagnostic_memo(&self) -> &DiagnosticMemo {
     &self.diagnostic_memo
   }

--- a/crates/stylex-state/src/state_manager.rs
+++ b/crates/stylex-state/src/state_manager.rs
@@ -2256,9 +2256,14 @@ impl StateManager {
     let metadatas = MetaData::convert_from_injected_styles_map(style);
     let inject_var_ident = self.setup_injection_imports();
 
+    // The hashes key the injection slots and do not change per rule, so they
+    // are computed once here and not once per metadata in the loop.
+    let ast_hash = stable_hash_unspanned(ast);
+    let fallback_ast_hash = fallback_ast.map(stable_hash_unspanned);
+
     for metadata in metadatas {
       self.add_style(&metadata);
-      self.add_style_to_inject(&metadata, &inject_var_ident, ast, fallback_ast);
+      self.add_style_to_inject(&metadata, &inject_var_ident, ast_hash, fallback_ast_hash);
     }
 
     // Update all references to this call expression with the new AST
@@ -2391,12 +2396,19 @@ impl StateManager {
     }
   }
 
+  /// Queues the injection call for one rule before each declaration it belongs
+  /// to, once per declaration.
+  ///
+  /// `ast_hash` names the declaration the styles land in, and
+  /// `fallback_ast_hash` the object a hoisted call site was replaced by. Both
+  /// are the stable hashes of the expressions `register_styles` receives, and
+  /// it computes them once for all the rules of one call.
   fn add_style_to_inject(
     &mut self,
     metadata: &MetaData,
     inject_var_ident: &Ident,
-    ast: &Expr,
-    fallback_ast: Option<&Expr>,
+    ast_hash: u128,
+    fallback_ast_hash: Option<u128>,
   ) {
     let priority = metadata.get_priority();
     let css_ltr = metadata.get_css();
@@ -2439,7 +2451,6 @@ impl StateManager {
       expr: Box::new(stylex_call),
     }));
 
-    let ast_hash = stable_hash_unspanned(ast);
     let normalized_module = module;
 
     // Per-decl dedup: keying by `ast_hash` keeps the per-bucket
@@ -2460,8 +2471,7 @@ impl StateManager {
       bucket.push(normalized_module.clone());
     }
 
-    if let Some(fallback_ast) = fallback_ast {
-      let fallback_ast_hash = stable_hash_unspanned(fallback_ast);
+    if let Some(fallback_ast_hash) = fallback_ast_hash {
       let fallback_bucket = self
         .injection
         .queued_decl_items

--- a/crates/stylex-state/src/state_manager.rs
+++ b/crates/stylex-state/src/state_manager.rs
@@ -273,14 +273,17 @@ impl ModuleSourceState {
 
     Some((
       &seen_module_source.module,
-      seen_module_source.source_code.as_deref(),
+      seen_module_source
+        .source_file
+        .as_ref()
+        .map(|file| file.src.as_str()),
     ))
   }
 
-  fn set_seen_module_source_code(&mut self, module: &Module, source_code: Option<String>) {
+  fn set_seen_module_source_code(&mut self, module: &Module, source_file: Option<Arc<SourceFile>>) {
     self.seen_module_source_code = Some(Rc::new(SeenModuleSource {
       module: module.clone(),
-      source_code,
+      source_file,
       // Built from the module above, so it cannot outlive it.
       key_span_index: OnceCell::new(),
     }));
@@ -1744,10 +1747,14 @@ impl StateManager {
   }
 
   /// Sets the source code module (marks as not yet normalized)
-  pub fn set_seen_module_source_code(&mut self, module: &Module, source_code: Option<String>) {
+  pub fn set_seen_module_source_code(
+    &mut self,
+    module: &Module,
+    source_file: Option<Arc<SourceFile>>,
+  ) {
     self
       .module_source
-      .set_seen_module_source_code(module, source_code);
+      .set_seen_module_source_code(module, source_file);
   }
 
   pub fn import_as(&self, import: &str) -> Option<&str> {
@@ -2968,10 +2975,10 @@ impl DiagnosticState for StateManager {
     self.module_source.get_seen_module_source_code()
   }
 
-  fn set_seen_module_source_code(&mut self, module: &Module, source_code: Option<String>) {
+  fn set_seen_module_source_code(&mut self, module: &Module, source_file: Option<Arc<SourceFile>>) {
     self
       .module_source
-      .set_seen_module_source_code(module, source_code);
+      .set_seen_module_source_code(module, source_file);
   }
 
   fn key_span_index(&self) -> Option<&KeySpanIndex> {

--- a/crates/stylex-state/src/state_manager.rs
+++ b/crates/stylex-state/src/state_manager.rs
@@ -2931,6 +2931,10 @@ impl DiagnosticState for StateManager {
       .map(|file| file.src.as_str())
   }
 
+  fn reads_source_from_disk(&self) -> bool {
+    self.options.use_real_file_for_source
+  }
+
   fn diagnostic_memo(&self) -> &DiagnosticMemo {
     &self.diagnostic_memo
   }

--- a/crates/stylex-state/src/tests/capturing_logger.rs
+++ b/crates/stylex-state/src/tests/capturing_logger.rs
@@ -1,0 +1,67 @@
+//! A logger the tests can read back, so a reporting path is covered by an
+//! assertion rather than by a coverage exclusion.
+//!
+//! A `log` macro builds its message only when `log::max_level` admits it, so
+//! every argument of every message is unexecuted code until a logger is in
+//! place. Reading the message back then makes the message itself the subject of
+//! a case.
+//!
+//! Both the level and the messages are per thread, because the harness runs
+//! tests in parallel and one global level would let one case decide what
+//! another one sees. `log::max_level` stays wide open; the per-thread level is
+//! what [`Log::enabled`] answers from.
+//!
+//! The same helper as `stylex_diagnostics`'s. `log` takes one logger for the
+//! whole process and every test binary is a process of its own, so each crate
+//! that reads its messages back holds its own copy.
+
+use std::cell::RefCell;
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+thread_local! {
+  static LEVEL: RefCell<LevelFilter> = const { RefCell::new(LevelFilter::Off) };
+  static MESSAGES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+struct CapturingLogger;
+
+impl Log for CapturingLogger {
+  fn enabled(&self, metadata: &Metadata) -> bool {
+    LEVEL.with_borrow(|level| metadata.level() <= *level)
+  }
+
+  fn log(&self, record: &Record) {
+    if !self.enabled(record.metadata()) {
+      return;
+    }
+
+    MESSAGES.with_borrow_mut(|messages| messages.push(record.args().to_string()));
+  }
+
+  fn flush(&self) {}
+}
+
+/// Installs the logger, on the first case that reads a message back.
+///
+/// A second call answers `Err`, which is the expected reply once the logger is
+/// in place.
+fn install() {
+  if log::set_boxed_logger(Box::new(CapturingLogger)).is_ok() {
+    log::set_max_level(LevelFilter::Trace);
+  }
+}
+
+/// Runs `body` with this thread logging at `level`, and hands back everything
+/// it wrote.
+pub(crate) fn logged_at<T>(level: Level, body: impl FnOnce() -> T) -> Vec<String> {
+  install();
+
+  LEVEL.with_borrow_mut(|current| *current = level.to_level_filter());
+  MESSAGES.with_borrow_mut(Vec::clear);
+
+  body();
+
+  LEVEL.with_borrow_mut(|current| *current = LevelFilter::Off);
+  MESSAGES.with_borrow(Clone::clone)
+}

--- a/crates/stylex-state/src/tests/diagnostic_state_test.rs
+++ b/crates/stylex-state/src/tests/diagnostic_state_test.rs
@@ -35,6 +35,14 @@ fn state_for_file(filename: &str) -> StateManager {
   state
 }
 
+/// The source file the frame hands the state: the text, registered in a map of
+/// its own, exactly as a diagnostic registers it before it parses.
+fn source_file_of(source: &str) -> Arc<SourceFile> {
+  let source_map: Lrc<SourceMap> = Default::default();
+
+  source_map.new_source_file(FileName::Anon.into(), source.to_owned())
+}
+
 /// Parses a module into a source map of its own, so its first byte is
 /// `BytePos(1)` -- the one arrangement where an offset into the file and a
 /// `BytePos` are interchangeable. Every case here resolves a key against the
@@ -121,7 +129,7 @@ fn the_memoized_module_and_its_text_come_back_as_they_went_in() {
   let module = parse(source);
   let mut state = StateManager::default();
 
-  DiagnosticState::set_seen_module_source_code(&mut state, &module, Some(String::from(source)));
+  DiagnosticState::set_seen_module_source_code(&mut state, &module, Some(source_file_of(source)));
 
   let (seen, text) =
     DiagnosticState::get_seen_module_source_code(&state).expect("the module was just memoized");
@@ -156,7 +164,7 @@ fn the_key_span_index_places_a_namespace_of_the_memoized_module() {
   let call = first_call(&module);
   let mut state = StateManager::default();
 
-  DiagnosticState::set_seen_module_source_code(&mut state, &module, Some(String::from(source)));
+  DiagnosticState::set_seen_module_source_code(&mut state, &module, Some(source_file_of(source)));
 
   assert!(!resolve_key(&state, &module, &call, "root").is_dummy());
   assert!(resolve_key(&state, &module, &call, "absent").is_dummy());
@@ -180,7 +188,7 @@ fn replacing_the_memoized_module_drops_the_index_built_from_it() {
   DiagnosticState::set_seen_module_source_code(
     &mut state,
     &first,
-    Some(String::from(first_source)),
+    Some(source_file_of(first_source)),
   );
   // Built here, so the replacement below has something to drop.
   assert!(!resolve_key(&state, &first, &first_call_expr, "root").is_dummy());
@@ -188,7 +196,7 @@ fn replacing_the_memoized_module_drops_the_index_built_from_it() {
   DiagnosticState::set_seen_module_source_code(
     &mut state,
     &second,
-    Some(String::from(second_source)),
+    Some(source_file_of(second_source)),
   );
 
   assert!(

--- a/crates/stylex-state/src/tests/diagnostic_state_test.rs
+++ b/crates/stylex-state/src/tests/diagnostic_state_test.rs
@@ -9,9 +9,11 @@
 //! type, tested in their own crate. What is asserted is that this manager hands
 //! back one memo rather than a fresh one per question.
 
+use std::{path::PathBuf, sync::Arc};
+
 use swc_core::{
   atoms::Atom,
-  common::{BytePos, FileName, SourceMap, Span, sync::Lrc},
+  common::{BytePos, FileName, SourceFile, SourceMap, Span, sync::Lrc},
   ecma::{
     ast::{CallExpr, EsVersion, Expr, Module, ModuleItem, Stmt},
     parser::{Parser, StringInput, Syntax, TsSyntax, lexer::Lexer},
@@ -227,4 +229,135 @@ fn a_fresh_state_remembers_nothing() {
 
   assert_eq!(memo.cached_span(7), None);
   assert!(!memo.has_framed_declarations());
+}
+
+/// A state whose host recorded `source_text` as the text the compiler was given
+/// for the file.
+///
+/// [`SourceFile::new`] rather than `SourceMap::new_source_file`, which
+/// normalizes what it is given -- a BOM is dropped, a lone `\r` is rewritten.
+/// The cases below are about what the state hands back, so the text has to
+/// reach it unaltered.
+fn state_with_input_source_text(source_text: &str) -> StateManager {
+  let mut state = StateManager::default();
+  let name = Arc::new(FileName::Real(PathBuf::from("/app/components/Button.tsx")));
+
+  state.set_input_source_file(Arc::new(SourceFile::new(
+    name.clone(),
+    false,
+    name,
+    source_text.to_owned().into(),
+    BytePos(1),
+  )));
+
+  state
+}
+
+/// The text the host recorded, for a case that has just recorded one. Absence
+/// is a failure of the case rather than an outcome it asserts, so it stops
+/// here instead of at a comparison against `None`.
+fn recorded_text(state: &StateManager) -> &str {
+  match DiagnosticState::input_source_text(state) {
+    Some(text) => text,
+    None => panic!("the text the host handed in was not kept"),
+  }
+}
+
+/// The host records the input text; a state no host has spoken to has none, and
+/// says so rather than answering with an empty file.
+#[test]
+fn a_fresh_state_was_handed_no_input_source_text() {
+  let state = StateManager::default();
+
+  assert_eq!(DiagnosticState::input_source_text(&state), None);
+}
+
+/// The authored layout is the whole reason the text is kept: a `file:line` is
+/// measured against it precisely where a module printed back out from its AST
+/// would put the line somewhere else. So the assertion is byte-for-byte, on a
+/// source whose comment, tabs, blank line and trailing spaces a printer removes.
+#[test]
+fn the_input_source_text_keeps_the_authored_layout() {
+  let source = "// a comment a printer drops\n\n\
+                const styles = create({\n\troot: {   \n\
+                \t\tcolor: 'red',\n\t},\n});\n";
+  let state = state_with_input_source_text(source);
+
+  assert_eq!(DiagnosticState::input_source_text(&state), Some(source));
+}
+
+/// An empty file is a file the host recorded, not a file it did not: the two
+/// answers are `Some("")` and `None`, and a frame that confuses them quotes the
+/// wrong source.
+#[test]
+fn an_empty_input_source_is_recorded_rather_than_absent() {
+  let state = state_with_input_source_text("");
+
+  assert_eq!(DiagnosticState::input_source_text(&state), Some(""));
+}
+
+/// Nothing in the path is a `str` operation that could split a character or
+/// rewrite a line ending, so the bytes come back as they went in -- multi-byte
+/// characters, CRLF, a lone CR and an embedded NUL alike.
+#[test]
+fn the_input_source_text_keeps_every_byte_it_was_given() {
+  let source = "const \u{e8}\u{6f22}\u{1f680} = '\u{0}\u{feff}';\r\nconst b = 2;\rconst c = 3;\n";
+  let state = state_with_input_source_text(source);
+
+  let text = recorded_text(&state);
+
+  // Byte length as well as equality: a normalizing copy that happened to
+  // round-trip the characters would still change the offsets a frame counts.
+  assert_eq!(text, source);
+  assert_eq!(text.len(), source.len());
+}
+
+/// A file far larger than any a human writes -- a generated module of a hundred
+/// thousand declarations -- is handed back whole rather than truncated at some
+/// buffer boundary. The state borrows the host's text, so the cost of the case
+/// is the one allocation the host already made.
+#[test]
+fn a_very_large_input_source_is_handed_back_whole() {
+  let mut source = String::with_capacity(4 * 1024 * 1024);
+  for index in 0..100_000 {
+    source.push_str("const value");
+    source.push_str(&index.to_string());
+    source.push_str(" = 'x';\n");
+  }
+
+  let state = state_with_input_source_text(&source);
+
+  let text = recorded_text(&state);
+
+  assert_eq!(text.len(), source.len());
+  assert!(text.ends_with("const value99999 = 'x';\n"));
+}
+
+/// The flag a frame consults before it opens a file is the option the project
+/// set, read straight through.
+#[test]
+fn reads_source_from_disk_follows_use_real_file_for_source() {
+  let mut state = StateManager::default();
+
+  state.options.use_real_file_for_source = true;
+  assert!(DiagnosticState::reads_source_from_disk(&state));
+
+  state.options.use_real_file_for_source = false;
+  assert!(!DiagnosticState::reads_source_from_disk(&state));
+}
+
+/// The flag gates the frame, not the state. `get_source_code` reads the text
+/// only inside its `reads_source_from_disk` branch and prints the memoized
+/// module otherwise, so the choice belongs to the frame; this accessor answers
+/// the same either way, and a state that withheld the text would move that
+/// decision somewhere the frame cannot see.
+#[test]
+fn the_input_source_text_is_kept_even_when_no_file_may_be_read() {
+  let source = "const styles = create({ root: {} });\n";
+  let mut state = state_with_input_source_text(source);
+
+  state.options.use_real_file_for_source = false;
+
+  assert!(!DiagnosticState::reads_source_from_disk(&state));
+  assert_eq!(DiagnosticState::input_source_text(&state), Some(source));
 }

--- a/crates/stylex-state/src/tests/file_and_options_test.rs
+++ b/crates/stylex-state/src/tests/file_and_options_test.rs
@@ -6,9 +6,10 @@
 //! every question below answers empty rather than refusing.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
-use swc_core::common::{DUMMY_SP, FileName, Span, SyntaxContext};
+use swc_core::common::{DUMMY_SP, FileName, SourceMap, Span, SyntaxContext, sync::Lrc};
 use swc_core::ecma::ast::Module;
 
 use stylex_enums::import_path_resolution::ImportPathResolution;
@@ -320,7 +321,11 @@ fn the_parsed_module_is_kept_for_a_diagnostic_to_quote() {
     shebang: None,
   };
 
-  StateManager::set_seen_module_source_code(&mut state, &module, Some("const a = 1;".to_string()));
+  let source_map: Lrc<SourceMap> = Default::default();
+  let source_file: Arc<_> =
+    source_map.new_source_file(FileName::Anon.into(), "const a = 1;".to_string());
+
+  StateManager::set_seen_module_source_code(&mut state, &module, Some(source_file));
 
   let Some((seen, source)) = state.get_seen_module_source_code() else {
     panic!("the parsed module was not kept");

--- a/crates/stylex-state/src/tests/file_and_options_test.rs
+++ b/crates/stylex-state/src/tests/file_and_options_test.rs
@@ -20,7 +20,9 @@ use stylex_structures::stylex_options::CheckModuleResolution;
 use stylex_structures::stylex_state_options::StyleXStateOptions;
 
 use crate::state_manager::StateManager;
+use crate::tests::capturing_logger::logged_at;
 use crate::tests::prelude::fixture_path as fixture;
+use log::Level;
 
 fn state_for(filename: FileName, resolution: CheckModuleResolution) -> StateManager {
   let mut state = StateManager::for_test(
@@ -500,6 +502,69 @@ fn common_js_resolves_an_import_to_the_name_the_file_is_hashed_under() {
     ImportPathResolution::Resolved { path }
       if path == "package_json_with_name:vars.stylex.js"
   ));
+}
+
+/// The resolution is written as well as returned, because the name a file is
+/// hashed under is what a reader of the log matches against the CSS. The
+/// message is built from the resolved path, which a `log` macro does not build
+/// while no logger admits the level.
+#[test]
+fn common_js_writes_the_name_it_resolved_an_import_to() {
+  let state = state_for(
+    real(&fixture("package_json_with_name/app.js").to_string_lossy()),
+    common_js(None, None),
+  );
+
+  let messages = logged_at(Level::Debug, || {
+    state.import_path_resolver("./vars.stylex.js", &mut FxHashMap::default())
+  });
+
+  assert!(
+    messages.iter().any(|message| {
+      message.starts_with("Resolved import path: ")
+        && message.ends_with("package_json_with_name/vars.stylex.js")
+    }),
+    "the path that was resolved must be written, got {messages:?}"
+  );
+}
+
+/// An import that is not on disk is left alone, and the reason is only in what
+/// was written: the import, and the error behind it.
+#[test]
+fn common_js_writes_why_an_import_stayed_unresolved() {
+  let state = state_for(
+    real(&fixture("package_json_with_name/app.js").to_string_lossy()),
+    common_js(None, None),
+  );
+  let mut resolution = None;
+
+  let messages = logged_at(Level::Debug, || {
+    resolution = Some(state.import_path_resolver("./missing.stylex.js", &mut FxHashMap::default()));
+  });
+
+  assert!(matches!(resolution, Some(ImportPathResolution::Unresolved)));
+  assert!(
+    messages
+      .iter()
+      .any(|message| message.starts_with("Could not resolve import path ./missing.stylex.js: ")),
+    "the import and the error must both be written, got {messages:?}"
+  );
+}
+
+/// A build that does not ask for debug messages is written nothing, which is
+/// what keeps the resolver's cost off every other build.
+#[test]
+fn an_import_resolution_writes_nothing_at_a_higher_level() {
+  let state = state_for(
+    real(&fixture("package_json_with_name/app.js").to_string_lossy()),
+    common_js(None, None),
+  );
+
+  let messages = logged_at(Level::Warn, || {
+    state.import_path_resolver("./vars.stylex.js", &mut FxHashMap::default())
+  });
+
+  assert!(messages.is_empty());
 }
 
 /// Reading variables out of the file that imports them is not supported, and

--- a/crates/stylex-state/src/tests/hoisted_ident_test.rs
+++ b/crates/stylex-state/src/tests/hoisted_ident_test.rs
@@ -1,0 +1,101 @@
+//! The module-level names the compiler generates for the expressions it lifts
+//! out of a `stylex.create` call.
+//!
+//! Two properties matter. The name is a function of the file alone, so the same
+//! input always gives the same output whatever the compiler did before it. And
+//! the name is free, so it cannot take a name the module already uses.
+
+use crate::tests::prelude::test_state as state;
+
+#[test]
+fn gives_the_first_name_without_a_number() {
+  let mut state = state();
+
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp");
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp2");
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp3");
+}
+
+#[test]
+fn counts_each_stem_on_its_own() {
+  let mut state = state();
+
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp");
+  assert_eq!(state.next_hoisted_ident("styles").sym.as_str(), "_styles");
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp2");
+  assert_eq!(state.next_hoisted_ident("styles").sym.as_str(), "_styles2");
+}
+
+/// The property the whole change is for. One file must not see the names
+/// another file took, or the output of a file depends on the order the compiler
+/// read the files in.
+#[test]
+fn starts_again_for_the_next_file() {
+  let mut first = state();
+  let mut second = state();
+
+  for _ in 0..40 {
+    first.next_hoisted_ident("temp");
+  }
+
+  assert_eq!(second.next_hoisted_ident("temp").sym.as_str(), "_temp");
+}
+
+#[test]
+fn passes_over_a_name_the_module_already_uses() {
+  let mut state = state();
+  state.bound_names.insert("_temp".to_string());
+
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp2");
+}
+
+#[test]
+fn passes_over_a_run_of_names_the_module_already_uses() {
+  let mut state = state();
+
+  for name in ["_temp", "_temp2", "_temp3"] {
+    state.bound_names.insert(name.to_string());
+  }
+
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp4");
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp5");
+}
+
+/// A name taken in the middle of the run is passed over, and the count goes on
+/// from where it stopped.
+#[test]
+fn passes_over_a_name_taken_in_the_middle_of_the_run() {
+  let mut state = state();
+  state.bound_names.insert("_temp2".to_string());
+
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp");
+  assert_eq!(state.next_hoisted_ident("temp").sym.as_str(), "_temp3");
+}
+
+/// A module can hold a great many hoisted expressions. The names stay unique
+/// and in order.
+#[test]
+fn gives_a_unique_name_for_every_one_of_many_expressions() {
+  let mut state = state();
+
+  let names: Vec<String> = (0..5_000)
+    .map(|_| state.next_hoisted_ident("temp").sym.to_string())
+    .collect();
+
+  let unique: std::collections::BTreeSet<&String> = names.iter().collect();
+
+  assert_eq!(unique.len(), names.len());
+  assert_eq!(names[0], "_temp");
+  assert_eq!(names[4_999], "_temp5000");
+}
+
+/// The name goes on a `const` declaration of the module, so it is a binding
+/// like any other and every later question about the name sees it.
+#[test]
+fn records_the_name_it_gave_as_a_binding() {
+  let mut state = state();
+  let name = state.next_hoisted_ident("temp").sym.to_string();
+
+  assert_eq!(name, "_temp");
+  assert!(state.has_binding("_temp"));
+}

--- a/crates/stylex-state/src/tests/mod.rs
+++ b/crates/stylex-state/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod flat_compiled_styles_value_test;
 mod functions_test;
 mod get_canonical_file_path_test;
 mod get_package_name_and_path_test;
+mod hoisted_ident_test;
 mod import_kind_test;
 mod import_queries_test;
 mod jsx_spread_test;

--- a/crates/stylex-state/src/tests/mod.rs
+++ b/crates/stylex-state/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod capturing_logger;
 mod prelude;
 
 mod binding_queries_test;

--- a/crates/stylex-state/src/tests/style_injection_test.rs
+++ b/crates/stylex-state/src/tests/style_injection_test.rs
@@ -24,6 +24,7 @@ use stylex_structures::named_import_source::{NamedImportSource, RuntimeInjection
 use stylex_structures::stylex_state_options::StyleXStateOptions;
 use stylex_types::enums::data_structures::injectable_style::InjectableStyleKind;
 use stylex_types::structures::injectable_style::{InjectableConstStyle, InjectableStyle};
+use stylex_utils::hash::stable_hash_unspanned;
 
 use crate::state_manager::{InsertionSlot, StateManager, flush_pending_insertions};
 use crate::tests::prelude::{make_var_declarator, object_expr, string_expr};
@@ -379,7 +380,7 @@ fn a_fallback_shape_is_injected_in_front_of_too() {
     &call_expr("create"),
     &regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None),
     &ast,
-    Some(&fallback),
+    Some(stable_hash_unspanned(&fallback)),
   );
 
   flush_pending_insertions(&mut state, &mut body, true);
@@ -396,8 +397,18 @@ fn one_shape_is_injected_in_front_of_once() {
   let styles = regular_style("x1e2nbdu", ".x1e2nbdu{color:red}", None);
   let mut body = vec![var_item("styles", ast.clone())];
 
-  state.register_styles(&call_expr("create"), &styles, &ast, Some(&ast));
-  state.register_styles(&call_expr("create"), &styles, &ast, Some(&ast));
+  state.register_styles(
+    &call_expr("create"),
+    &styles,
+    &ast,
+    Some(stable_hash_unspanned(&ast)),
+  );
+  state.register_styles(
+    &call_expr("create"),
+    &styles,
+    &ast,
+    Some(stable_hash_unspanned(&ast)),
+  );
 
   flush_pending_insertions(&mut state, &mut body, true);
 

--- a/crates/stylex-state/src/types.rs
+++ b/crates/stylex-state/src/types.rs
@@ -1,11 +1,13 @@
 use std::cell::OnceCell;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use indexmap::IndexMap;
 use rustc_hash::FxHashMap;
 use stylex_utils::collections::FxIndexMap;
 use swc_core::{
   atoms::Atom,
+  common::SourceFile,
   ecma::ast::{BindingIdent, Expr, Ident, Module},
 };
 
@@ -80,7 +82,9 @@ pub(crate) struct SeenModuleSource {
   /// the source being memoized here is always parsed as one and every reader
   /// wants it as one.
   pub(crate) module: Module,
-  pub(crate) source_code: Option<String>,
+  /// The file the module was parsed from, kept whole so its text costs
+  /// nothing to hand back. `None` for a module memoized without its text.
+  pub(crate) source_file: Option<Arc<SourceFile>>,
   /// Where every namespace key of `module` is written, built on the first
   /// debug-path lookup that needs it and dropped with the module it indexes.
   ///

--- a/crates/stylex-structures/src/stylex_options.rs
+++ b/crates/stylex-structures/src/stylex_options.rs
@@ -85,7 +85,8 @@ impl Default for StyleXOptionsParams {
       debug: None,
       enable_debug_class_names: Some(false),
       enable_debug_data_prop: Some(true),
-      enable_dev_class_names: Some(false),
+      // Absent on purpose: the option follows `dev` when it is not set.
+      enable_dev_class_names: None,
       enable_minified_keys: Some(true),
       inject_stylex_side_effects: Some(false),
       use_real_file_for_source: Some(true),
@@ -359,7 +360,7 @@ impl From<StyleXOptionsParams> for StyleXOptions {
       .maybe_test(options.test)
       .maybe_enable_debug_class_names(options.enable_debug_class_names)
       .maybe_enable_debug_data_prop(options.enable_debug_data_prop)
-      .maybe_enable_dev_class_names(options.enable_dev_class_names)
+      .maybe_enable_dev_class_names(options.enable_dev_class_names.or(options.dev))
       .maybe_enable_minified_keys(options.enable_minified_keys)
       .maybe_inject_stylex_side_effects(options.inject_stylex_side_effects)
       .maybe_treeshake_compensation(options.treeshake_compensation)

--- a/crates/stylex-styleq/src/lib.rs
+++ b/crates/stylex-styleq/src/lib.rs
@@ -16,6 +16,11 @@
 mod styleq;
 mod types;
 
+/// The logger the cache cases read messages back from.
+#[cfg(test)]
+#[path = "tests/capturing_logger.rs"]
+mod capturing_logger;
+
 pub use styleq::{Styleq, create_styleq, styleq};
 pub use types::{
   StyleMap, StyleValue, StyleqArgument, StyleqInput, StyleqOptions, StyleqResult, StyleqValue,

--- a/crates/stylex-styleq/src/styleq.rs
+++ b/crates/stylex-styleq/src/styleq.rs
@@ -344,6 +344,8 @@ mod tests {
   use super::*;
   use std::panic::{AssertUnwindSafe, catch_unwind};
 
+  use crate::capturing_logger::logged_at;
+
   /// Calling the `_assert_cache_send_sync` helper covers its body in tests
   /// while still serving its compile-time purpose of asserting `Send`+`Sync`
   /// for `CacheEntry`/`CacheKey` (relevant when StyleX is invoked from
@@ -406,6 +408,10 @@ mod tests {
   /// The `poison_warned` latch must flip exactly once: the first poisoned
   /// recovery is logged at `error!` (actionable), every later one falls back
   /// to `debug!` so a single panicked writer can't flood the log under load.
+  ///
+  /// The messages are read back, because the latch is only observable in what
+  /// was written: the flag alone cannot tell a second `error!` from the
+  /// `debug!` that has to replace it.
   #[test]
   fn poison_warning_latches_after_first_recovery() {
     let styleq = create_styleq::<crate::StyleValue>(StyleqOptions::default());
@@ -420,20 +426,51 @@ mod tests {
       panic!("poison cache rwlock for latch test");
     }));
 
-    // First recovery: latches the flag and emits `error!`.
-    drop(styleq.cache_read());
-    assert!(
-      styleq.poison_warned.load(Ordering::Relaxed),
-      "first recovery must latch the poison-warned flag"
-    );
+    let messages = logged_at(log::Level::Debug, || {
+      // First recovery: latches the flag and emits `error!`.
+      drop(styleq.cache_read());
+      assert!(
+        styleq.poison_warned.load(Ordering::Relaxed),
+        "first recovery must latch the poison-warned flag"
+      );
 
-    // Second recovery: same path, no re-latch (still true). This call is
-    // what would previously have produced a second `error!` log line; now
-    // it's demoted to `debug!` and the flag stays unchanged.
-    drop(styleq.cache_read());
-    assert!(
-      styleq.poison_warned.load(Ordering::Relaxed),
-      "subsequent recoveries must keep the flag set without flipping it back"
+      // Second recovery: same path, no re-latch (still true). This call is
+      // what would previously have produced a second `error!` log line; now
+      // it's demoted to `debug!` and the flag stays unchanged.
+      drop(styleq.cache_read());
+      assert!(
+        styleq.poison_warned.load(Ordering::Relaxed),
+        "subsequent recoveries must keep the flag set without flipping it back"
+      );
+    });
+
+    assert_eq!(
+      messages,
+      vec![
+        "styleq: cache RwLock was poisoned (read); continuing with inner cache.".to_string(),
+        "styleq: cache RwLock still poisoned (read); recovered transparently.".to_string(),
+      ],
+      "the first recovery is the loud one and every later one is quiet"
+    );
+  }
+
+  /// The write path names itself, so a reader of the log can tell which guard
+  /// was recovered. The kind is an argument of the message, which is built only
+  /// while a logger admits the level.
+  #[test]
+  fn a_recovered_write_guard_names_itself() {
+    let styleq = create_styleq::<crate::StyleValue>(StyleqOptions::default());
+
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+      let _guard = styleq.cache.write();
+      panic!("poison cache rwlock for the write path");
+    }));
+
+    let messages = logged_at(log::Level::Error, || drop(styleq.cache_write()));
+
+    assert_eq!(
+      messages,
+      vec!["styleq: cache RwLock was poisoned (write); continuing with inner cache.".to_string()]
     );
   }
 }

--- a/crates/stylex-styleq/src/tests/capturing_logger.rs
+++ b/crates/stylex-styleq/src/tests/capturing_logger.rs
@@ -1,0 +1,67 @@
+//! A logger the tests can read back, so a reporting path is covered by an
+//! assertion rather than by a coverage exclusion.
+//!
+//! A `log` macro builds its message only when `log::max_level` admits it, so
+//! every argument of every message is unexecuted code until a logger is in
+//! place. Reading the message back then makes the message itself the subject of
+//! a case.
+//!
+//! Both the level and the messages are per thread, because the harness runs
+//! tests in parallel and one global level would let one case decide what
+//! another one sees. `log::max_level` stays wide open; the per-thread level is
+//! what [`Log::enabled`] answers from.
+//!
+//! The same helper as `stylex_diagnostics`'s. `log` takes one logger for the
+//! whole process and every test binary is a process of its own, so each crate
+//! that reads its messages back holds its own copy.
+
+use std::cell::RefCell;
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+thread_local! {
+  static LEVEL: RefCell<LevelFilter> = const { RefCell::new(LevelFilter::Off) };
+  static MESSAGES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+struct CapturingLogger;
+
+impl Log for CapturingLogger {
+  fn enabled(&self, metadata: &Metadata) -> bool {
+    LEVEL.with_borrow(|level| metadata.level() <= *level)
+  }
+
+  fn log(&self, record: &Record) {
+    if !self.enabled(record.metadata()) {
+      return;
+    }
+
+    MESSAGES.with_borrow_mut(|messages| messages.push(record.args().to_string()));
+  }
+
+  fn flush(&self) {}
+}
+
+/// Installs the logger, on the first case that reads a message back.
+///
+/// A second call answers `Err`, which is the expected reply once the logger is
+/// in place.
+fn install() {
+  if log::set_boxed_logger(Box::new(CapturingLogger)).is_ok() {
+    log::set_max_level(LevelFilter::Trace);
+  }
+}
+
+/// Runs `body` with this thread logging at `level`, and hands back everything
+/// it wrote.
+pub(crate) fn logged_at<T>(level: Level, body: impl FnOnce() -> T) -> Vec<String> {
+  install();
+
+  LEVEL.with_borrow_mut(|current| *current = level.to_level_filter());
+  MESSAGES.with_borrow_mut(Vec::clear);
+
+  body();
+
+  LEVEL.with_borrow_mut(|current| *current = LevelFilter::Off);
+  MESSAGES.with_borrow(Clone::clone)
+}

--- a/crates/stylex-test-parser/Cargo.toml
+++ b/crates/stylex-test-parser/Cargo.toml
@@ -31,3 +31,9 @@ walkdir = { version = "2.5.0" }
 
 [lints]
 workspace = true
+
+# The package keeps the workspace's snake_case naming, but Cargo wants a
+# kebab-case binary. Naming the target explicitly satisfies both.
+[[bin]]
+name = "stylex-test-parser"
+path = "src/main.rs"

--- a/crates/stylex-test-parser/package.json
+++ b/crates/stylex-test-parser/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "bench": "scripty",
     "build": "scripty --rust",
-    "check:artifacts": "scripty ./dist/stylex_test_parser",
+    "check:artifacts": "scripty ./dist/stylex-test-parser",
     "clean": "del-cli dist",
     "do:nothing": "exit 0",
     "format": "run-p format:rs format:toml",
@@ -25,7 +25,7 @@
     "format:toml:check": "taplo format --check",
     "postbuild": "pnpm run check:artifacts",
     "prepublishOnly": "pnpm run build",
-    "start": "./dist/test-parser",
+    "start": "./dist/stylex-test-parser",
     "test": "echo \"Skip: the root test script runs the workspace suite.\"",
     "test:coverage": "scripty",
     "test:flamegraph": "scripty"
@@ -42,5 +42,5 @@
   "keywords": [
     "swc-plugin"
   ],
-  "main": "./dist/test-parser"
+  "main": "./dist/stylex-test-parser"
 }

--- a/crates/stylex-transform/benches/transform_debug_bench.rs
+++ b/crates/stylex-transform/benches/transform_debug_bench.rs
@@ -361,11 +361,30 @@ fn parse(file_name: &FileName, source: &str) -> Program {
 /// lookup. Everything else matches the fixture suite's `dev` leg so a number
 /// here and a snapshot there describe the same transform.
 fn transform(path: &Path, program: Program, dev: bool) -> Program {
+  transform_with_dev_class_names(path, program, dev, dev)
+}
+
+/// The same transform with the debug names of the namespaces set apart from
+/// `dev`.
+///
+/// `enable_dev_class_names` follows `dev`, so a development build names every
+/// namespace of every call. That naming is the one part of the `dev` shape that
+/// can be turned off on its own, and the pair of legs below prices it. Both
+/// legs run in one process off one build, so the answer holds no cross-build
+/// term -- which matters, because cross-run noise on this platform is far
+/// wider than the cost being measured.
+fn transform_with_dev_class_names(
+  path: &Path,
+  program: Program,
+  dev: bool,
+  dev_class_names: bool,
+) -> Program {
   let comments = Rc::new(SingleThreadedComments::default());
 
   let pass = StyleXTransform::test(comments)
     .with_filename(FileName::Real(path.to_path_buf()))
     .with_dev(dev)
+    .with_enable_dev_class_names(dev_class_names)
     .with_treeshake_compensation(true)
     .with_unstable_module_resolution(ModuleResolution::haste(None))
     .with_enable_minified_keys(false)
@@ -429,6 +448,72 @@ fn count_resolved_annotations(program: &Program) -> usize {
   counter.resolved
 }
 
+/// Counts the debug names of the namespaces: a property whose key and whose
+/// string value are the same word, which is how such a name is emitted.
+#[derive(Default)]
+struct DevClassNameCounter {
+  named: usize,
+}
+
+impl Visit for DevClassNameCounter {
+  fn visit_key_value_prop(&mut self, prop: &KeyValueProp) {
+    let key = match &prop.key {
+      PropName::Ident(ident) => Some(ident.sym.as_ref()),
+      PropName::Str(value) => value.value.as_str(),
+      _ => None,
+    };
+
+    if let Some(key) = key
+      && let Expr::Lit(Lit::Str(value)) = prop.value.as_ref()
+      && value.value.as_str() == Some(key)
+    {
+      self.named += 1;
+    }
+
+    prop.visit_children_with(self);
+  }
+}
+
+fn count_dev_class_names(program: &Program) -> usize {
+  let mut counter = DevClassNameCounter::default();
+  program.visit_with(&mut counter);
+  counter.named
+}
+
+/// Panics unless the two development legs differ by the debug names alone.
+///
+/// The pair exists to price the naming, and the cheaper leg has to be cheaper
+/// because it stopped naming and not because it stopped working. A leg that
+/// names nothing while the other names every namespace is the only shape that
+/// prices anything.
+fn assert_prices_the_debug_names(slice: &Slice) {
+  let named = count_dev_class_names(&transform_with_dev_class_names(
+    &slice.path,
+    slice.program.clone(),
+    /* dev */ true,
+    /* dev_class_names */ true,
+  ));
+  let unnamed = count_dev_class_names(&transform_with_dev_class_names(
+    &slice.path,
+    slice.program.clone(),
+    /* dev */ true,
+    /* dev_class_names */ false,
+  ));
+
+  assert!(
+    named >= slice.creates,
+    "a {}-create slice named {named} namespaces, fewer than one per create -- the pair below \
+     would price something other than the naming",
+    slice.creates
+  );
+  assert_eq!(
+    unnamed, 0,
+    "a {}-create slice named {unnamed} namespaces with the option off, so the two legs below \
+     do not differ by the naming alone",
+    slice.creates
+  );
+}
+
 /// Panics unless transforming `slice` with `dev` on annotated every namespace it
 /// compiled with a resolved `file:line`.
 ///
@@ -477,18 +562,32 @@ fn debug_path_benchmarks(c: &mut Criterion) {
 
     for slice in &slices {
       assert_annotates_every_namespace(slice);
+      assert_prices_the_debug_names(slice);
     }
 
     let mut group = c.benchmark_group("TransformDebugPath");
 
     for slice in &slices {
-      for (label, dev) in [("dev", true), ("prod", false)] {
+      // `dev` and `dev-no-names` differ by the debug names alone, so the two
+      // together say what the naming costs a development build.
+      for (label, dev, dev_class_names) in [
+        ("dev", true, true),
+        ("dev-no-names", true, false),
+        ("prod", false, false),
+      ] {
         // Batched because `apply` consumes the program: the clone is setup, not
         // work under measurement.
         group.bench_function(format!("{label}/{}", slice.creates), |b| {
           b.iter_batched(
             || slice.program.clone(),
-            |program| black_box(transform(black_box(&slice.path), program, black_box(dev))),
+            |program| {
+              black_box(transform_with_dev_class_names(
+                black_box(&slice.path),
+                program,
+                black_box(dev),
+                black_box(dev_class_names),
+              ))
+            },
             BatchSize::SmallInput,
           )
         });
@@ -534,6 +633,7 @@ fn namespace_count_benchmarks(c: &mut Criterion) {
 
     for slice in &slices {
       assert_annotates_every_namespace(slice);
+      assert_prices_the_debug_names(slice);
     }
 
     let mut group = c.benchmark_group("TransformDebugNamespacesPerCall");

--- a/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
+++ b/crates/stylex-transform/src/shared/utils/core/add_source_map_data.rs
@@ -34,14 +34,21 @@ static NEXTJS_HYDRATION_WARNING: LazyLock<String> = LazyLock::new(|| {
     Please verify the expression that caused this error.".to_string()
 });
 
+/// The `$$css` entry of each namespace, carrying the `file:line` the namespace
+/// was written on.
+///
+/// Takes the styles rather than borrowing them, so the properties of a
+/// namespace move into the new map. Copying them allocated one string for
+/// every property of every namespace, and a debug build annotates every
+/// namespace of every `stylex.create` call.
 pub(crate) fn add_source_map_data(
-  obj: &StylesObjectMap,
+  obj: StylesObjectMap,
   call_expr: &CallExpr,
   state: &mut StateManager,
   package_json_seen: &mut FxHashMap<String, PackageJsonExtended>,
   functions: &FunctionMap,
 ) -> StylesObjectMap {
-  let mut result: StylesObjectMap = IndexMap::new();
+  let mut result: StylesObjectMap = IndexMap::with_capacity(obj.len());
   let mut style_node_paths: FxHashMap<String, KeyValueProp> = FxHashMap::default();
 
   match call_expr.args.first() {
@@ -78,11 +85,12 @@ pub(crate) fn add_source_map_data(
   let lookup = CallLookup::new(call_expr, state.input_module_base());
 
   for (key, value) in obj {
-    let mut inner_map = IndexMap::new();
+    let styles = Rc::unwrap_or_clone(value);
+    let mut inner_map = IndexMap::with_capacity(styles.len() + 1);
 
-    inner_map.extend((**value).clone());
+    inner_map.extend(styles);
 
-    match style_node_paths.remove(key) {
+    match style_node_paths.remove(&key) {
       Some(style_node_path) => {
         // Highest fidelity: resolve the key's own span against the compiler's
         // input and map it through the host-provided input source map back to
@@ -99,7 +107,7 @@ pub(crate) fn add_source_map_data(
             package_json_seen,
             functions,
           );
-          result.insert(key.clone(), Rc::new(inner_map));
+          result.insert(key, Rc::new(inner_map));
           continue;
         }
 
@@ -109,7 +117,7 @@ pub(crate) fn add_source_map_data(
         // when the compiled values no longer match the file content. Fall
         // back to matching the value expression when the key cannot be
         // located (e.g. computed keys).
-        let source_code_frame_and_span = match get_key_span_from_source_code(&lookup, key, state) {
+        let source_code_frame_and_span = match get_key_span_from_source_code(&lookup, &key, state) {
           Ok((code_frame, span)) if !span.eq(&DUMMY_SP) => Ok((code_frame, span)),
           _ => get_span_from_source_code(lookup.wrapped(), &style_node_path.value, state),
         };
@@ -172,11 +180,11 @@ pub(crate) fn add_source_map_data(
           );
         }
 
-        result.insert(key.clone(), Rc::new(inner_map));
+        result.insert(key, Rc::new(inner_map));
       },
       _ => {
         // Fallback in case no sourcemap data is found
-        result.insert(key.clone(), Rc::new(inner_map));
+        result.insert(key, Rc::new(inner_map));
       },
     };
   }

--- a/crates/stylex-transform/src/shared/utils/core/dev_class_name.rs
+++ b/crates/stylex-transform/src/shared/utils/core/dev_class_name.rs
@@ -11,18 +11,42 @@ use stylex_state::{
   types::{FlatCompiledStyles, StylesObjectMap},
 };
 
+/// The debug name of each namespace, in front of the styles of that namespace.
 pub(crate) fn inject_dev_class_names(
   obj: &StylesObjectMap,
   var_name: &Option<String>,
   state: &StateManager,
 ) -> StylesObjectMap {
-  let mut result: StylesObjectMap = IndexMap::new();
+  let prefix = dev_class_name_prefix(var_name, state.get_short_filename().as_str());
+
+  with_dev_class_names(obj, |key| dev_class_name(&prefix, key))
+}
+
+/// The debug name of a compiled `sx` value.
+///
+/// Such a value is bound to no variable, and the one namespace it holds is a
+/// name the compiler keys on rather than one the author wrote. So the name
+/// says `sx`, which is what the author reads in the source.
+pub(crate) fn inject_sx_dev_class_name(
+  obj: &StylesObjectMap,
+  state: &StateManager,
+) -> StylesObjectMap {
+  let prefix = dev_class_name_prefix(&None, state.get_short_filename().as_str());
+  let name = dev_class_name(&prefix, "sx");
+
+  with_dev_class_names(obj, |_| name.clone())
+}
+
+/// Puts the name `label` gives each namespace in front of the styles of that
+/// namespace, keyed by itself.
+fn with_dev_class_names(obj: &StylesObjectMap, label: impl Fn(&str) -> String) -> StylesObjectMap {
+  let mut result: StylesObjectMap = IndexMap::with_capacity(obj.len());
 
   for (key, value) in obj.iter() {
-    let dev_class_name =
-      namespace_to_dev_class_name(key, var_name, state.get_short_filename().as_str());
+    let dev_class_name = label(key);
 
-    let mut dev_class = IndexMap::new();
+    // The debug name and the styles it belongs to, so the map is sized once.
+    let mut dev_class = IndexMap::with_capacity(value.len() + 1);
 
     dev_class.insert(
       dev_class_name.clone(),
@@ -42,13 +66,14 @@ pub(crate) fn convert_to_test_styles(
   var_name: &Option<String>,
   state: &StateManager,
 ) -> StylesObjectMap {
-  let mut result: StylesObjectMap = IndexMap::new();
+  let prefix = dev_class_name_prefix(var_name, state.get_short_filename().as_str());
+  let mut result: StylesObjectMap = IndexMap::with_capacity(obj.len());
 
   for (key, _value) in obj.iter() {
-    let dev_class_name =
-      namespace_to_dev_class_name(key, var_name, state.get_short_filename().as_str());
+    let dev_class_name = dev_class_name(&prefix, key);
 
-    let mut dev_class = IndexMap::new();
+    // The debug name and the compiled marker, and nothing else.
+    let mut dev_class = IndexMap::with_capacity(2);
 
     dev_class.insert(
       dev_class_name.clone(),
@@ -66,47 +91,54 @@ pub(crate) fn convert_to_test_styles(
   result
 }
 
-fn namespace_to_dev_class_name(
-  namespace: &str,
-  var_name: &Option<String>,
-  filename: &str,
-) -> String {
-  // Get the basename of the file without the extension
-  let basename = Path::new(filename)
+/// The name of the file, without any extension, for a debug name to start
+/// with.
+///
+/// Answers `UnknownFile` when the path holds no name to read. An empty answer
+/// would be the same for every file, so every file would give the same debug
+/// name.
+fn file_basename(filename: &str) -> &str {
+  Path::new(filename)
     .file_stem()
-    .and_then(|os_str| os_str.to_str())
-    .unwrap_or_default();
+    .and_then(|stem| stem.to_str())
+    .and_then(|stem| stem.split('.').next())
+    .filter(|stem| !stem.is_empty())
+    .unwrap_or("UnknownFile")
+}
 
-  // Build up the class name, and sanitize it of disallowed characters
-  let class_name = format!(
-    "{}__{}{}",
-    basename,
-    var_name
-      .as_ref()
-      .map(|var_name| format!("{}.", var_name))
-      .unwrap_or_default(),
-    namespace
-  );
+/// The start that every debug name of one call shares: the file, and the
+/// variable the styles are bound to.
+///
+/// Built once per call. It does not depend on the namespace, and reading the
+/// file name means walking the path.
+fn dev_class_name_prefix(var_name: &Option<String>, filename: &str) -> String {
+  match var_name {
+    Some(var_name) => format!("{}__{}.", file_basename(filename), var_name),
+    None => format!("{}__", file_basename(filename)),
+  }
+}
 
-  SANITIZE_CLASS_NAME_REGEX
-    .replace_all(&class_name, "$1 $2")
-    .to_string()
+/// The debug name of one style namespace.
+fn dev_class_name(prefix: &str, namespace: &str) -> String {
+  let class_name = format!("{prefix}{namespace}");
+
+  // A character a class name cannot hold is removed, not replaced. A space in
+  // its place would make the name two class names, and the first of the two is
+  // the debug name of another namespace of the same variable.
+  match SANITIZE_CLASS_NAME_REGEX.is_match(&class_name) {
+    // Almost every namespace holds nothing to remove, and the name it built is
+    // already the answer. Asking first keeps that name from being copied.
+    Ok(false) => class_name,
+    _ => SANITIZE_CLASS_NAME_REGEX
+      .replace_all(&class_name, "")
+      .to_string(),
+  }
 }
 
 fn convert_theme_to_base_styles(variable_name: &str, filename: &str) -> FlatCompiledStyles {
   let mut overrides_obj_extended = IndexMap::new();
 
-  // Get the basename of the file without the extension
-  let basename = Path::new(filename)
-    .file_stem()
-    .and_then(|os_str| os_str.to_str())
-    .unwrap_or_default()
-    .split('.')
-    .next()
-    .unwrap_or_else(|| stylex_panic!("File path has no base name."));
-
-  // Build up the class name, and sanitize it of disallowed characters
-  let dev_class_name = format!("{}__{}", basename, variable_name);
+  let dev_class_name = format!("{}__{}", file_basename(filename), variable_name);
 
   overrides_obj_extended.insert(
     dev_class_name.clone(),
@@ -148,3 +180,7 @@ pub(crate) fn convert_theme_to_test_styles(
 
   overrides_obj_extended
 }
+
+#[cfg(test)]
+#[path = "tests/dev_class_name_tests.rs"]
+mod tests;

--- a/crates/stylex-transform/src/shared/utils/core/dev_class_name.rs
+++ b/crates/stylex-transform/src/shared/utils/core/dev_class_name.rs
@@ -13,7 +13,7 @@ use stylex_state::{
 
 /// The debug name of each namespace, in front of the styles of that namespace.
 pub(crate) fn inject_dev_class_names(
-  obj: &StylesObjectMap,
+  obj: StylesObjectMap,
   var_name: &Option<String>,
   state: &StateManager,
 ) -> StylesObjectMap {
@@ -28,7 +28,7 @@ pub(crate) fn inject_dev_class_names(
 /// name the compiler keys on rather than one the author wrote. So the name
 /// says `sx`, which is what the author reads in the source.
 pub(crate) fn inject_sx_dev_class_name(
-  obj: &StylesObjectMap,
+  obj: StylesObjectMap,
   state: &StateManager,
 ) -> StylesObjectMap {
   let prefix = dev_class_name_prefix(&None, state.get_short_filename().as_str());
@@ -39,38 +39,44 @@ pub(crate) fn inject_sx_dev_class_name(
 
 /// Puts the name `label` gives each namespace in front of the styles of that
 /// namespace, keyed by itself.
-fn with_dev_class_names(obj: &StylesObjectMap, label: impl Fn(&str) -> String) -> StylesObjectMap {
+///
+/// Takes the styles rather than borrowing them, so the properties of a
+/// namespace move into the new map. Copying them allocated one string for
+/// every property of every namespace, and a development build names every
+/// namespace of every `stylex.create` call.
+fn with_dev_class_names(obj: StylesObjectMap, label: impl Fn(&str) -> String) -> StylesObjectMap {
   let mut result: StylesObjectMap = IndexMap::with_capacity(obj.len());
 
-  for (key, value) in obj.iter() {
-    let dev_class_name = label(key);
+  for (key, value) in obj {
+    let dev_class_name = label(&key);
+    let styles = Rc::unwrap_or_clone(value);
 
     // The debug name and the styles it belongs to, so the map is sized once.
-    let mut dev_class = IndexMap::with_capacity(value.len() + 1);
+    let mut dev_class = IndexMap::with_capacity(styles.len() + 1);
 
     dev_class.insert(
       dev_class_name.clone(),
       Rc::new(FlatCompiledStylesValue::String(dev_class_name)),
     );
 
-    dev_class.extend((**value).clone());
+    dev_class.extend(styles);
 
-    result.insert(key.clone(), Rc::new(dev_class));
+    result.insert(key, Rc::new(dev_class));
   }
 
   result
 }
 
 pub(crate) fn convert_to_test_styles(
-  obj: &StylesObjectMap,
+  obj: StylesObjectMap,
   var_name: &Option<String>,
   state: &StateManager,
 ) -> StylesObjectMap {
   let prefix = dev_class_name_prefix(var_name, state.get_short_filename().as_str());
   let mut result: StylesObjectMap = IndexMap::with_capacity(obj.len());
 
-  for (key, _value) in obj.iter() {
-    let dev_class_name = dev_class_name(&prefix, key);
+  for (key, _value) in obj {
+    let dev_class_name = dev_class_name(&prefix, &key);
 
     // The debug name and the compiled marker, and nothing else.
     let mut dev_class = IndexMap::with_capacity(2);
@@ -85,7 +91,7 @@ pub(crate) fn convert_to_test_styles(
       Rc::new(FlatCompiledStylesValue::Bool(true)),
     );
 
-    result.insert(key.clone(), Rc::new(dev_class));
+    result.insert(key, Rc::new(dev_class));
   }
 
   result

--- a/crates/stylex-transform/src/shared/utils/core/tests/dev_class_name_tests.rs
+++ b/crates/stylex-transform/src/shared/utils/core/tests/dev_class_name_tests.rs
@@ -1,0 +1,109 @@
+//! Tests for the debug class names a dev build adds to each style namespace.
+
+use super::{dev_class_name, dev_class_name_prefix, file_basename};
+
+/// Shorthand for the name built from a namespace, a variable name and a file.
+fn name(namespace: &str, var_name: Option<&str>, filename: &str) -> String {
+  let prefix = dev_class_name_prefix(&var_name.map(str::to_owned), filename);
+
+  dev_class_name(&prefix, namespace)
+}
+
+#[test]
+fn names_a_namespace_after_its_file_and_variable() {
+  assert_eq!(
+    name("root", Some("styles"), "MyComponent"),
+    "MyComponent__styles.root"
+  );
+}
+
+#[test]
+fn leaves_out_the_variable_when_there_is_none() {
+  assert_eq!(name("root", None, "MyComponent"), "MyComponent__root");
+}
+
+/// A class name holds one class. A space in the name would make it two, and the
+/// first of the two is the name of another namespace of the same variable.
+#[test]
+fn removes_a_character_that_a_class_name_cannot_hold() {
+  assert_eq!(name("p+1", Some("c"), "input"), "input__c.p1");
+  assert_eq!(name("a b+c!d", Some("c"), "input"), "input__c.abcd");
+}
+
+#[test]
+fn keeps_the_characters_a_class_name_can_hold() {
+  assert_eq!(name("a-b_c.d", None, "input"), "input__a-b_c.d");
+}
+
+/// Two namespaces that differ only in a character no class name can hold get
+/// the same debug name. The name is a label for a person to read, so a
+/// duplicate is acceptable; a space, which silently adds a second class, is
+/// not.
+#[test]
+fn two_namespaces_can_share_a_name() {
+  assert_eq!(
+    name("p+1", Some("c"), "input"),
+    name("p1", Some("c"), "input")
+  );
+}
+
+#[test]
+fn keeps_only_the_first_part_of_a_file_name_with_several_dots() {
+  assert_eq!(name("root", Some("s"), "input.stylex"), "input__s.root");
+  assert_eq!(name("root", Some("s"), "a.b.c"), "a__s.root");
+}
+
+#[test]
+fn reads_the_file_name_out_of_a_path() {
+  assert_eq!(
+    name("root", Some("s"), "src/components/Card.tsx"),
+    "Card__s.root"
+  );
+}
+
+/// The compiler does not always know the file. The name still has to say which
+/// part is the file, or every file gives the same name.
+#[test]
+fn names_an_unknown_file() {
+  assert_eq!(name("base", Some("styles"), ""), "UnknownFile__styles.base");
+  assert_eq!(name("base", None, "."), "UnknownFile__base");
+  assert_eq!(name("base", None, "/"), "UnknownFile__base");
+}
+
+/// Every character of the namespace can be one a class name cannot hold. The
+/// name then says the file and the variable and nothing more.
+#[test]
+fn accepts_a_namespace_that_is_left_empty() {
+  assert_eq!(name("+++", Some("c"), "input"), "input__c.");
+}
+
+/// A class name holds no letter outside the ASCII range, so an accented letter
+/// goes and the plain letters beside it stay.
+#[test]
+fn removes_the_accented_letters_of_a_namespace() {
+  assert_eq!(name("ünïcödé", None, "input"), "input__ncd");
+}
+
+#[test]
+fn accepts_a_very_long_namespace() {
+  let namespace = "a".repeat(100_000);
+
+  assert_eq!(
+    name(&namespace, Some("c"), "input").len(),
+    "input__c.".len() + 100_000
+  );
+}
+
+/// Every character is one to remove, so the work is a full rewrite of a large
+/// string rather than a copy of it.
+#[test]
+fn accepts_a_very_long_namespace_that_is_left_empty() {
+  let namespace = "+".repeat(100_000);
+
+  assert_eq!(name(&namespace, Some("c"), "input"), "input__c.");
+}
+
+#[test]
+fn reads_a_base_name_that_needs_no_change() {
+  assert_eq!(file_basename("MyComponent"), "MyComponent");
+}

--- a/crates/stylex-transform/src/transform/mod.rs
+++ b/crates/stylex-transform/src/transform/mod.rs
@@ -74,6 +74,7 @@ where
   ///
   /// The tester registers the file after the pass is built, so the lookup waits
   /// for the program.
+  #[doc(hidden)]
   pub fn with_source_map(mut self, source_map: Lrc<SourceMap>) -> Self {
     self.source_map = Some(source_map);
     self
@@ -282,6 +283,9 @@ where
     }
   }
 
+  /// The tester builds its pass through this. Production drives the transform
+  /// directly, so it is here for the test harness and the benches alone.
+  #[doc(hidden)]
   pub fn into_pass(self) -> impl Pass + use<C> {
     let unresolved_mark = Mark::new();
     let top_level_mark = Mark::new();
@@ -314,8 +318,14 @@ where
   fn process(&mut self, program: &mut Program) {
     // A program with no span, or one this map did not parse, has no text to
     // give. The transform then falls back to the printed module, as before.
+    //
+    // The lookup searches on the start of each file alone, so a position past
+    // the end of the last file answers with that last file. Only a position the
+    // file really holds names its text, or a program parsed by another map
+    // would be quoted as this one.
     if let Some(source_map) = &self.source_map
       && let Ok(Some(source_file)) = source_map.try_lookup_source_file(program.span_lo())
+      && (source_file.start_pos..source_file.end_pos).contains(&program.span_lo())
     {
       self.transform.state.set_input_source_file(source_file);
     }

--- a/crates/stylex-transform/src/transform/mod.rs
+++ b/crates/stylex-transform/src/transform/mod.rs
@@ -1,11 +1,11 @@
 use indexmap::{IndexMap, IndexSet};
 use rustc_hash::FxHashMap;
 use swc_core::{
-  common::{Mark, comments::Comments},
+  common::{Mark, SourceMap, Spanned, comments::Comments, sync::Lrc},
   ecma::{
-    ast::{CallExpr, Callee, Expr, Id, MemberProp, Pass, VarDeclarator},
+    ast::{CallExpr, Callee, Expr, Id, MemberProp, Pass, Program, VarDeclarator},
     transforms::{base::resolver, typescript::strip},
-    visit::visit_mut_pass,
+    visit::VisitMutWith,
   },
 };
 
@@ -59,12 +59,26 @@ where
   plugin_pass: PluginPass,
   config: Option<StyleXOptionsParams>,
   runtime_injection: bool,
+  source_map: Option<Lrc<SourceMap>>,
 }
 
 impl<C> StyleXTransformBuilder<C>
 where
   C: Comments,
 {
+  /// The source map the test parses its input into, so the transform can read
+  /// the authored text of the module. Debug annotations then name the line the
+  /// author wrote a key on, as a build fed by a bundler does. Without it the
+  /// module is printed back out from its AST, and the printed layout is not the
+  /// authored one.
+  ///
+  /// The tester registers the file after the pass is built, so the lookup waits
+  /// for the program.
+  pub fn with_source_map(mut self, source_map: Lrc<SourceMap>) -> Self {
+    self.source_map = Some(source_map);
+    self
+  }
+
   pub fn with_pass(mut self, pass: PluginPass) -> Self {
     self.plugin_pass = pass;
     self
@@ -271,11 +285,42 @@ where
   pub fn into_pass(self) -> impl Pass + use<C> {
     let unresolved_mark = Mark::new();
     let top_level_mark = Mark::new();
+    let source_map = self.source_map.clone();
 
     (
       resolve_factory(unresolved_mark, top_level_mark),
-      visit_mut_pass(self.build()),
+      InputSourcePass {
+        source_map,
+        transform: self.build(),
+      },
     )
+  }
+}
+
+/// The test pass: gives the transform the text of the module it is about to
+/// walk, then runs it.
+struct InputSourcePass<C>
+where
+  C: Comments,
+{
+  source_map: Option<Lrc<SourceMap>>,
+  transform: StyleXTransform<C>,
+}
+
+impl<C> Pass for InputSourcePass<C>
+where
+  C: Comments,
+{
+  fn process(&mut self, program: &mut Program) {
+    // A program with no span, or one this map did not parse, has no text to
+    // give. The transform then falls back to the printed module, as before.
+    if let Some(source_map) = &self.source_map
+      && let Ok(Some(source_file)) = source_map.try_lookup_source_file(program.span_lo())
+    {
+      self.transform.state.set_input_source_file(source_file);
+    }
+
+    program.visit_mut_with(&mut self.transform);
   }
 }
 
@@ -306,6 +351,7 @@ where
       plugin_pass: PluginPass::default(),
       config: None,
       runtime_injection: false,
+      source_map: None,
     }
   }
 

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_atoms.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_atoms.rs
@@ -99,7 +99,7 @@ where
     );
 
     if self.state.is_dev() && self.state.options.enable_dev_class_names {
-      compiled = inject_sx_dev_class_name(&compiled, &self.state);
+      compiled = inject_sx_dev_class_name(compiled, &self.state);
     }
     self.state.in_stylex_create = prev_in_stylex_create;
 

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_atoms.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_atoms.rs
@@ -13,7 +13,7 @@ use crate::{
   shared::{
     transformers::stylex_create::stylex_create_set,
     utils::core::{
-      dev_class_name::inject_dev_class_names,
+      dev_class_name::inject_sx_dev_class_name,
       evaluate_stylex_create_arg::evaluate_stylex_create_arg,
       js_to_ast::{NestedStringObject, convert_object_to_ast},
     },
@@ -99,7 +99,7 @@ where
     );
 
     if self.state.is_dev() && self.state.options.enable_dev_class_names {
-      compiled = inject_dev_class_names(&compiled, &None, &self.state);
+      compiled = inject_sx_dev_class_name(&compiled, &self.state);
     }
     self.state.in_stylex_create = prev_in_stylex_create;
 

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/dynamic_style_functions.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/dynamic_style_functions.rs
@@ -87,7 +87,6 @@ pub(super) fn apply_dynamic_style_functions<C>(
   fns: Option<DynamicFns>,
   class_paths_per_namespace: &ClassPathsMap,
   injected_styles: &InjectableStylesMap,
-  is_program_level: bool,
 ) -> Expr
 where
   C: Comments,
@@ -329,11 +328,7 @@ where
             })
             .collect();
 
-    result_ast = path_replace_hoisted(
-      create_object_expression(props),
-      is_program_level,
-      &mut transform.state,
-    );
+    result_ast = create_object_expression(props);
   };
 
   result_ast

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/helpers.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/helpers.rs
@@ -137,15 +137,14 @@ pub(super) fn extract_expr_from_rule(
 /// Hoist an expression to the module level as a `const` declaration.
 ///
 /// The declaration is queued after the imports and the returned identifier
-/// stands for the expression at the call site. `prefix` is the stem of the
-/// generated identifier.
+/// stands for the expression at the call site. `stem` is what the generated
+/// name is built on.
 fn hoist_to_module_level(
-  prefix: &str,
+  stem: &'static str,
   ast_expression: Expr,
   state: &mut stylex_state::state_manager::StateManager,
 ) -> Expr {
-  let uid_generator = UidGenerator::new(prefix, CounterMode::ThreadLocal);
-  let hoisted_ident = uid_generator.generate_ident();
+  let hoisted_ident = state.next_hoisted_ident(stem);
 
   let var_decl = VarDecl {
     span: DUMMY_SP,
@@ -174,6 +173,28 @@ pub(crate) fn hoist_expression(
 
 /// Hoist the compiled styles object of a `stylex.create` call that is not a
 /// module-level statement to a `_styles` constant.
+///
+/// # A dynamic entry can hold a reference the module level does not
+///
+/// A value the compiler cannot fold becomes an inline style that holds the
+/// authored expression as it is written, and no rule says that expression may
+/// name only the parameters of the entry. So an entry that reads a constant of
+/// the enclosing scope carries that name to the module level, where it is not
+/// declared:
+///
+/// ```js
+/// export function render() {
+///   const gap = compute();
+///   const styles = stylex.create({ box: (v) => ({ width: v, margin: gap }) });
+///   return stylex.props(styles.box(1));
+/// }
+/// ```
+///
+/// The module still loads, because the body of the entry runs only when it is
+/// called. The call is what fails, which puts the fault a long way from its
+/// cause. The snapshot
+/// `a_nested_dynamic_entry_keeps_a_reference_to_the_scope_it_left` records the
+/// output as it is.
 pub(crate) fn hoist_styles_object(
   ast_expression: Expr,
   state: &mut stylex_state::state_manager::StateManager,

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/helpers.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/helpers.rs
@@ -134,21 +134,17 @@ pub(super) fn extract_expr_from_rule(
   None
 }
 
-/// Hoists an expression to the program level by creating a const variable
-/// declaration. This is the Rust equivalent of the JavaScript `hoistExpression`
-/// function.
+/// Hoist an expression to the module level as a `const` declaration.
 ///
-/// # Arguments
-/// * `ast_expression` - The expression to hoist
-/// * `state` - The state manager to add the hoisted declaration to
-///
-/// # Returns
-/// An identifier referencing the hoisted variable
-pub(crate) fn hoist_expression(
+/// The declaration is queued after the imports and the returned identifier
+/// stands for the expression at the call site. `prefix` is the stem of the
+/// generated identifier.
+fn hoist_to_module_level(
+  prefix: &str,
   ast_expression: Expr,
   state: &mut stylex_state::state_manager::StateManager,
 ) -> Expr {
-  let uid_generator = UidGenerator::new("temp", CounterMode::ThreadLocal);
+  let uid_generator = UidGenerator::new(prefix, CounterMode::ThreadLocal);
   let hoisted_ident = uid_generator.generate_ident();
 
   let var_decl = VarDecl {
@@ -168,31 +164,19 @@ pub(crate) fn hoist_expression(
   Expr::Ident(hoisted_ident)
 }
 
-pub(crate) fn path_replace_hoisted(
+/// Hoist a static fragment of a style value to a `_temp` constant.
+pub(crate) fn hoist_expression(
   ast_expression: Expr,
-  is_program_level: bool,
   state: &mut stylex_state::state_manager::StateManager,
 ) -> Expr {
-  if is_program_level {
-    return ast_expression;
-  }
+  hoist_to_module_level("temp", ast_expression, state)
+}
 
-  let uid_generator = UidGenerator::new("styles", CounterMode::ThreadLocal);
-  let name_ident = uid_generator.generate_ident();
-
-  let var_decl = VarDecl {
-    span: DUMMY_SP,
-    kind: VarDeclKind::Const,
-    declare: false,
-    decls: vec![create_var_declarator(name_ident.clone(), ast_expression)],
-    ctxt: swc_core::common::SyntaxContext::empty(),
-  };
-
-  let module_item = ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(var_decl))));
-  state.queue_insertion(
-    stylex_state::state_manager::InsertionSlot::AfterImports,
-    module_item,
-  );
-
-  Expr::Ident(name_ident)
+/// Hoist the compiled styles object of a `stylex.create` call that is not a
+/// module-level statement to a `_styles` constant.
+pub(crate) fn hoist_styles_object(
+  ast_expression: Expr,
+  state: &mut stylex_state::state_manager::StateManager,
+) -> Expr {
+  hoist_to_module_level("styles", ast_expression, state)
 }

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
@@ -279,7 +279,7 @@ where
 
       if self.state.is_debug() && self.state.options.enable_debug_data_prop {
         compiled_styles = add_source_map_data(
-          &compiled_styles,
+          compiled_styles,
           call,
           &mut self.state,
           &mut package_json_seen,
@@ -288,11 +288,11 @@ where
       }
 
       if self.state.is_dev() && self.state.options.enable_dev_class_names {
-        compiled_styles = inject_dev_class_names(&compiled_styles, &var_name, &self.state);
+        compiled_styles = inject_dev_class_names(compiled_styles, &var_name, &self.state);
       }
 
       if self.state.is_test() {
-        compiled_styles = convert_to_test_styles(&compiled_styles, &var_name, &self.state);
+        compiled_styles = convert_to_test_styles(compiled_styles, &var_name, &self.state);
       }
 
       if is_program_level && let Some(var_name) = var_name.as_ref() {

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
@@ -350,25 +350,31 @@ where
       let styles_ast =
         convert_object_to_ast(&NestedStringObject::FlatCompiledStyles(compiled_styles));
 
-      let mut result_ast =
-        path_replace_hoisted(styles_ast.clone(), is_program_level, &mut self.state);
-
-      result_ast = apply_dynamic_style_functions(
+      // The rewrite of the dynamic entries needs the object, not the hoisted
+      // identifier, so it runs before the hoist.
+      let styles_ast = apply_dynamic_style_functions(
         self,
         call,
-        result_ast,
+        styles_ast,
         evaluated_arg.fns,
         &class_paths_per_namespace,
         &injected_styles,
-        is_program_level,
       );
 
-      self.state.register_styles(
-        call,
-        &injected_styles,
-        &result_ast,
-        (!result_ast.eq(&styles_ast)).then_some(&styles_ast),
-      );
+      // A call that is not a module-level statement is hoisted to one and the
+      // call site becomes a reference. The object stays as the fallback, so the
+      // runtime injection calls still know the styles they belong to.
+      let (result_ast, fallback_ast) = if is_program_level {
+        (styles_ast, None)
+      } else {
+        let hoisted_ident = hoist_styles_object(styles_ast.clone(), &mut self.state);
+
+        (hoisted_ident, Some(styles_ast))
+      };
+
+      self
+        .state
+        .register_styles(call, &injected_styles, &result_ast, fallback_ast.as_ref());
 
       Some(result_ast)
     } else {

--- a/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
+++ b/crates/stylex-transform/src/transform/stylex/transform_stylex_create_call/mod.rs
@@ -63,7 +63,7 @@ use stylex_constants::constants::{
 };
 use stylex_css::utils::{pseudo::is_pseudo_element, when as stylex_when};
 use stylex_diagnostics::code_frame::{build_code_frame_error, build_code_frame_error_and_panic};
-use stylex_enums::{counter_mode::CounterMode, style_resolution::StyleResolution};
+use stylex_enums::style_resolution::StyleResolution;
 use stylex_evaluator::{
   evaluate::evaluate_result_is_nullish, state::EvaluationState,
   stylex_first_that_works::stylex_first_that_works,
@@ -80,10 +80,10 @@ use stylex_state::{
 };
 use stylex_structures::{
   dynamic_style::DynamicStyle, order_pair::OrderPair, stylex_state_options::StyleXStateOptions,
-  uid_generator::UidGenerator,
 };
 use stylex_types::structures::injectable_style::InjectableStyle;
 use stylex_types::traits::WhenMarkerValue;
+use stylex_utils::hash::stable_hash_unspanned;
 
 /// Resolves the value that occupies the second slot of a `when` call: the
 /// custom marker when one was passed, and the StyleX options otherwise.
@@ -232,20 +232,6 @@ where
         None => stylex_panic!("{}", non_static_value(STYLEX_CREATE)),
       };
 
-      assert!(
-        evaluated_arg.confident,
-        "{}",
-        build_code_frame_error(
-          &Expr::Call(call.clone()),
-          &evaluated_arg.deopt.unwrap_or_else(|| *first_arg.to_owned()),
-          evaluated_arg
-            .reason
-            .as_deref()
-            .unwrap_or(&non_static_value(STYLEX_CREATE)),
-          &mut self.state,
-        )
-      );
-
       let mut injected_inherit_styles: InjectableStylesMap = IndexMap::default();
 
       if let Some(fns) = &evaluated_arg.fns {
@@ -362,19 +348,22 @@ where
       );
 
       // A call that is not a module-level statement is hoisted to one and the
-      // call site becomes a reference. The object stays as the fallback, so the
-      // runtime injection calls still know the styles they belong to.
-      let (result_ast, fallback_ast) = if is_program_level {
+      // call site becomes a reference. The hash of the object goes on, so the
+      // runtime injection calls still find the declaration they belong to.
+      let (result_ast, fallback_ast_hash) = if is_program_level {
         (styles_ast, None)
       } else {
-        let hoisted_ident = hoist_styles_object(styles_ast.clone(), &mut self.state);
+        let fallback_ast_hash = stable_hash_unspanned(&styles_ast);
 
-        (hoisted_ident, Some(styles_ast))
+        (
+          hoist_styles_object(styles_ast, &mut self.state),
+          Some(fallback_ast_hash),
+        )
       };
 
       self
         .state
-        .register_styles(call, &injected_styles, &result_ast, fallback_ast.as_ref());
+        .register_styles(call, &injected_styles, &result_ast, fallback_ast_hash);
 
       Some(result_ast)
     } else {

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_exported_stylex_create_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_exported_stylex_create_call.js
@@ -51,7 +51,7 @@ _inject2({
 });
 export const styles = {
     sidebar: {
-        "__styles.sidebar": "__styles.sidebar",
+        "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
         "boxSizing-kB7OPa": "boxSizing-x9f619",
         "gridArea-kJuA4N": "gridArea-x1yc5d2u",
         "gridRow-kbNqZ1": null,
@@ -63,7 +63,7 @@ export const styles = {
         $$css: true
     },
     content: {
-        "__styles.content": "__styles.content",
+        "UnknownFile__styles.content": "UnknownFile__styles.content",
         "gridArea-kJuA4N": "gridArea-x1fdo2jl",
         "gridRow-kbNqZ1": null,
         "gridRowStart-k1lYIM": null,
@@ -74,14 +74,14 @@ export const styles = {
         $$css: true
     },
     root: {
-        "__styles.root": "__styles.root",
+        "UnknownFile__styles.root": "UnknownFile__styles.root",
         "display-k1xSpc": "display-xrvj5dj",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
         $$css: true
     },
     withSidebar: {
-        "__styles.withSidebar": "__styles.withSidebar",
+        "UnknownFile__styles.withSidebar": "UnknownFile__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
@@ -91,12 +91,12 @@ export const styles = {
         $$css: true
     },
     noSidebar: {
-        "__styles.noSidebar": "__styles.noSidebar",
+        "UnknownFile__styles.noSidebar": "UnknownFile__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
         $$css: true
     }
 };
 ({
-    0: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-    1: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x"
+    0: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+    1: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x"
 })[!!(sidebar == null) << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_exported_stylex_create_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_exported_stylex_create_call.js
@@ -51,6 +51,7 @@ _inject2({
 });
 export const styles = {
     sidebar: {
+        "__styles.sidebar": "__styles.sidebar",
         "boxSizing-kB7OPa": "boxSizing-x9f619",
         "gridArea-kJuA4N": "gridArea-x1yc5d2u",
         "gridRow-kbNqZ1": null,
@@ -62,6 +63,7 @@ export const styles = {
         $$css: true
     },
     content: {
+        "__styles.content": "__styles.content",
         "gridArea-kJuA4N": "gridArea-x1fdo2jl",
         "gridRow-kbNqZ1": null,
         "gridRowStart-k1lYIM": null,
@@ -72,12 +74,14 @@ export const styles = {
         $$css: true
     },
     root: {
+        "__styles.root": "__styles.root",
         "display-k1xSpc": "display-xrvj5dj",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
         $$css: true
     },
     withSidebar: {
+        "__styles.withSidebar": "__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
@@ -87,11 +91,12 @@ export const styles = {
         $$css: true
     },
     noSidebar: {
+        "__styles.noSidebar": "__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
         $$css: true
     }
 };
 ({
-    0: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-    1: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x"
+    0: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+    1: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x"
 })[!!(sidebar == null) << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call.js
@@ -51,6 +51,7 @@ _inject2({
 });
 export const styles = {
     sidebar: {
+        "Foo__styles.sidebar": "Foo__styles.sidebar",
         "boxSizing-kB7OPa": "boxSizing-x9f619",
         "gridArea-kJuA4N": "gridArea-x1yc5d2u",
         "gridRow-kbNqZ1": null,
@@ -62,6 +63,7 @@ export const styles = {
         $$css: "src/js/components/Foo.react.js:3"
     },
     content: {
+        "Foo__styles.content": "Foo__styles.content",
         "gridArea-kJuA4N": "gridArea-x1fdo2jl",
         "gridRow-kbNqZ1": null,
         "gridRowStart-k1lYIM": null,
@@ -72,12 +74,14 @@ export const styles = {
         $$css: "src/js/components/Foo.react.js:7"
     },
     root: {
+        "Foo__styles.root": "Foo__styles.root",
         "display-k1xSpc": "display-xrvj5dj",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
         $$css: "src/js/components/Foo.react.js:10"
     },
     withSidebar: {
+        "Foo__styles.withSidebar": "Foo__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
@@ -87,11 +91,12 @@ export const styles = {
         $$css: "src/js/components/Foo.react.js:15"
     },
     noSidebar: {
+        "Foo__styles.noSidebar": "Foo__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
         $$css: "src/js/components/Foo.react.js:25"
     }
 };
 ({
-    0: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-    1: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x"
+    0: "Foo__styles.root display-xrvj5dj Foo__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+    1: "Foo__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm Foo__styles.noSidebar gridTemplateColumns-x1mkdm3x"
 })[!!(sidebar == null) << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call_extended.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call_extended.js
@@ -50,12 +50,12 @@ _inject2({
     priority: 3000
 });
 export const complex = {
-    0: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-    4: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x",
-    2: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u",
-    6: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u",
-    1: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.content gridArea-x1fdo2jl",
-    5: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.content gridArea-x1fdo2jl",
-    3: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.sidebar boxSizing-x9f619 __styles.content gridArea-x1fdo2jl",
-    7: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.sidebar boxSizing-x9f619 __styles.content gridArea-x1fdo2jl"
+    0: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+    4: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x",
+    2: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 UnknownFile__styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u",
+    6: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x UnknownFile__styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u",
+    1: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 UnknownFile__styles.content gridArea-x1fdo2jl",
+    5: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x UnknownFile__styles.content gridArea-x1fdo2jl",
+    3: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 UnknownFile__styles.sidebar boxSizing-x9f619 UnknownFile__styles.content gridArea-x1fdo2jl",
+    7: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x UnknownFile__styles.sidebar boxSizing-x9f619 UnknownFile__styles.content gridArea-x1fdo2jl"
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call_extended.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call_extended.js
@@ -50,12 +50,12 @@ _inject2({
     priority: 3000
 });
 export const complex = {
-    0: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
-    4: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x",
-    2: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1yc5d2u",
-    6: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1yc5d2u",
-    1: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 gridArea-x1fdo2jl",
-    5: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x gridArea-x1fdo2jl",
-    3: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1fdo2jl",
-    7: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1fdo2jl"
+    0: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+    4: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x",
+    2: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u",
+    6: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u",
+    1: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.content gridArea-x1fdo2jl",
+    5: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.content gridArea-x1fdo2jl",
+    3: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.sidebar boxSizing-x9f619 __styles.content gridArea-x1fdo2jl",
+    7: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.sidebar boxSizing-x9f619 __styles.content gridArea-x1fdo2jl"
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call_skip_conditional.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call_skip_conditional.js
@@ -51,6 +51,7 @@ _inject2({
 });
 export const styles = {
     sidebar: {
+        "__styles.sidebar": "__styles.sidebar",
         "boxSizing-kB7OPa": "boxSizing-x9f619",
         "gridArea-kJuA4N": "gridArea-x1yc5d2u",
         "gridRow-kbNqZ1": null,
@@ -62,6 +63,7 @@ export const styles = {
         $$css: true
     },
     content: {
+        "__styles.content": "__styles.content",
         "gridArea-kJuA4N": "gridArea-x1fdo2jl",
         "gridRow-kbNqZ1": null,
         "gridRowStart-k1lYIM": null,
@@ -72,12 +74,14 @@ export const styles = {
         $$css: true
     },
     root: {
+        "__styles.root": "__styles.root",
         "display-k1xSpc": "display-xrvj5dj",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
         $$css: true
     },
     withSidebar: {
+        "__styles.withSidebar": "__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
@@ -87,6 +91,7 @@ export const styles = {
         $$css: true
     },
     noSidebar: {
+        "__styles.noSidebar": "__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
         $$css: true
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call_skip_conditional.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/specific_edge_case_bugs.rs/basic_stylex_call_skip_conditional.js
@@ -51,7 +51,7 @@ _inject2({
 });
 export const styles = {
     sidebar: {
-        "__styles.sidebar": "__styles.sidebar",
+        "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
         "boxSizing-kB7OPa": "boxSizing-x9f619",
         "gridArea-kJuA4N": "gridArea-x1yc5d2u",
         "gridRow-kbNqZ1": null,
@@ -63,7 +63,7 @@ export const styles = {
         $$css: true
     },
     content: {
-        "__styles.content": "__styles.content",
+        "UnknownFile__styles.content": "UnknownFile__styles.content",
         "gridArea-kJuA4N": "gridArea-x1fdo2jl",
         "gridRow-kbNqZ1": null,
         "gridRowStart-k1lYIM": null,
@@ -74,14 +74,14 @@ export const styles = {
         $$css: true
     },
     root: {
-        "__styles.root": "__styles.root",
+        "UnknownFile__styles.root": "UnknownFile__styles.root",
         "display-k1xSpc": "display-xrvj5dj",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
         $$css: true
     },
     withSidebar: {
-        "__styles.withSidebar": "__styles.withSidebar",
+        "UnknownFile__styles.withSidebar": "UnknownFile__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
@@ -91,7 +91,7 @@ export const styles = {
         $$css: true
     },
     noSidebar: {
-        "__styles.noSidebar": "__styles.noSidebar",
+        "UnknownFile__styles.noSidebar": "UnknownFile__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
         $$css: true
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_collisions.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_collisions.js
@@ -10,6 +10,6 @@ _inject2({
     priority: 3000
 });
 ({
-    0: "color-x1e2nbdu",
-    1: "color-xju2f9n"
+    0: "FooBar__styles.default color-x1e2nbdu",
+    1: "FooBar__styles.default FooBar__styles.active color-xju2f9n"
 })[!!isActive << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_collisions_skip_conditional.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_collisions_skip_conditional.js
@@ -11,10 +11,12 @@ _inject2({
 });
 const styles = {
     default: {
+        "FooBar__styles.default": "FooBar__styles.default",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "js/FooBar.react.js:3"
     },
     active: {
+        "FooBar__styles.active": "FooBar__styles.active",
         "color-kMwMTN": "color-xju2f9n",
         $$css: "js/FooBar.react.js:6"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions.js
@@ -10,6 +10,6 @@ _inject2({
     priority: 3000
 });
 ({
-    0: "color-x1e2nbdu",
-    1: "color-x1e2nbdu backgroundColor-x1t391ir"
+    0: "FooBar__styles.default color-x1e2nbdu",
+    1: "FooBar__styles.default color-x1e2nbdu FooBar__otherStyles.default backgroundColor-x1t391ir"
 })[!!isActive << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions_skip_conditional.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions_skip_conditional.js
@@ -7,6 +7,7 @@ _inject2({
 });
 const styles = {
     default: {
+        "FooBar__styles.default": "FooBar__styles.default",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "js/FooBar.react.js:3"
     }
@@ -17,6 +18,7 @@ _inject2({
 });
 const otherStyles = {
     default: {
+        "FooBar__otherStyles.default": "FooBar__otherStyles.default",
         "backgroundColor-kWkggS": "backgroundColor-x1t391ir",
         $$css: "js/FooBar.react.js:8"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_names_and_enable_inlined_conditional_merge_false.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/legacy/transform_call/with_plugin_options.rs/stylex_call_produces_dev_class_names_and_enable_inlined_conditional_merge_false.js
@@ -5,4 +5,4 @@ _inject2({
     ltr: ".color-x1e2nbdu{color:red}",
     priority: 3000
 });
-"color-x1e2nbdu";
+"FooBar__styles.default color-x1e2nbdu";

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/correct_transform_variables_with_same_name_in_different_scopes.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/correct_transform_variables_with_same_name_in_different_scopes.js
@@ -53,7 +53,7 @@ _inject2({
 });
 const s = {
     div: {
-        "__s.div": "__s.div",
+        "UnknownFile__s.div": "UnknownFile__s.div",
         "backgroundColor-kWkggS": "backgroundColor-xvto61e",
         $$css: true
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/correct_transform_variables_with_same_name_in_different_scopes.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/correct_transform_variables_with_same_name_in_different_scopes.js
@@ -53,6 +53,7 @@ _inject2({
 });
 const s = {
     div: {
+        "__s.div": "__s.div",
         "backgroundColor-kWkggS": "backgroundColor-xvto61e",
         $$css: true
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/stylex_call_with_redaclare_import_declaration_in_dev_mode.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/stylex_call_with_redaclare_import_declaration_in_dev_mode.js
@@ -33,7 +33,7 @@ export const ComponentWithCallings = ()=>{
 };
 const s = {
     div: {
-        "__s.div": "__s.div",
+        "UnknownFile__s.div": "UnknownFile__s.div",
         "backgroundColor-kWkggS": "backgroundColor-xvto61e",
         $$css: true
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/stylex_call_with_redaclare_import_declaration_in_dev_mode.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/stylex_call_with_redaclare_import_declaration_in_dev_mode.js
@@ -33,6 +33,7 @@ export const ComponentWithCallings = ()=>{
 };
 const s = {
     div: {
+        "__s.div": "__s.div",
         "backgroundColor-kWkggS": "backgroundColor-xvto61e",
         $$css: true
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/stylex_call_with_redaclare_variable_from_other_scope_in_dev_mode.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/stylex_call_with_redaclare_variable_from_other_scope_in_dev_mode.js
@@ -33,7 +33,7 @@ export const ComponentWithCallings = ()=>{
 };
 const s = {
     div: {
-        "__s.div": "__s.div",
+        "UnknownFile__s.div": "UnknownFile__s.div",
         "backgroundColor-kWkggS": "backgroundColor-xvto61e",
         $$css: true
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/stylex_call_with_redaclare_variable_from_other_scope_in_dev_mode.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_misc_test/scope.rs/stylex_call_with_redaclare_variable_from_other_scope_in_dev_mode.js
@@ -33,6 +33,7 @@ export const ComponentWithCallings = ()=>{
 };
 const s = {
     div: {
+        "__s.div": "__s.div",
         "backgroundColor-kWkggS": "backgroundColor-xvto61e",
         $$css: true
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/basic_stylex_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/basic_stylex_call.js
@@ -51,25 +51,25 @@ _inject2({
 });
 export const styles = {
     sidebar: {
-        "__styles.sidebar": "__styles.sidebar",
+        "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
         "boxSizing-kB7OPa": "x9f619",
         "gridArea-kJuA4N": "x1yc5d2u",
         $$css: true
     },
     content: {
-        "__styles.content": "__styles.content",
+        "UnknownFile__styles.content": "UnknownFile__styles.content",
         "gridArea-kJuA4N": "x1fdo2jl",
         $$css: true
     },
     root: {
-        "__styles.root": "__styles.root",
+        "UnknownFile__styles.root": "UnknownFile__styles.root",
         "display-k1xSpc": "xrvj5dj",
         "gridTemplateRows-k9llMU": "x7k18q3",
         "gridTemplateAreas-kC13JO": "x5gp9wm",
         $$css: true
     },
     withSidebar: {
-        "__styles.withSidebar": "__styles.withSidebar",
+        "UnknownFile__styles.withSidebar": "UnknownFile__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "x1rkzygb",
         "gridTemplateRows-k9llMU": "x7k18q3",
         "gridTemplateAreas-kC13JO": "x17lh93j",
@@ -79,16 +79,16 @@ export const styles = {
         $$css: true
     },
     noSidebar: {
-        "__styles.noSidebar": "__styles.noSidebar",
+        "UnknownFile__styles.noSidebar": "UnknownFile__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "x1mkdm3x",
         $$css: true
     }
 };
 ({
     0: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
     },
     1: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x"
     }
 })[!!(sidebar == null) << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/basic_stylex_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/basic_stylex_call.js
@@ -51,21 +51,25 @@ _inject2({
 });
 export const styles = {
     sidebar: {
+        "__styles.sidebar": "__styles.sidebar",
         "boxSizing-kB7OPa": "x9f619",
         "gridArea-kJuA4N": "x1yc5d2u",
         $$css: true
     },
     content: {
+        "__styles.content": "__styles.content",
         "gridArea-kJuA4N": "x1fdo2jl",
         $$css: true
     },
     root: {
+        "__styles.root": "__styles.root",
         "display-k1xSpc": "xrvj5dj",
         "gridTemplateRows-k9llMU": "x7k18q3",
         "gridTemplateAreas-kC13JO": "x5gp9wm",
         $$css: true
     },
     withSidebar: {
+        "__styles.withSidebar": "__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "x1rkzygb",
         "gridTemplateRows-k9llMU": "x7k18q3",
         "gridTemplateAreas-kC13JO": "x17lh93j",
@@ -75,15 +79,16 @@ export const styles = {
         $$css: true
     },
     noSidebar: {
+        "__styles.noSidebar": "__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "x1mkdm3x",
         $$css: true
     }
 };
 ({
     0: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
     },
     1: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x"
     }
 })[!!(sidebar == null) << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/basic_stylex_call_exported.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/basic_stylex_call_exported.js
@@ -51,27 +51,27 @@ _inject2({
 });
 export const complex = {
     0: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
     },
     4: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x"
     },
     2: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 x1yc5d2u"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.sidebar x9f619 x1yc5d2u"
     },
     6: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 x1yc5d2u"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.sidebar x9f619 x1yc5d2u"
     },
     1: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.content x1fdo2jl"
     },
     5: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.content x1fdo2jl"
     },
     3: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.sidebar x9f619 UnknownFile__styles.content x1fdo2jl"
     },
     7: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.sidebar x9f619 UnknownFile__styles.content x1fdo2jl"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/basic_stylex_call_exported.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/basic_stylex_call_exported.js
@@ -51,27 +51,27 @@ _inject2({
 });
 export const complex = {
     0: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
     },
     4: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x"
     },
     2: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1yc5d2u"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 x1yc5d2u"
     },
     6: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1yc5d2u"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 x1yc5d2u"
     },
     1: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x1fdo2jl"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.content x1fdo2jl"
     },
     5: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x1fdo2jl"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.content x1fdo2jl"
     },
     3: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1fdo2jl"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 __styles.content x1fdo2jl"
     },
     7: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1fdo2jl"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 __styles.content x1fdo2jl"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/stylex_call_in_debug_mode.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/stylex_call_in_debug_mode.js
@@ -51,27 +51,27 @@ _inject2({
 });
 export const complex = {
     0: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
     },
     4: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x"
     },
     2: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 x1yc5d2u"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.sidebar x9f619 x1yc5d2u"
     },
     6: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 x1yc5d2u"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.sidebar x9f619 x1yc5d2u"
     },
     1: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.content x1fdo2jl"
     },
     5: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.content x1fdo2jl"
     },
     3: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.sidebar x9f619 UnknownFile__styles.content x1fdo2jl"
     },
     7: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.sidebar x9f619 UnknownFile__styles.content x1fdo2jl"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/stylex_call_in_debug_mode.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/stylex_call_in_debug_mode.js
@@ -51,27 +51,27 @@ _inject2({
 });
 export const complex = {
     0: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
     },
     4: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x"
     },
     2: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1yc5d2u"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 x1yc5d2u"
     },
     6: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1yc5d2u"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 x1yc5d2u"
     },
     1: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x1fdo2jl"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.content x1fdo2jl"
     },
     5: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x1fdo2jl"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.content x1fdo2jl"
     },
     3: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1fdo2jl"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 __styles.content x1fdo2jl"
     },
     7: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1fdo2jl"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 __styles.content x1fdo2jl"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/stylex_call_in_debug_mode_with_debug_classnames_disabled.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/stylex_call_in_debug_mode_with_debug_classnames_disabled.js
@@ -51,27 +51,27 @@ _inject2({
 });
 export const complex = {
     0: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
     },
     4: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x"
     },
     2: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 x1yc5d2u"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.sidebar x9f619 x1yc5d2u"
     },
     6: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 x1yc5d2u"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.sidebar x9f619 x1yc5d2u"
     },
     1: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.content x1fdo2jl"
     },
     5: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.content x1fdo2jl"
     },
     3: {
-        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj UnknownFile__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 UnknownFile__styles.sidebar x9f619 UnknownFile__styles.content x1fdo2jl"
     },
     7: {
-        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 __styles.content x1fdo2jl"
+        class: "UnknownFile__styles.root xrvj5dj x7k18q3 x5gp9wm UnknownFile__styles.noSidebar x1mkdm3x UnknownFile__styles.sidebar x9f619 UnknownFile__styles.content x1fdo2jl"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/stylex_call_in_debug_mode_with_debug_classnames_disabled.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/specific_edge_case_bugs.rs/stylex_call_in_debug_mode_with_debug_classnames_disabled.js
@@ -51,27 +51,27 @@ _inject2({
 });
 export const complex = {
     0: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4"
     },
     4: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x"
     },
     2: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1yc5d2u"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 x1yc5d2u"
     },
     6: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1yc5d2u"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 x1yc5d2u"
     },
     1: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x1fdo2jl"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.content x1fdo2jl"
     },
     5: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x1fdo2jl"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.content x1fdo2jl"
     },
     3: {
-        class: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1fdo2jl"
+        class: "__styles.root xrvj5dj __styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 __styles.sidebar x9f619 __styles.content x1fdo2jl"
     },
     7: {
-        class: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1fdo2jl"
+        class: "__styles.root xrvj5dj x7k18q3 x5gp9wm __styles.noSidebar x1mkdm3x __styles.sidebar x9f619 __styles.content x1fdo2jl"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_collisions.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_collisions.js
@@ -11,11 +11,11 @@ _inject2({
 });
 ({
     0: {
-        class: "x1e2nbdu",
+        class: "FooBar__styles.default x1e2nbdu",
         "data-style-src": "js/FooBar.react.js:3"
     },
     1: {
-        class: "xju2f9n",
+        class: "FooBar__styles.default FooBar__styles.active xju2f9n",
         "data-style-src": "js/FooBar.react.js:3; js/FooBar.react.js:6"
     }
 })[!!isActive << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions.js
@@ -11,11 +11,11 @@ _inject2({
 });
 ({
     0: {
-        class: "x1e2nbdu",
+        class: "FooBar__styles.default x1e2nbdu",
         "data-style-src": "js/FooBar.react.js:3"
     },
     1: {
-        class: "x1e2nbdu x1t391ir",
+        class: "FooBar__styles.default x1e2nbdu FooBar__otherStyles.default x1t391ir",
         "data-style-src": "js/FooBar.react.js:3; js/FooBar.react.js:8"
     }
 })[!!isActive << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions_skip_conditional.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions_skip_conditional.js
@@ -11,11 +11,11 @@ _inject2({
 });
 ({
     0: {
-        class: "x1e2nbdu",
+        class: "FooBar__styles.default x1e2nbdu",
         "data-style-src": "js/FooBar.react.js:3"
     },
     1: {
-        class: "x1e2nbdu x1t391ir",
+        class: "FooBar__styles.default x1e2nbdu FooBar__otherStyles.default x1t391ir",
         "data-style-src": "js/FooBar.react.js:3; js/FooBar.react.js:8"
     }
 })[!!isActive << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/with_plugin_options.rs/stylex_call_produces_dev_class_names.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_attrs_test/with_plugin_options.rs/stylex_call_produces_dev_class_names.js
@@ -6,6 +6,6 @@ _inject2({
     priority: 3000
 });
 ({
-    class: "x1e2nbdu",
+    class: "FooBar__styles.default x1e2nbdu",
     "data-style-src": "js/FooBar.react.js:3"
 });

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/debug_options.rs/a_dev_build_names_each_namespace_by_default.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/debug_options.rs/a_dev_build_names_each_namespace_by_default.js
@@ -1,0 +1,22 @@
+import * as stylex from '@stylexjs/stylex';
+const _temp = {
+    "MyComponent__styles.dyn": "MyComponent__styles.dyn",
+    $$css: "MyComponent.js:5"
+};
+export const styles = {
+    root: {
+        "MyComponent__styles.root": "MyComponent__styles.root",
+        "color-kMwMTN": "x1e2nbdu",
+        $$css: "MyComponent.js:4"
+    },
+    dyn: (width)=>[
+            _temp,
+            {
+                "width-kzqmXN": width != null ? "x5lhr3w" : width,
+                $$css: "MyComponent.js:5"
+            },
+            {
+                "--x-width": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
+            }
+        ]
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/debug_options.rs/a_dev_build_names_no_namespace_when_the_option_is_off.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/debug_options.rs/a_dev_build_names_no_namespace_when_the_option_is_off.js
@@ -1,0 +1,16 @@
+import * as stylex from '@stylexjs/stylex';
+export const styles = {
+    root: {
+        "color-kMwMTN": "x1e2nbdu",
+        $$css: "MyComponent.js:4"
+    },
+    dyn: (width)=>[
+            {
+                "width-kzqmXN": width != null ? "x5lhr3w" : width,
+                $$css: "MyComponent.js:5"
+            },
+            {
+                "--x-width": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : undefined)(width)
+            }
+        ]
+};

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_block_stays_callable.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_block_stays_callable.js
@@ -1,0 +1,21 @@
+import * as stylex from '@stylexjs/stylex';
+const _styles = {
+    color: (value)=>[
+            {
+                kMwMTN: value != null ? "x14rh7hd" : value,
+                $$css: true
+            },
+            {
+                "--x-color": value != null ? value : undefined
+            }
+        ],
+    base: {
+        k1xSpc: "x78zum5",
+        $$css: true
+    }
+};
+export let render;
+{
+    const styles = _styles;
+    render = (value)=>stylex.props(styles.base, styles.color(value));
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_function_body_stays_callable.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_function_body_stays_callable.js
@@ -1,0 +1,20 @@
+import * as stylex from '@stylexjs/stylex';
+const _styles = {
+    color: (value)=>[
+            {
+                kMwMTN: value != null ? "x14rh7hd" : value,
+                $$css: true
+            },
+            {
+                "--x-color": value != null ? value : undefined
+            }
+        ],
+    base: {
+        k1xSpc: "x78zum5",
+        $$css: true
+    }
+};
+export function render(value) {
+    const styles = _styles;
+    return stylex.props(styles.base, styles.color(value));
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_namespace_in_dev_with_runtime_injection.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_namespace_in_dev_with_runtime_injection.js
@@ -1,0 +1,42 @@
+import _inject from "@stylexjs/stylex/lib/stylex-inject";
+var _inject2 = _inject;
+import * as stylex from '@stylexjs/stylex';
+const _temp = {
+    "MyComponent__styles.color": "MyComponent__styles.color",
+    $$css: "MyComponent.tsx:4"
+};
+_inject2({
+    ltr: ".x14rh7hd{color:var(--x-color)}",
+    priority: 3000
+});
+_inject2({
+    ltr: ".x78zum5{display:flex}",
+    priority: 3000
+});
+_inject2({
+    ltr: '@property --x-color { syntax: "*"; inherits: false;}',
+    priority: 0
+});
+const _styles = {
+    color: (value: string)=>[
+            _temp,
+            {
+                "color-kMwMTN": value != null ? "x14rh7hd" : value,
+                $$css: "MyComponent.tsx:4"
+            },
+            {
+                "--x-color": value != null ? value : undefined
+            }
+        ],
+    base: {
+        "MyComponent__styles.base": "MyComponent__styles.base",
+        "display-k1xSpc": "x78zum5",
+        $$css: "MyComponent.tsx:7"
+    }
+};
+export namespace Demo {
+    const styles = _styles;
+    export function render() {
+        return stylex.props(styles.base, styles.color('red'));
+    }
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_namespace_in_dev_with_runtime_injection.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_namespace_in_dev_with_runtime_injection.js
@@ -3,7 +3,7 @@ var _inject2 = _inject;
 import * as stylex from '@stylexjs/stylex';
 const _temp = {
     "MyComponent__styles.color": "MyComponent__styles.color",
-    $$css: "MyComponent.tsx:4"
+    $$css: "MyComponent.tsx:5"
 };
 _inject2({
     ltr: ".x14rh7hd{color:var(--x-color)}",
@@ -22,7 +22,7 @@ const _styles = {
             _temp,
             {
                 "color-kMwMTN": value != null ? "x14rh7hd" : value,
-                $$css: "MyComponent.tsx:4"
+                $$css: "MyComponent.tsx:5"
             },
             {
                 "--x-color": value != null ? value : undefined
@@ -31,7 +31,7 @@ const _styles = {
     base: {
         "MyComponent__styles.base": "MyComponent__styles.base",
         "display-k1xSpc": "x78zum5",
-        $$css: "MyComponent.tsx:7"
+        $$css: "MyComponent.tsx:6"
     }
 };
 export namespace Demo {

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_namespace_stays_callable.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_a_namespace_stays_callable.js
@@ -1,0 +1,22 @@
+import * as stylex from '@stylexjs/stylex';
+const _styles = {
+    color: (value: string)=>[
+            {
+                kMwMTN: value != null ? "x14rh7hd" : value,
+                $$css: true
+            },
+            {
+                "--x-color": value != null ? value : undefined
+            }
+        ],
+    base: {
+        k1xSpc: "x78zum5",
+        $$css: true
+    }
+};
+export namespace Demo {
+    const styles = _styles;
+    export function render() {
+        return stylex.props(styles.base, styles.color('red'));
+    }
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_an_iife_stays_callable.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_dynamic_entry_inside_an_iife_stays_callable.js
@@ -1,0 +1,20 @@
+import * as stylex from '@stylexjs/stylex';
+const _styles = {
+    color: (value)=>[
+            {
+                kMwMTN: value != null ? "x14rh7hd" : value,
+                $$css: true
+            },
+            {
+                "--x-color": value != null ? value : undefined
+            }
+        ],
+    base: {
+        k1xSpc: "x78zum5",
+        $$css: true
+    }
+};
+export const render = (()=>{
+    const styles = _styles;
+    return (value)=>stylex.props(styles.base, styles.color(value));
+})();

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_hoisted_styles_object_passes_over_a_name_the_module_already_uses.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_hoisted_styles_object_passes_over_a_name_the_module_already_uses.js
@@ -1,0 +1,17 @@
+import * as stylex from '@stylexjs/stylex';
+const _styles2 = {
+    color: (v)=>[
+            {
+                kMwMTN: v != null ? "x14rh7hd" : v,
+                $$css: true
+            },
+            {
+                "--x-color": v != null ? v : undefined
+            }
+        ]
+};
+export const _styles = 1;
+export function render(value) {
+    const styles = _styles2;
+    return stylex.props(styles.color(value));
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_nested_dynamic_entry_keeps_a_reference_to_the_scope_it_left.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_create_test/dynamic_styles.rs/a_nested_dynamic_entry_keeps_a_reference_to_the_scope_it_left.js
@@ -1,0 +1,18 @@
+import * as stylex from '@stylexjs/stylex';
+const _styles = {
+    box: (value)=>[
+            {
+                kzqmXN: value != null ? "x5lhr3w" : value,
+                kogj98: gap != null ? "xb9ncqk" : gap,
+                $$css: true
+            },
+            {
+                "--x-width": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : undefined)(value),
+                "--x-margin": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : undefined)(gap)
+            }
+        ]
+};
+export function render(gap) {
+    const styles = _styles;
+    return stylex.props(styles.box(1));
+}

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_atoms.rs/dev_debug_classnames_for_atoms.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_atoms.rs/dev_debug_classnames_for_atoms.js
@@ -7,5 +7,5 @@ _inject2({
     priority: 3000
 });
 ({
-    className: "Foo____inline__ display-x78zum5"
+    className: "Foo__sx display-x78zum5"
 });

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_jsx.rs/jsx_spread_keeps_style_object_for_mixed_static_and_dynamic_styles.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_jsx.rs/jsx_spread_keeps_style_object_for_mixed_static_and_dynamic_styles.js
@@ -1,6 +1,10 @@
 import _inject from "@stylexjs/stylex/lib/stylex-inject";
 var _inject2 = _inject;
 import stylex from 'stylex';
+const _temp = {
+    "Foo__styles.opacity": "Foo__styles.opacity",
+    $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"
+};
 _inject2({
     ltr: ".color-x1e2nbdu{color:red}",
     priority: 3000
@@ -15,10 +19,12 @@ _inject2({
 });
 const styles = {
     red: {
+        "Foo__styles.red": "Foo__styles.red",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     },
     opacity: (opacity)=>[
+            _temp,
             {
                 "opacity-kSiTet": opacity != null ? "opacity-xb4nw82" : opacity,
                 $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_jsx.rs/local_dynamic_styles.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_jsx.rs/local_dynamic_styles.js
@@ -1,6 +1,10 @@
 import _inject from "@stylexjs/stylex/lib/stylex-inject";
 var _inject2 = _inject;
 import stylex from 'stylex';
+const _temp = {
+    "Foo__styles.opacity": "Foo__styles.opacity",
+    $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"
+};
 _inject2({
     ltr: ".color-x1e2nbdu{color:red}",
     priority: 3000
@@ -15,10 +19,12 @@ _inject2({
 });
 const styles = {
     red: {
+        "Foo__styles.red": "Foo__styles.red",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     },
     opacity: (opacity)=>[
+            _temp,
             {
                 "opacity-kSiTet": opacity != null ? "opacity-xb4nw82" : opacity,
                 $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_jsx.rs/local_static_styles.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_jsx.rs/local_static_styles.js
@@ -7,8 +7,8 @@ _inject2({
 });
 function Foo() {
     return <>
-          <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>
-          <div className="test" className="color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3" id="test">Hello World</div>
-          <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3" className="test">Hello World</div>
+          <div id="test" className="Foo__styles.red color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>
+          <div className="test" className="Foo__styles.red color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3" id="test">Hello World</div>
+          <div id="test" className="Foo__styles.red color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3" className="test">Hello World</div>
         </>;
 }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_jsx.rs/non_local_styles.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/props_calls_with_jsx.rs/non_local_styles.js
@@ -7,6 +7,7 @@ _inject2({
 });
 const styles = {
     red: {
+        "Foo__styles.red": "Foo__styles.red",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/basic_stylex_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/basic_stylex_call.js
@@ -51,21 +51,25 @@ _inject2({
 });
 export const styles = {
     sidebar: {
+        "__styles.sidebar": "__styles.sidebar",
         "boxSizing-kB7OPa": "boxSizing-x9f619",
         "gridArea-kJuA4N": "gridArea-x1yc5d2u",
         $$css: true
     },
     content: {
+        "__styles.content": "__styles.content",
         "gridArea-kJuA4N": "gridArea-x1fdo2jl",
         $$css: true
     },
     root: {
+        "__styles.root": "__styles.root",
         "display-k1xSpc": "display-xrvj5dj",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
         $$css: true
     },
     withSidebar: {
+        "__styles.withSidebar": "__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
@@ -75,15 +79,16 @@ export const styles = {
         $$css: true
     },
     noSidebar: {
+        "__styles.noSidebar": "__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
         $$css: true
     }
 };
 ({
     0: {
-        className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4"
+        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4"
     },
     1: {
-        className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x"
+        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x"
     }
 })[!!(sidebar == null) << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/basic_stylex_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/basic_stylex_call.js
@@ -51,25 +51,25 @@ _inject2({
 });
 export const styles = {
     sidebar: {
-        "__styles.sidebar": "__styles.sidebar",
+        "UnknownFile__styles.sidebar": "UnknownFile__styles.sidebar",
         "boxSizing-kB7OPa": "boxSizing-x9f619",
         "gridArea-kJuA4N": "gridArea-x1yc5d2u",
         $$css: true
     },
     content: {
-        "__styles.content": "__styles.content",
+        "UnknownFile__styles.content": "UnknownFile__styles.content",
         "gridArea-kJuA4N": "gridArea-x1fdo2jl",
         $$css: true
     },
     root: {
-        "__styles.root": "__styles.root",
+        "UnknownFile__styles.root": "UnknownFile__styles.root",
         "display-k1xSpc": "display-xrvj5dj",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x5gp9wm",
         $$css: true
     },
     withSidebar: {
-        "__styles.withSidebar": "__styles.withSidebar",
+        "UnknownFile__styles.withSidebar": "UnknownFile__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1rkzygb",
         "gridTemplateRows-k9llMU": "gridTemplateRows-x7k18q3",
         "gridTemplateAreas-kC13JO": "gridTemplateAreas-x17lh93j",
@@ -79,16 +79,16 @@ export const styles = {
         $$css: true
     },
     noSidebar: {
-        "__styles.noSidebar": "__styles.noSidebar",
+        "UnknownFile__styles.noSidebar": "UnknownFile__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "gridTemplateColumns-x1mkdm3x",
         $$css: true
     }
 };
 ({
     0: {
-        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4"
+        className: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4"
     },
     1: {
-        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x"
+        className: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x"
     }
 })[!!(sidebar == null) << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/basic_stylex_call_exported.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/basic_stylex_call_exported.js
@@ -51,27 +51,27 @@ _inject2({
 });
 export const complex = {
     0: {
-        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4"
+        className: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4"
     },
     4: {
-        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x"
+        className: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x"
     },
     2: {
-        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u"
+        className: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 UnknownFile__styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u"
     },
     6: {
-        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u"
+        className: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x UnknownFile__styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u"
     },
     1: {
-        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.content gridArea-x1fdo2jl"
+        className: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 UnknownFile__styles.content gridArea-x1fdo2jl"
     },
     5: {
-        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.content gridArea-x1fdo2jl"
+        className: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x UnknownFile__styles.content gridArea-x1fdo2jl"
     },
     3: {
-        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.sidebar boxSizing-x9f619 __styles.content gridArea-x1fdo2jl"
+        className: "UnknownFile__styles.root display-xrvj5dj UnknownFile__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 UnknownFile__styles.sidebar boxSizing-x9f619 UnknownFile__styles.content gridArea-x1fdo2jl"
     },
     7: {
-        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.sidebar boxSizing-x9f619 __styles.content gridArea-x1fdo2jl"
+        className: "UnknownFile__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm UnknownFile__styles.noSidebar gridTemplateColumns-x1mkdm3x UnknownFile__styles.sidebar boxSizing-x9f619 UnknownFile__styles.content gridArea-x1fdo2jl"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/basic_stylex_call_exported.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/basic_stylex_call_exported.js
@@ -51,27 +51,27 @@ _inject2({
 });
 export const complex = {
     0: {
-        className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4"
+        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4"
     },
     4: {
-        className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x"
+        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x"
     },
     2: {
-        className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1yc5d2u"
+        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u"
     },
     6: {
-        className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1yc5d2u"
+        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u"
     },
     1: {
-        className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 gridArea-x1fdo2jl"
+        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.content gridArea-x1fdo2jl"
     },
     5: {
-        className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x gridArea-x1fdo2jl"
+        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.content gridArea-x1fdo2jl"
     },
     3: {
-        className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1fdo2jl"
+        className: "__styles.root display-xrvj5dj __styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 __styles.sidebar boxSizing-x9f619 __styles.content gridArea-x1fdo2jl"
     },
     7: {
-        className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1fdo2jl"
+        className: "__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm __styles.noSidebar gridTemplateColumns-x1mkdm3x __styles.sidebar boxSizing-x9f619 __styles.content gridArea-x1fdo2jl"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/stylex_call_with_debug_on.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/stylex_call_with_debug_on.js
@@ -51,35 +51,35 @@ _inject2({
 });
 export const complex = {
     0: {
-        className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
+        className: "FooBar__styles.root display-xrvj5dj FooBar__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:15"
     },
     4: {
-        className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x",
+        className: "FooBar__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm FooBar__styles.noSidebar gridTemplateColumns-x1mkdm3x",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:25"
     },
     2: {
-        className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1yc5d2u",
+        className: "FooBar__styles.root display-xrvj5dj FooBar__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 FooBar__styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:15; js/FooBar.react.js:3"
     },
     6: {
-        className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1yc5d2u",
+        className: "FooBar__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm FooBar__styles.noSidebar gridTemplateColumns-x1mkdm3x FooBar__styles.sidebar boxSizing-x9f619 gridArea-x1yc5d2u",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:25; js/FooBar.react.js:3"
     },
     1: {
-        className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 gridArea-x1fdo2jl",
+        className: "FooBar__styles.root display-xrvj5dj FooBar__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 FooBar__styles.content gridArea-x1fdo2jl",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:15; js/FooBar.react.js:7"
     },
     5: {
-        className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x gridArea-x1fdo2jl",
+        className: "FooBar__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm FooBar__styles.noSidebar gridTemplateColumns-x1mkdm3x FooBar__styles.content gridArea-x1fdo2jl",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:25; js/FooBar.react.js:7"
     },
     3: {
-        className: "display-xrvj5dj gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 boxSizing-x9f619 gridArea-x1fdo2jl",
+        className: "FooBar__styles.root display-xrvj5dj FooBar__styles.withSidebar gridTemplateColumns-x1rkzygb gridTemplateRows-x7k18q3 gridTemplateAreas-x17lh93j gridTemplateRows-xmr4b4k gridTemplateAreas-xesbpuc gridTemplateColumns-x15nfgh4 FooBar__styles.sidebar boxSizing-x9f619 FooBar__styles.content gridArea-x1fdo2jl",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:15; js/FooBar.react.js:3; js/FooBar.react.js:7"
     },
     7: {
-        className: "display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm gridTemplateColumns-x1mkdm3x boxSizing-x9f619 gridArea-x1fdo2jl",
+        className: "FooBar__styles.root display-xrvj5dj gridTemplateRows-x7k18q3 gridTemplateAreas-x5gp9wm FooBar__styles.noSidebar gridTemplateColumns-x1mkdm3x FooBar__styles.sidebar boxSizing-x9f619 FooBar__styles.content gridArea-x1fdo2jl",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:25; js/FooBar.react.js:3; js/FooBar.react.js:7"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/stylex_call_with_debug_on_and_debug_classnames_off.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/specific_edge_case_bugs.rs/stylex_call_with_debug_on_and_debug_classnames_off.js
@@ -51,21 +51,25 @@ _inject2({
 });
 export const styles = {
     sidebar: {
+        "FooBar__styles.sidebar": "FooBar__styles.sidebar",
         "boxSizing-kB7OPa": "x9f619",
         "gridArea-kJuA4N": "x1yc5d2u",
         $$css: "js/FooBar.react.js:3"
     },
     content: {
+        "FooBar__styles.content": "FooBar__styles.content",
         "gridArea-kJuA4N": "x1fdo2jl",
         $$css: "js/FooBar.react.js:7"
     },
     root: {
+        "FooBar__styles.root": "FooBar__styles.root",
         "display-k1xSpc": "xrvj5dj",
         "gridTemplateRows-k9llMU": "x7k18q3",
         "gridTemplateAreas-kC13JO": "x5gp9wm",
         $$css: "js/FooBar.react.js:10"
     },
     withSidebar: {
+        "FooBar__styles.withSidebar": "FooBar__styles.withSidebar",
         "gridTemplateColumns-kumcoG": "x1rkzygb",
         "gridTemplateRows-k9llMU": "x7k18q3",
         "gridTemplateAreas-kC13JO": "x17lh93j",
@@ -75,41 +79,42 @@ export const styles = {
         $$css: "js/FooBar.react.js:15"
     },
     noSidebar: {
+        "FooBar__styles.noSidebar": "FooBar__styles.noSidebar",
         "gridTemplateColumns-kumcoG": "x1mkdm3x",
         $$css: "js/FooBar.react.js:25"
     }
 };
 export const complex = {
     0: {
-        className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
+        className: "FooBar__styles.root xrvj5dj FooBar__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:15"
     },
     4: {
-        className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x",
+        className: "FooBar__styles.root xrvj5dj x7k18q3 x5gp9wm FooBar__styles.noSidebar x1mkdm3x",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:25"
     },
     2: {
-        className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1yc5d2u",
+        className: "FooBar__styles.root xrvj5dj FooBar__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 FooBar__styles.sidebar x9f619 x1yc5d2u",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:15; js/FooBar.react.js:3"
     },
     6: {
-        className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1yc5d2u",
+        className: "FooBar__styles.root xrvj5dj x7k18q3 x5gp9wm FooBar__styles.noSidebar x1mkdm3x FooBar__styles.sidebar x9f619 x1yc5d2u",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:25; js/FooBar.react.js:3"
     },
     1: {
-        className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x1fdo2jl",
+        className: "FooBar__styles.root xrvj5dj FooBar__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 FooBar__styles.content x1fdo2jl",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:15; js/FooBar.react.js:7"
     },
     5: {
-        className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x1fdo2jl",
+        className: "FooBar__styles.root xrvj5dj x7k18q3 x5gp9wm FooBar__styles.noSidebar x1mkdm3x FooBar__styles.content x1fdo2jl",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:25; js/FooBar.react.js:7"
     },
     3: {
-        className: "xrvj5dj x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 x9f619 x1fdo2jl",
+        className: "FooBar__styles.root xrvj5dj FooBar__styles.withSidebar x1rkzygb x7k18q3 x17lh93j xmr4b4k xesbpuc x15nfgh4 FooBar__styles.sidebar x9f619 FooBar__styles.content x1fdo2jl",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:15; js/FooBar.react.js:3; js/FooBar.react.js:7"
     },
     7: {
-        className: "xrvj5dj x7k18q3 x5gp9wm x1mkdm3x x9f619 x1fdo2jl",
+        className: "FooBar__styles.root xrvj5dj x7k18q3 x5gp9wm FooBar__styles.noSidebar x1mkdm3x FooBar__styles.sidebar x9f619 FooBar__styles.content x1fdo2jl",
         "data-style-src": "js/FooBar.react.js:10; js/FooBar.react.js:25; js/FooBar.react.js:3; js/FooBar.react.js:7"
     }
 }[!!(sidebar == null && !isSidebar) << 2 | !!isSidebar << 1 | !!isContent << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/stylex_props_call.rs/transform_props_with_null.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/stylex_props_call.rs/transform_props_with_null.js
@@ -24,28 +24,33 @@ _inject2({
 });
 const styles = {
     base: {
+        "__styles.base": "__styles.base",
         backgroundColor: "backgroundColor-x1t391ir",
         $$css: true
     },
     active: {
+        "__styles.active": "__styles.active",
         right: "right-x3m8u43",
         insetInlineStart: null,
         insetInlineEnd: null,
         $$css: true
     },
     inactive: {
+        "__styles.inactive": "__styles.inactive",
         left: "left-xu96u03",
         insetInlineStart: null,
         insetInlineEnd: null,
         $$css: true
     },
     answered: {
+        "__styles.answered": "__styles.answered",
         right: "right-x131sewu",
         insetInlineStart: null,
         insetInlineEnd: null,
         $$css: true
     },
     unanswered: {
+        "__styles.unanswered": "__styles.unanswered",
         left: "left-x12lbrt0",
         insetInlineStart: null,
         insetInlineEnd: null,

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/stylex_props_call.rs/transform_props_with_null.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/stylex_props_call.rs/transform_props_with_null.js
@@ -24,33 +24,33 @@ _inject2({
 });
 const styles = {
     base: {
-        "__styles.base": "__styles.base",
+        "UnknownFile__styles.base": "UnknownFile__styles.base",
         backgroundColor: "backgroundColor-x1t391ir",
         $$css: true
     },
     active: {
-        "__styles.active": "__styles.active",
+        "UnknownFile__styles.active": "UnknownFile__styles.active",
         right: "right-x3m8u43",
         insetInlineStart: null,
         insetInlineEnd: null,
         $$css: true
     },
     inactive: {
-        "__styles.inactive": "__styles.inactive",
+        "UnknownFile__styles.inactive": "UnknownFile__styles.inactive",
         left: "left-xu96u03",
         insetInlineStart: null,
         insetInlineEnd: null,
         $$css: true
     },
     answered: {
-        "__styles.answered": "__styles.answered",
+        "UnknownFile__styles.answered": "UnknownFile__styles.answered",
         right: "right-x131sewu",
         insetInlineStart: null,
         insetInlineEnd: null,
         $$css: true
     },
     unanswered: {
-        "__styles.unanswered": "__styles.unanswered",
+        "UnknownFile__styles.unanswered": "UnknownFile__styles.unanswered",
         left: "left-x12lbrt0",
         insetInlineStart: null,
         insetInlineEnd: null,

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_and_props_calls_are_equivalent.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_and_props_calls_are_equivalent.js
@@ -11,29 +11,29 @@ _inject2({
 });
 function Foo() {
     return <>
-          <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>
-          <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>
+          <div id="test" className="Foo__styles.red color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>
+          <div id="test" className="Foo__styles.red color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>
           <div className="test" {...{
         0: {
-            className: "color-x1e2nbdu",
+            className: "Foo__styles.red color-x1e2nbdu",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
         },
         1: {
-            className: "color-x1e2nbdu backgroundColor-x1t391ir",
+            className: "Foo__styles.red color-x1e2nbdu Foo__styles.blueBg backgroundColor-x1t391ir",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3; npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"
         }
     }[!!color << 0]} id="test">Hello World</div>
           <div className="test" {...{
         0: {
-            className: "color-x1e2nbdu",
+            className: "Foo__styles.red color-x1e2nbdu",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
         },
         1: {
-            className: "color-x1e2nbdu backgroundColor-x1t391ir",
+            className: "Foo__styles.red color-x1e2nbdu Foo__styles.blueBg backgroundColor-x1t391ir",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3; npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"
         }
     }[!!color << 0]} id="test">Hello World</div>
-          <div id="test" className="backgroundColor-x1t391ir" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:6" className="test">Hello World</div>
-          <div id="test" className="backgroundColor-x1t391ir" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:6" className="test">Hello World</div>
+          <div id="test" className="Foo__styles.blueBg backgroundColor-x1t391ir" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:6" className="test">Hello World</div>
+          <div id="test" className="Foo__styles.blueBg backgroundColor-x1t391ir" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:6" className="test">Hello World</div>
         </>;
 }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_array_syntax.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_array_syntax.js
@@ -10,5 +10,5 @@ _inject2({
     priority: 3000
 });
 function Foo() {
-    return <div className="borderRadius-x12oqio5 backgroundColor-x1t391ir" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3; npm-package:node_modules/npm-package/dist/components/Foo.react.js:6">Hello World</div>;
+    return <div className="Foo__styles.card borderRadius-x12oqio5 Foo__styles.blueBg backgroundColor-x1t391ir" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3; npm-package:node_modules/npm-package/dist/components/Foo.react.js:6">Hello World</div>;
 }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_compiled_jsx_form.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_compiled_jsx_form.js
@@ -8,7 +8,7 @@ _inject2({
 function App() {
     return _jsx("div", {
         ...{
-            className: "color-x1e2nbdu",
+            className: "Foo__styles.main color-x1e2nbdu",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
         },
         children: "Hello World"

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_compiled_jsx_form_array_syntax.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_compiled_jsx_form_array_syntax.js
@@ -12,7 +12,7 @@ _inject2({
 function App() {
     return _jsx("div", {
         ...{
-            className: "borderRadius-x12oqio5 backgroundColor-x1t391ir",
+            className: "Foo__styles.card borderRadius-x12oqio5 Foo__styles.blueBg backgroundColor-x1t391ir",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3; npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"
         },
         children: "Hello World"

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_compiled_jsx_not_applied_to_components.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_compiled_jsx_not_applied_to_components.js
@@ -7,6 +7,7 @@ _inject2({
 });
 const styles = {
     main: {
+        "Foo__styles.main": "Foo__styles.main",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_disabled_when_sx_prop_name_is_false.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_disabled_when_sx_prop_name_is_false.js
@@ -7,6 +7,7 @@ _inject2({
 });
 const styles = {
     red: {
+        "Foo__styles.red": "Foo__styles.red",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_default.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_default.js
@@ -7,6 +7,7 @@ _inject2({
 });
 const styles = {
     red: {
+        "Foo__styles.red": "Foo__styles.red",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_named.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_named.js
@@ -8,6 +8,7 @@ _inject2({
 });
 const styles = {
     red: {
+        "Foo__styles.red": "Foo__styles.red",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_namespace.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_namespace.js
@@ -7,6 +7,7 @@ _inject2({
 });
 const styles = {
     red: {
+        "Foo__styles.red": "Foo__styles.red",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_props.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_import_name_as_props.js
@@ -8,6 +8,7 @@ _inject2({
 });
 const styles = {
     red: {
+        "Foo__styles.red": "Foo__styles.red",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_instead_of_stylex_props.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_instead_of_stylex_props.js
@@ -7,8 +7,8 @@ _inject2({
 });
 function Foo() {
     return <>
-          <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>
-          <div className="test" className="color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3" id="test">Hello World</div>
-          <div id="test" className="color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3" className="test">Hello World</div>
+          <div id="test" className="Foo__styles.red color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>
+          <div className="test" className="Foo__styles.red color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3" id="test">Hello World</div>
+          <div id="test" className="Foo__styles.red color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3" className="test">Hello World</div>
         </>;
 }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_not_applied_to_component_elements.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_not_applied_to_component_elements.js
@@ -7,6 +7,7 @@ _inject2({
 });
 const styles = {
     red: {
+        "Foo__styles.red": "Foo__styles.red",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_solid_js_set_attribute.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_solid_js_set_attribute.js
@@ -15,11 +15,11 @@ _inject2({
 });
 function App() {
     _$spread(_el$, _$mergeProps(()=>({
-            className: "color-x1e2nbdu",
+            className: "Foo__styles.main color-x1e2nbdu",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
         })), false, true);
     _$spread(_el$2, _$mergeProps(()=>({
-            className: "borderRadius-x12oqio5 backgroundColor-x1t391ir",
+            className: "Foo__styles.card borderRadius-x12oqio5 Foo__styles.blueBg backgroundColor-x1t391ir",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:6; npm-package:node_modules/npm-package/dist/components/Foo.react.js:9"
         })), false, true);
 }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_solid_js_set_attribute_array.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_solid_js_set_attribute_array.js
@@ -11,7 +11,7 @@ _inject2({
 });
 function App() {
     _$spread(_el$, _$mergeProps(()=>({
-            className: "borderRadius-x12oqio5 backgroundColor-x1t391ir",
+            className: "Foo__styles.card borderRadius-x12oqio5 Foo__styles.blueBg backgroundColor-x1t391ir",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3; npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"
         })), false, true);
 }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_vite_jsx_runtime_call.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_vite_jsx_runtime_call.js
@@ -16,13 +16,13 @@ _inject2({
 function App() {
     return jsx("div", {
         ...{
-            className: "color-x1e2nbdu",
+            className: "Foo__styles.main color-x1e2nbdu",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
         }
     }, [
         jsx("div", {
             ...{
-                className: "borderRadius-x12oqio5",
+                className: "Foo__styles.card borderRadius-x12oqio5",
                 "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"
             }
         }, "Hello World")

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_vue_create_element_block.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_vue_create_element_block.js
@@ -12,13 +12,13 @@ _inject2({
 function App() {
     return _createElementBlock("div", {
         ...{
-            className: "color-x1e2nbdu",
+            className: "Foo__styles.main color-x1e2nbdu",
             "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:3"
         }
     }, [
         _createElementVNode("div", {
             ...{
-                className: "borderRadius-x12oqio5",
+                className: "Foo__styles.card borderRadius-x12oqio5",
                 "data-style-src": "npm-package:node_modules/npm-package/dist/components/Foo.react.js:6"
             }
         }, "Hello World")

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_with_custom_sx_prop_name.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/sx_attribute.rs/sx_attr_with_custom_sx_prop_name.js
@@ -6,5 +6,5 @@ _inject2({
     priority: 3000
 });
 function Foo() {
-    return <div className="color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>;
+    return <div className="Foo__styles.red color-x1e2nbdu" data-style-src="npm-package:node_modules/npm-package/dist/components/Foo.react.js:3">Hello World</div>;
 }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_collisions.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_collisions.js
@@ -11,11 +11,11 @@ _inject2({
 });
 ({
     0: {
-        className: "color-x1e2nbdu",
+        className: "FooBar__styles.default color-x1e2nbdu",
         "data-style-src": "js/FooBar.react.js:3"
     },
     1: {
-        className: "color-xju2f9n",
+        className: "FooBar__styles.default FooBar__styles.active color-xju2f9n",
         "data-style-src": "js/FooBar.react.js:3; js/FooBar.react.js:6"
     }
 })[!!isActive << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions.js
@@ -11,11 +11,11 @@ _inject2({
 });
 ({
     0: {
-        className: "color-x1e2nbdu",
+        className: "FooBar__styles.default color-x1e2nbdu",
         "data-style-src": "js/FooBar.react.js:3"
     },
     1: {
-        className: "color-x1e2nbdu backgroundColor-x1t391ir",
+        className: "FooBar__styles.default color-x1e2nbdu FooBar__otherStyles.default backgroundColor-x1t391ir",
         "data-style-src": "js/FooBar.react.js:3; js/FooBar.react.js:8"
     }
 })[!!isActive << 0];

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions_skip_conditional.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/with_plugin_options.rs/stylex_call_produces_dev_class_name_with_conditions_skip_conditional.js
@@ -7,6 +7,7 @@ _inject2({
 });
 const styles = {
     default: {
+        "FooBar__styles.default": "FooBar__styles.default",
         "color-kMwMTN": "color-x1e2nbdu",
         $$css: "js/FooBar.react.js:3"
     }
@@ -17,6 +18,7 @@ _inject2({
 });
 const otherStyles = {
     default: {
+        "FooBar__otherStyles.default": "FooBar__otherStyles.default",
         "backgroundColor-kWkggS": "backgroundColor-x1t391ir",
         $$css: "js/FooBar.react.js:8"
     }

--- a/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/with_plugin_options.rs/stylex_call_produces_dev_class_names_and_enable_inlined_conditional_merge_false.js
+++ b/crates/stylex-transform/tests/__swc_snapshots__/tests/transform_stylex_stylex_props_test/with_plugin_options.rs/stylex_call_produces_dev_class_names_and_enable_inlined_conditional_merge_false.js
@@ -6,6 +6,6 @@ _inject2({
     priority: 3000
 });
 ({
-    className: "color-x1e2nbdu",
+    className: "FooBar__styles.default color-x1e2nbdu",
     "data-style-src": "js/FooBar.react.js:3"
 });

--- a/crates/stylex-transform/tests/fixture/buttons-demo/output.js
+++ b/crates/stylex-transform/tests/fixture/buttons-demo/output.js
@@ -85,6 +85,7 @@ _inject2({
 });
 const styles = {
     container: {
+        "input__styles.container": "input__styles.container",
         display: "display-x78zum5",
         flexDirection: "flexDirection-xdt5ytf",
         alignItems: "alignItems-x6s0dn4",
@@ -94,12 +95,14 @@ const styles = {
         $$css: "tests/fixture/buttons-demo/input.stylex.js:49"
     },
     bordered: {
+        "input__styles.bordered": "input__styles.bordered",
         borderWidth: "borderWidth-xdh2fpr",
         borderStyle: "borderStyle-x1y0btm7",
         borderColor: "borderColor-x71xlcl",
         $$css: "tests/fixture/buttons-demo/input.stylex.js:57"
     },
     greenBorder: {
+        "input__styles.greenBorder": "input__styles.greenBorder",
         borderColor: "borderColor-x1bg2uv5",
         $$css: "tests/fixture/buttons-demo/input.stylex.js:62"
     }

--- a/crates/stylex-transform/tests/fixture/buttons-demo/output.js
+++ b/crates/stylex-transform/tests/fixture/buttons-demo/output.js
@@ -91,17 +91,17 @@ const styles = {
         justifyContent: "justifyContent-xl56j7k",
         gap: "gap-xou54vl",
         paddingBottom: "paddingBottom-xzk7aed",
-        $$css: "tests/fixture/buttons-demo/input.stylex.js:42"
+        $$css: "tests/fixture/buttons-demo/input.stylex.js:49"
     },
     bordered: {
         borderWidth: "borderWidth-xdh2fpr",
         borderStyle: "borderStyle-x1y0btm7",
         borderColor: "borderColor-x71xlcl",
-        $$css: "tests/fixture/buttons-demo/input.stylex.js:50"
+        $$css: "tests/fixture/buttons-demo/input.stylex.js:57"
     },
     greenBorder: {
         borderColor: "borderColor-x1bg2uv5",
-        $$css: "tests/fixture/buttons-demo/input.stylex.js:55"
+        $$css: "tests/fixture/buttons-demo/input.stylex.js:62"
     }
 };
 _inject2({

--- a/crates/stylex-transform/tests/fixture/card/output.js
+++ b/crates/stylex-transform/tests/fixture/card/output.js
@@ -24,7 +24,7 @@ _inject2({
 export default function Card() {
     const { className, style } = {
         className: "color-x1e2nbdu borderColor-x15hxx75 padding-x7z7khe",
-        "data-style-src": "tests/fixture/card/input.stylex.js:3; tests/fixture/card/input.stylex.js:7"
+        "data-style-src": "tests/fixture/card/input.stylex.js:4; tests/fixture/card/input.stylex.js:8"
     };
     return <article className={className} style={style}>Card</article>;
 }

--- a/crates/stylex-transform/tests/fixture/card/output.js
+++ b/crates/stylex-transform/tests/fixture/card/output.js
@@ -23,7 +23,7 @@ _inject2({
 });
 export default function Card() {
     const { className, style } = {
-        className: "color-x1e2nbdu borderColor-x15hxx75 padding-x7z7khe",
+        className: "input__c.base color-x1e2nbdu input__c.test borderColor-x15hxx75 padding-x7z7khe",
         "data-style-src": "tests/fixture/card/input.stylex.js:4; tests/fixture/card/input.stylex.js:8"
     };
     return <article className={className} style={style}>Card</article>;

--- a/crates/stylex-transform/tests/fixture/counter-with-dynamic-styles/output.js
+++ b/crates/stylex-transform/tests/fixture/counter-with-dynamic-styles/output.js
@@ -9,18 +9,18 @@ import { colors } from '@stylexjs/open-props/lib/colors.stylex';
 import { useState } from 'react';
 const _temp = {
     fontSize: "fontSize-xdmh292",
-    $$css: "tests/fixture/counter-with-dynamic-styles/input.stylex.js:22"
+    $$css: "tests/fixture/counter-with-dynamic-styles/input.stylex.js:41"
 };
 export default function Counter() {
     const [count, setCount] = useState(0);
-    return <div className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k flexDirection-x1q0g3np borderRadius-x18tt229 borderWidth-xmkeg23 borderStyle-x1y0btm7 borderColor-x1nasx6d padding-x1l67flk fontFamily-x1o4itb0 gap-x1mm2g2v" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:25">
-      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:38" onClick={()=>setCount((c)=>c - 1)}>
+    return <div className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k flexDirection-x1q0g3np borderRadius-x18tt229 borderWidth-xmkeg23 borderStyle-x1y0btm7 borderColor-x1nasx6d padding-x1l67flk fontFamily-x1o4itb0 gap-x1mm2g2v" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:42">
+      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:55" onClick={()=>setCount((c)=>c - 1)}>
         -
       </button>
       <div {...stylex.props(styles.count, styles.size(count), Math.abs(count) > 99 && styles.largeNumber)}>
         {count}
       </div>
-      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:38" onClick={()=>setCount((c)=>c + 1)}>
+      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:55" onClick={()=>setCount((c)=>c + 1)}>
         +
       </button>
     </div>;
@@ -179,10 +179,10 @@ const styles = {
         minWidth: "minWidth-x1843ork",
         textAlign: "textAlign-x2b8uid",
         fontFamily: "fontFamily-xh1z4oz",
-        $$css: "tests/fixture/counter-with-dynamic-styles/input.stylex.js:66"
+        $$css: "tests/fixture/counter-with-dynamic-styles/input.stylex.js:83"
     },
     largeNumber: {
         fontSize: "fontSize-x1bb9vi5",
-        $$css: "tests/fixture/counter-with-dynamic-styles/input.stylex.js:74"
+        $$css: "tests/fixture/counter-with-dynamic-styles/input.stylex.js:91"
     }
 };

--- a/crates/stylex-transform/tests/fixture/counter-with-dynamic-styles/output.js
+++ b/crates/stylex-transform/tests/fixture/counter-with-dynamic-styles/output.js
@@ -8,19 +8,20 @@ import { spacing, text, globalTokens as $ } from './globalTokens.stylex';
 import { colors } from '@stylexjs/open-props/lib/colors.stylex';
 import { useState } from 'react';
 const _temp = {
+    "input__styles.size": "input__styles.size",
     fontSize: "fontSize-xdmh292",
     $$css: "tests/fixture/counter-with-dynamic-styles/input.stylex.js:41"
 };
 export default function Counter() {
     const [count, setCount] = useState(0);
-    return <div className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k flexDirection-x1q0g3np borderRadius-x18tt229 borderWidth-xmkeg23 borderStyle-x1y0btm7 borderColor-x1nasx6d padding-x1l67flk fontFamily-x1o4itb0 gap-x1mm2g2v" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:42">
-      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:55" onClick={()=>setCount((c)=>c - 1)}>
+    return <div className="input__styles.container display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k flexDirection-x1q0g3np borderRadius-x18tt229 borderWidth-xmkeg23 borderStyle-x1y0btm7 borderColor-x1nasx6d padding-x1l67flk fontFamily-x1o4itb0 gap-x1mm2g2v" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:42">
+      <button className="input__styles.button display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:55" onClick={()=>setCount((c)=>c - 1)}>
         -
       </button>
       <div {...stylex.props(styles.count, styles.size(count), Math.abs(count) > 99 && styles.largeNumber)}>
         {count}
       </div>
-      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:55" onClick={()=>setCount((c)=>c + 1)}>
+      <button className="input__styles.button display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter-with-dynamic-styles/input.stylex.js:55" onClick={()=>setCount((c)=>c + 1)}>
         +
       </button>
     </div>;
@@ -173,6 +174,7 @@ const styles = {
             }
         ],
     count: {
+        "input__styles.count": "input__styles.count",
         fontSize: "fontSize-xt4rhuc",
         fontWeight: "fontWeight-x3stwaq",
         color: "color-xnu1ptm",
@@ -182,6 +184,7 @@ const styles = {
         $$css: "tests/fixture/counter-with-dynamic-styles/input.stylex.js:83"
     },
     largeNumber: {
+        "input__styles.largeNumber": "input__styles.largeNumber",
         fontSize: "fontSize-x1bb9vi5",
         $$css: "tests/fixture/counter-with-dynamic-styles/input.stylex.js:91"
     }

--- a/crates/stylex-transform/tests/fixture/counter-with-dynamic-styles/output_prod.js
+++ b/crates/stylex-transform/tests/fixture/counter-with-dynamic-styles/output_prod.js
@@ -3,7 +3,7 @@ import * as stylex from '@stylexjs/stylex';
 import { spacing, text, globalTokens as $ } from './globalTokens.stylex';
 import { colors } from '@stylexjs/open-props/lib/colors.stylex';
 import { useState } from 'react';
-const _temp2 = {
+const _temp = {
     kGuDYH: "xdmh292",
     $$css: true
 };
@@ -23,7 +23,7 @@ export default function Counter() {
 }
 const styles = {
     size: (size)=>[
-            _temp2,
+            _temp,
             {
                 "--x-fontSize": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : undefined)(8 * size + 'px')
             }

--- a/crates/stylex-transform/tests/fixture/counter/output.js
+++ b/crates/stylex-transform/tests/fixture/counter/output.js
@@ -9,23 +9,23 @@ import { colors } from '@stylexjs/open-props/lib/colors.stylex';
 import { useState } from 'react';
 export default function Counter() {
     const [count, setCount] = useState(0);
-    return <div className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k flexDirection-x1q0g3np borderRadius-x18tt229 borderWidth-xmkeg23 borderStyle-x1y0btm7 borderColor-x1nasx6d padding-x1l67flk fontFamily-x1o4itb0 gap-x1mm2g2v" data-style-src="tests/fixture/counter/input.stylex.js:40">
-      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter/input.stylex.js:53" onClick={()=>setCount((c)=>c - 1)}>
+    return <div className="input__styles.container display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k flexDirection-x1q0g3np borderRadius-x18tt229 borderWidth-xmkeg23 borderStyle-x1y0btm7 borderColor-x1nasx6d padding-x1l67flk fontFamily-x1o4itb0 gap-x1mm2g2v" data-style-src="tests/fixture/counter/input.stylex.js:40">
+      <button className="input__styles.button display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter/input.stylex.js:53" onClick={()=>setCount((c)=>c - 1)}>
         -
       </button>
       <div {...{
         0: {
-            className: "fontSize-xt4rhuc fontWeight-x3stwaq color-xnu1ptm minWidth-x1843ork textAlign-x2b8uid fontFamily-xh1z4oz",
+            className: "input__styles.count fontSize-xt4rhuc fontWeight-x3stwaq color-xnu1ptm minWidth-x1843ork textAlign-x2b8uid fontFamily-xh1z4oz",
             "data-style-src": "tests/fixture/counter/input.stylex.js:81"
         },
         1: {
-            className: "fontWeight-x3stwaq color-xnu1ptm minWidth-x1843ork textAlign-x2b8uid fontFamily-xh1z4oz fontSize-x1bb9vi5",
+            className: "input__styles.count fontWeight-x3stwaq color-xnu1ptm minWidth-x1843ork textAlign-x2b8uid fontFamily-xh1z4oz input__styles.largeNumber fontSize-x1bb9vi5",
             "data-style-src": "tests/fixture/counter/input.stylex.js:81; tests/fixture/counter/input.stylex.js:89"
         }
     }[!!(Math.abs(count) > 99) << 0]}>
         {count}
       </div>
-      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter/input.stylex.js:53" onClick={()=>setCount((c)=>c + 1)}>
+      <button className="input__styles.button display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter/input.stylex.js:53" onClick={()=>setCount((c)=>c + 1)}>
         +
       </button>
     </div>;

--- a/crates/stylex-transform/tests/fixture/counter/output.js
+++ b/crates/stylex-transform/tests/fixture/counter/output.js
@@ -9,23 +9,23 @@ import { colors } from '@stylexjs/open-props/lib/colors.stylex';
 import { useState } from 'react';
 export default function Counter() {
     const [count, setCount] = useState(0);
-    return <div className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k flexDirection-x1q0g3np borderRadius-x18tt229 borderWidth-xmkeg23 borderStyle-x1y0btm7 borderColor-x1nasx6d padding-x1l67flk fontFamily-x1o4itb0 gap-x1mm2g2v" data-style-src="tests/fixture/counter/input.stylex.js:22">
-      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter/input.stylex.js:35" onClick={()=>setCount((c)=>c - 1)}>
+    return <div className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k flexDirection-x1q0g3np borderRadius-x18tt229 borderWidth-xmkeg23 borderStyle-x1y0btm7 borderColor-x1nasx6d padding-x1l67flk fontFamily-x1o4itb0 gap-x1mm2g2v" data-style-src="tests/fixture/counter/input.stylex.js:40">
+      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter/input.stylex.js:53" onClick={()=>setCount((c)=>c - 1)}>
         -
       </button>
       <div {...{
         0: {
             className: "fontSize-xt4rhuc fontWeight-x3stwaq color-xnu1ptm minWidth-x1843ork textAlign-x2b8uid fontFamily-xh1z4oz",
-            "data-style-src": "tests/fixture/counter/input.stylex.js:63"
+            "data-style-src": "tests/fixture/counter/input.stylex.js:81"
         },
         1: {
             className: "fontWeight-x3stwaq color-xnu1ptm minWidth-x1843ork textAlign-x2b8uid fontFamily-xh1z4oz fontSize-x1bb9vi5",
-            "data-style-src": "tests/fixture/counter/input.stylex.js:63; tests/fixture/counter/input.stylex.js:71"
+            "data-style-src": "tests/fixture/counter/input.stylex.js:81; tests/fixture/counter/input.stylex.js:89"
         }
     }[!!(Math.abs(count) > 99) << 0]}>
         {count}
       </div>
-      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter/input.stylex.js:35" onClick={()=>setCount((c)=>c + 1)}>
+      <button className="display-x78zum5 alignItems-x6s0dn4 justifyContent-xl56j7k height-x17frcva aspectRatio-x1plog1 color-x194xsre backgroundColor-x1a2lmyf backgroundColor-x1oi2zhp backgroundColor-xseld47 backgroundColor-xjbufok borderWidth-xc342km borderStyle-xng3xce borderRadius-x1nklt0o padding-x1t29n93 margin-x4kdmvg cursor-x1ypdohk fontSize-xt4rhuc transform-x1u4xmye transform-xglsxx3" data-style-src="tests/fixture/counter/input.stylex.js:53" onClick={()=>setCount((c)=>c + 1)}>
         +
       </button>
     </div>;

--- a/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import-edges/output.js
+++ b/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import-edges/output.js
@@ -12,7 +12,7 @@ const _temp = {
     zIndex: "zIndex-xr3buco",
     content: "content-x1p70blb",
     width: "width-x5lhr3w",
-    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:55"
+    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:60"
 };
 _inject2({
     ltr: ".padding-xt7k32d{padding:var(--md-xq1l1nf)}",
@@ -197,12 +197,12 @@ _inject2({
 export const styles = {
     unicodeName: {
         padding: "padding-xt7k32d",
-        $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:7"
+        $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:10"
     },
     unicodeParam: (ünïcödé)=>[
             {
                 padding: ünïcödé != null ? "padding-x1fozly0" : ünïcödé,
-                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:10"
+                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:11"
             },
             {
                 "--x-padding": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : undefined)(ünïcödé)
@@ -211,7 +211,7 @@ export const styles = {
     escapedParam: (ünïcödé)=>[
             {
                 margin: ünïcödé != null ? "margin-xb9ncqk" : ünïcödé,
-                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:13"
+                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:15"
             },
             {
                 "--x-margin": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : undefined)(ünïcödé)
@@ -220,7 +220,7 @@ export const styles = {
     helperName: (firstThatWorks)=>[
             {
                 fontFamily: firstThatWorks != null ? "fontFamily-xk2v41j" : firstThatWorks,
-                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:16"
+                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:19"
             },
             {
                 "--x-fontFamily": firstThatWorks != null ? firstThatWorks : undefined
@@ -230,7 +230,7 @@ export const styles = {
             {
                 inset: zIndex != null ? "inset-xccw97s" : zIndex,
                 marginInline: zIndex != null ? "marginInline-xvlecxo" : zIndex,
-                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:19"
+                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:23"
             },
             {
                 "--x-inset": ((val)=>typeof val === "number" ? val + "px" : val != null ? val : undefined)(zIndex),
@@ -241,7 +241,7 @@ export const styles = {
             {
                 "--depth": zIndex != null ? "--depth-x5h8hlk" : zIndex,
                 "--nested-depth": zIndex != null ? "--nested-depth-x91d7kb" : zIndex,
-                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:23"
+                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:26"
             },
             {
                 "--x---depth": zIndex != null ? zIndex : undefined,
@@ -252,7 +252,7 @@ export const styles = {
             {
                 userSelect: zIndex != null ? "userSelect-x9pkiyq" : zIndex,
                 appearance: zIndex != null ? "appearance-xafmcc1" : zIndex,
-                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:27"
+                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:29"
             },
             {
                 "--x-userSelect": zIndex != null ? zIndex : undefined,
@@ -262,7 +262,7 @@ export const styles = {
     deeplyNested: (zIndex)=>[
             {
                 zIndex: (zIndex != null ? "zIndex-xkrcnwa " : zIndex) + (zIndex != null ? "zIndex-x141uv47 " : zIndex) + (zIndex != null ? "zIndex-x140siia " : zIndex) + (zIndex != null ? "zIndex-xlzq18l " : zIndex) + (zIndex != null ? "zIndex-x103ewrf " : zIndex) + (zIndex != null ? "zIndex-x1gxqx9w " : zIndex) + (zIndex != null ? "zIndex-xqw1h1y " : zIndex) + (zIndex != null ? "zIndex-x15stwyu" : zIndex),
-                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:31"
+                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:33"
             },
             {
                 "--x-gsepj1": zIndex != null ? zIndex : undefined,
@@ -287,7 +287,7 @@ export const styles = {
             {
                 zIndex: zIndex != null ? "zIndex-xr3buco" : zIndex,
                 order: level != null ? "order-xuwbzjh" : level,
-                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:60"
+                $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:67"
             },
             {
                 "--x-zIndex": zIndex != null ? zIndex : undefined,
@@ -297,6 +297,6 @@ export const styles = {
     "static": {
         zIndex: "zIndex-x1bsllxr",
         gridArea: "gridArea-xq91r1r",
-        $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:64"
+        $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:71"
     }
 };

--- a/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import-edges/output.js
+++ b/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import-edges/output.js
@@ -9,10 +9,43 @@ import { spacing as ünïcödé } from './vars/spacing.stylex.js';
 import { firstThatWorks } from './vars/legacy.stylex.js';
 import { grid } from './vars/grid.stylex.js';
 const _temp = {
+    "input__styles.unicodeParam": "input__styles.unicodeParam",
+    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:11"
+};
+const _temp2 = {
+    "input__styles.escapedParam": "input__styles.escapedParam",
+    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:15"
+};
+const _temp3 = {
+    "input__styles.helperName": "input__styles.helperName",
+    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:19"
+};
+const _temp4 = {
+    "input__styles.shorthand": "input__styles.shorthand",
+    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:23"
+};
+const _temp5 = {
+    "input__styles.customProperty": "input__styles.customProperty",
+    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:26"
+};
+const _temp6 = {
+    "input__styles.prefixed": "input__styles.prefixed",
+    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:29"
+};
+const _temp7 = {
+    "input__styles.deeplyNested": "input__styles.deeplyNested",
+    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:33"
+};
+const _temp8 = {
+    "input__styles.computedFromParam": "input__styles.computedFromParam",
     zIndex: "zIndex-xr3buco",
     content: "content-x1p70blb",
     width: "width-x5lhr3w",
     $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:60"
+};
+const _temp9 = {
+    "input__styles.mixedParams": "input__styles.mixedParams",
+    $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:67"
 };
 _inject2({
     ltr: ".padding-xt7k32d{padding:var(--md-xq1l1nf)}",
@@ -196,10 +229,12 @@ _inject2({
 });
 export const styles = {
     unicodeName: {
+        "input__styles.unicodeName": "input__styles.unicodeName",
         padding: "padding-xt7k32d",
         $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:10"
     },
     unicodeParam: (ünïcödé)=>[
+            _temp,
             {
                 padding: ünïcödé != null ? "padding-x1fozly0" : ünïcödé,
                 $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:11"
@@ -209,6 +244,7 @@ export const styles = {
             }
         ],
     escapedParam: (ünïcödé)=>[
+            _temp2,
             {
                 margin: ünïcödé != null ? "margin-xb9ncqk" : ünïcödé,
                 $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:15"
@@ -218,6 +254,7 @@ export const styles = {
             }
         ],
     helperName: (firstThatWorks)=>[
+            _temp3,
             {
                 fontFamily: firstThatWorks != null ? "fontFamily-xk2v41j" : firstThatWorks,
                 $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:19"
@@ -227,6 +264,7 @@ export const styles = {
             }
         ],
     shorthand: (zIndex)=>[
+            _temp4,
             {
                 inset: zIndex != null ? "inset-xccw97s" : zIndex,
                 marginInline: zIndex != null ? "marginInline-xvlecxo" : zIndex,
@@ -238,6 +276,7 @@ export const styles = {
             }
         ],
     customProperty: (zIndex)=>[
+            _temp5,
             {
                 "--depth": zIndex != null ? "--depth-x5h8hlk" : zIndex,
                 "--nested-depth": zIndex != null ? "--nested-depth-x91d7kb" : zIndex,
@@ -249,6 +288,7 @@ export const styles = {
             }
         ],
     prefixed: (zIndex)=>[
+            _temp6,
             {
                 userSelect: zIndex != null ? "userSelect-x9pkiyq" : zIndex,
                 appearance: zIndex != null ? "appearance-xafmcc1" : zIndex,
@@ -260,6 +300,7 @@ export const styles = {
             }
         ],
     deeplyNested: (zIndex)=>[
+            _temp7,
             {
                 zIndex: (zIndex != null ? "zIndex-xkrcnwa " : zIndex) + (zIndex != null ? "zIndex-x141uv47 " : zIndex) + (zIndex != null ? "zIndex-x140siia " : zIndex) + (zIndex != null ? "zIndex-xlzq18l " : zIndex) + (zIndex != null ? "zIndex-x103ewrf " : zIndex) + (zIndex != null ? "zIndex-x1gxqx9w " : zIndex) + (zIndex != null ? "zIndex-xqw1h1y " : zIndex) + (zIndex != null ? "zIndex-x15stwyu" : zIndex),
                 $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:33"
@@ -276,7 +317,7 @@ export const styles = {
             }
         ],
     computedFromParam: (zIndex)=>[
-            _temp,
+            _temp8,
             {
                 "--x-zIndex": zIndex + 1 != null ? zIndex + 1 : undefined,
                 "--x-content": `"${zIndex}"` != null ? `"${zIndex}"` : undefined,
@@ -284,6 +325,7 @@ export const styles = {
             }
         ],
     mixedParams: (zIndex, level)=>[
+            _temp9,
             {
                 zIndex: zIndex != null ? "zIndex-xr3buco" : zIndex,
                 order: level != null ? "order-xuwbzjh" : level,
@@ -295,6 +337,7 @@ export const styles = {
             }
         ],
     "static": {
+        "input__styles.static": "input__styles.static",
         zIndex: "zIndex-x1bsllxr",
         gridArea: "gridArea-xq91r1r",
         $$css: "tests/fixture/dynamic-param-shadows-import-edges/input.stylex.js:71"

--- a/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import-edges/output_prod.js
+++ b/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import-edges/output_prod.js
@@ -3,7 +3,7 @@ import { zIndex } from './vars/zIndex.stylex.js';
 import { spacing as ünïcödé } from './vars/spacing.stylex.js';
 import { firstThatWorks } from './vars/legacy.stylex.js';
 import { grid } from './vars/grid.stylex.js';
-const _temp2 = {
+const _temp10 = {
     kY2c9j: "xr3buco",
     kah6P1: "x1p70blb",
     kzqmXN: "x5lhr3w",
@@ -91,7 +91,7 @@ export const styles = {
             }
         ],
     computedFromParam: (zIndex)=>[
-            _temp2,
+            _temp10,
             {
                 "--x-zIndex": zIndex + 1 != null ? zIndex + 1 : undefined,
                 "--x-content": `"${zIndex}"` != null ? `"${zIndex}"` : undefined,

--- a/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import-edges/output_prod.js
+++ b/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import-edges/output_prod.js
@@ -3,7 +3,7 @@ import { zIndex } from './vars/zIndex.stylex.js';
 import { spacing as ünïcödé } from './vars/spacing.stylex.js';
 import { firstThatWorks } from './vars/legacy.stylex.js';
 import { grid } from './vars/grid.stylex.js';
-const _temp10 = {
+const _temp = {
     kY2c9j: "xr3buco",
     kah6P1: "x1p70blb",
     kzqmXN: "x5lhr3w",
@@ -91,7 +91,7 @@ export const styles = {
             }
         ],
     computedFromParam: (zIndex)=>[
-            _temp10,
+            _temp,
             {
                 "--x-zIndex": zIndex + 1 != null ? zIndex + 1 : undefined,
                 "--x-content": `"${zIndex}"` != null ? `"${zIndex}"` : undefined,

--- a/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import/output.js
+++ b/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import/output.js
@@ -18,12 +18,12 @@ _inject2({
 export const styles = {
     wrapper: {
         zIndex: "zIndex-x1bsllxr",
-        $$css: "tests/fixture/dynamic-param-shadows-import/input.stylex.js:4"
+        $$css: "tests/fixture/dynamic-param-shadows-import/input.stylex.js:5"
     },
     zIndex: (zIndex)=>[
             {
                 zIndex: zIndex != null ? "zIndex-xr3buco" : zIndex,
-                $$css: "tests/fixture/dynamic-param-shadows-import/input.stylex.js:7"
+                $$css: "tests/fixture/dynamic-param-shadows-import/input.stylex.js:6"
             },
             {
                 "--x-zIndex": zIndex != null ? zIndex : undefined

--- a/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import/output.js
+++ b/crates/stylex-transform/tests/fixture/dynamic-param-shadows-import/output.js
@@ -3,6 +3,10 @@ var _inject2 = _inject;
 import "./vars/zIndex.stylex.js";
 import * as stylex from '@stylexjs/stylex';
 import { zIndex } from './vars/zIndex.stylex.js';
+const _temp = {
+    "input__styles.zIndex": "input__styles.zIndex",
+    $$css: "tests/fixture/dynamic-param-shadows-import/input.stylex.js:6"
+};
 _inject2({
     ltr: ".zIndex-x1bsllxr{z-index:var(--_10-x19xkwqv)}",
     priority: 3000
@@ -17,10 +21,12 @@ _inject2({
 });
 export const styles = {
     wrapper: {
+        "input__styles.wrapper": "input__styles.wrapper",
         zIndex: "zIndex-x1bsllxr",
         $$css: "tests/fixture/dynamic-param-shadows-import/input.stylex.js:5"
     },
     zIndex: (zIndex)=>[
+            _temp,
             {
                 zIndex: zIndex != null ? "zIndex-xr3buco" : zIndex,
                 $$css: "tests/fixture/dynamic-param-shadows-import/input.stylex.js:6"

--- a/crates/stylex-transform/tests/fixture/markers/output.js
+++ b/crates/stylex-transform/tests/fixture/markers/output.js
@@ -25,6 +25,7 @@ _inject2({
 });
 export const styles = {
     label: {
+        "input__styles.label": "input__styles.label",
         color: "color-xkn7p67 color-xomp1nr color-x1wgracu color-x1uatm7",
         $$css: "tests/fixture/markers/input.stylex.js:8"
     }

--- a/crates/stylex-transform/tests/fixture/markers/output.js
+++ b/crates/stylex-transform/tests/fixture/markers/output.js
@@ -26,6 +26,6 @@ _inject2({
 export const styles = {
     label: {
         color: "color-xkn7p67 color-xomp1nr color-x1wgracu color-x1uatm7",
-        $$css: "tests/fixture/markers/input.stylex.js:5"
+        $$css: "tests/fixture/markers/input.stylex.js:8"
     }
 };

--- a/crates/stylex-transform/tests/fixture/namespace-cleaning-no-unused/output.js
+++ b/crates/stylex-transform/tests/fixture/namespace-cleaning-no-unused/output.js
@@ -49,42 +49,52 @@ _inject2({
 });
 const c = {
     "1": {
+        "input__c.1": "input__c.1",
         fontSize: "fontSize-xeuu8e4",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:41"
     },
     "2": {
+        "input__c.2": "input__c.2",
         fontSize: "fontSize-x1jbhjkf",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:47"
     },
     wrapper: {
+        "input__c.wrapper": "input__c.wrapper",
         display: "display-xjp7ctv",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:8"
     },
     "p-2": {
+        "input__c.p-2": "input__c.p-2",
         fontSize: "fontSize-x1f3yvym",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:11"
     },
     "p-1": {
+        "input__c.p-1": "input__c.p-1",
         fontSize: "fontSize-x17vjwcc",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:17"
     },
     p: {
+        "input__c.p": "input__c.p",
         fontSize: "fontSize-x19ppoyo",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:23"
     },
     "p+1": {
+        "input__c.p 1": "input__c.p 1",
         fontSize: "fontSize-x3gzoht",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:29"
     },
     "p+2": {
+        "input__c.p 2": "input__c.p 2",
         fontSize: "fontSize-xd310an",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:35"
     },
     "p+3": {
+        "input__c.p 3": "input__c.p 3",
         fontSize: "fontSize-x14h6vv3",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:53"
     },
     "p+4": {
+        "input__c.p 4": "input__c.p 4",
         fontSize: "fontSize-x1eh3tls",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:59"
     }

--- a/crates/stylex-transform/tests/fixture/namespace-cleaning-no-unused/output.js
+++ b/crates/stylex-transform/tests/fixture/namespace-cleaning-no-unused/output.js
@@ -50,43 +50,43 @@ _inject2({
 const c = {
     "1": {
         fontSize: "fontSize-xeuu8e4",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:39"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:41"
     },
     "2": {
         fontSize: "fontSize-x1jbhjkf",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:45"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:47"
     },
     wrapper: {
         display: "display-xjp7ctv",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:6"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:8"
     },
     "p-2": {
         fontSize: "fontSize-x1f3yvym",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:9"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:11"
     },
     "p-1": {
         fontSize: "fontSize-x17vjwcc",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:15"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:17"
     },
     p: {
         fontSize: "fontSize-x19ppoyo",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:21"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:23"
     },
     "p+1": {
         fontSize: "fontSize-x3gzoht",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:27"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:29"
     },
     "p+2": {
         fontSize: "fontSize-xd310an",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:33"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:35"
     },
     "p+3": {
         fontSize: "fontSize-x14h6vv3",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:51"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:53"
     },
     "p+4": {
         fontSize: "fontSize-x1eh3tls",
-        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:57"
+        $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:59"
     }
 };
 const pClasses = [

--- a/crates/stylex-transform/tests/fixture/namespace-cleaning-no-unused/output.js
+++ b/crates/stylex-transform/tests/fixture/namespace-cleaning-no-unused/output.js
@@ -79,22 +79,22 @@ const c = {
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:23"
     },
     "p+1": {
-        "input__c.p 1": "input__c.p 1",
+        "input__c.p1": "input__c.p1",
         fontSize: "fontSize-x3gzoht",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:29"
     },
     "p+2": {
-        "input__c.p 2": "input__c.p 2",
+        "input__c.p2": "input__c.p2",
         fontSize: "fontSize-xd310an",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:35"
     },
     "p+3": {
-        "input__c.p 3": "input__c.p 3",
+        "input__c.p3": "input__c.p3",
         fontSize: "fontSize-x14h6vv3",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:53"
     },
     "p+4": {
-        "input__c.p 4": "input__c.p 4",
+        "input__c.p4": "input__c.p4",
         fontSize: "fontSize-x1eh3tls",
         $$css: "tests/fixture/namespace-cleaning-no-unused/input.stylex.js:59"
     }

--- a/crates/stylex-transform/tests/fixture/namespace-cleaning/output.js
+++ b/crates/stylex-transform/tests/fixture/namespace-cleaning/output.js
@@ -55,51 +55,51 @@ _inject2({
 const c = {
     "1": {
         fontSize: "fontSize-xeuu8e4",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:39"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:41"
     },
     "2": {
         fontSize: "fontSize-x1jbhjkf",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:45"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:47"
     },
     wrapper: {
         display: "display-xjp7ctv",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:6"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:8"
     },
     "p-2": {
         fontSize: "fontSize-x1f3yvym",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:9"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:11"
     },
     "p-1": {
         fontSize: "fontSize-x17vjwcc",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:15"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:17"
     },
     p: {
         fontSize: "fontSize-x19ppoyo",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:21"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:23"
     },
     "p+1": {
         fontSize: "fontSize-x3gzoht",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:27"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:29"
     },
     "p+2": {
         fontSize: "fontSize-xd310an",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:33"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:35"
     },
     "p+3": {
         fontSize: "fontSize-x14h6vv3",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:51"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:53"
     },
     "p+4": {
         fontSize: "fontSize-x1eh3tls",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:57"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:59"
     },
     "p+5": {
         fontSize: "fontSize-x8rl4l3",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:63"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:65"
     },
     unused: {
         color: "color-x1e2nbdu",
-        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:69"
+        $$css: "tests/fixture/namespace-cleaning/input.stylex.js:71"
     }
 };
 const pClasses = [

--- a/crates/stylex-transform/tests/fixture/namespace-cleaning/output.js
+++ b/crates/stylex-transform/tests/fixture/namespace-cleaning/output.js
@@ -54,50 +54,62 @@ _inject2({
 });
 const c = {
     "1": {
+        "input__c.1": "input__c.1",
         fontSize: "fontSize-xeuu8e4",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:41"
     },
     "2": {
+        "input__c.2": "input__c.2",
         fontSize: "fontSize-x1jbhjkf",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:47"
     },
     wrapper: {
+        "input__c.wrapper": "input__c.wrapper",
         display: "display-xjp7ctv",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:8"
     },
     "p-2": {
+        "input__c.p-2": "input__c.p-2",
         fontSize: "fontSize-x1f3yvym",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:11"
     },
     "p-1": {
+        "input__c.p-1": "input__c.p-1",
         fontSize: "fontSize-x17vjwcc",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:17"
     },
     p: {
+        "input__c.p": "input__c.p",
         fontSize: "fontSize-x19ppoyo",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:23"
     },
     "p+1": {
+        "input__c.p 1": "input__c.p 1",
         fontSize: "fontSize-x3gzoht",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:29"
     },
     "p+2": {
+        "input__c.p 2": "input__c.p 2",
         fontSize: "fontSize-xd310an",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:35"
     },
     "p+3": {
+        "input__c.p 3": "input__c.p 3",
         fontSize: "fontSize-x14h6vv3",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:53"
     },
     "p+4": {
+        "input__c.p 4": "input__c.p 4",
         fontSize: "fontSize-x1eh3tls",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:59"
     },
     "p+5": {
+        "input__c.p 5": "input__c.p 5",
         fontSize: "fontSize-x8rl4l3",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:65"
     },
     unused: {
+        "input__c.unused": "input__c.unused",
         color: "color-x1e2nbdu",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:71"
     }

--- a/crates/stylex-transform/tests/fixture/namespace-cleaning/output.js
+++ b/crates/stylex-transform/tests/fixture/namespace-cleaning/output.js
@@ -84,27 +84,27 @@ const c = {
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:23"
     },
     "p+1": {
-        "input__c.p 1": "input__c.p 1",
+        "input__c.p1": "input__c.p1",
         fontSize: "fontSize-x3gzoht",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:29"
     },
     "p+2": {
-        "input__c.p 2": "input__c.p 2",
+        "input__c.p2": "input__c.p2",
         fontSize: "fontSize-xd310an",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:35"
     },
     "p+3": {
-        "input__c.p 3": "input__c.p 3",
+        "input__c.p3": "input__c.p3",
         fontSize: "fontSize-x14h6vv3",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:53"
     },
     "p+4": {
-        "input__c.p 4": "input__c.p 4",
+        "input__c.p4": "input__c.p4",
         fontSize: "fontSize-x1eh3tls",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:59"
     },
     "p+5": {
-        "input__c.p 5": "input__c.p 5",
+        "input__c.p5": "input__c.p5",
         fontSize: "fontSize-x8rl4l3",
         $$css: "tests/fixture/namespace-cleaning/input.stylex.js:65"
     },

--- a/crates/stylex-transform/tests/fixture/page-tsx/output.js
+++ b/crates/stylex-transform/tests/fixture/page-tsx/output.js
@@ -11,21 +11,21 @@ interface Props {
 }
 export default function Home(_props: Props) {
     return(// @ts-expect-error - sx is not correctly typed
-    <main className="display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 paddingTop-x1llwu7x paddingBottom-xjfnvzm paddingBottom-x191vjuz" data-style-src="tests/fixture/page-tsx/input.stylex.js:73">
-      <div className="display-x1jfb8zj justifyContent-xarpa2k alignItems-x1h91t0o fontSize-xmit1kp maxWidth-xmrzitl width-xh8yej3 zIndex-xhtitgo fontFamily-xh1z4oz" data-style-src="tests/fixture/page-tsx/input.stylex.js:119">
-        <p className="display-xjg0vao position-x1n2onr6 position-x15f3dyk justifyContent-xo5s888 alignItems-xu8adaz width-x1v68ji2 margin-x1ghz6dp paddingInline-x1fvqwet paddingTop-x1eq7djj paddingTop-xrmelco paddingBottom-x1hsyo9t paddingBottom-x191vjuz backgroundColor-x1lz9bv1 backgroundImage-x1n7lvf9 borderWidth-xmkeg23 borderWidth-x1m60m6i borderStyle-x1y0btm7 borderColor-x1hydj5d borderBottomColor-xslp3sd borderRadius-x1nklt0o borderRadius-xd22jv inset-x1los6se" data-style-src="tests/fixture/page-tsx/input.stylex.js:136">
+    <main className="input__style.main display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 paddingTop-x1llwu7x paddingBottom-xjfnvzm paddingBottom-x191vjuz" data-style-src="tests/fixture/page-tsx/input.stylex.js:73">
+      <div className="input__style.description display-x1jfb8zj justifyContent-xarpa2k alignItems-x1h91t0o fontSize-xmit1kp maxWidth-xmrzitl width-xh8yej3 zIndex-xhtitgo fontFamily-xh1z4oz" data-style-src="tests/fixture/page-tsx/input.stylex.js:119">
+        <p className="input__style.descP display-xjg0vao position-x1n2onr6 position-x15f3dyk justifyContent-xo5s888 alignItems-xu8adaz width-x1v68ji2 margin-x1ghz6dp paddingInline-x1fvqwet paddingTop-x1eq7djj paddingTop-xrmelco paddingBottom-x1hsyo9t paddingBottom-x191vjuz backgroundColor-x1lz9bv1 backgroundImage-x1n7lvf9 borderWidth-xmkeg23 borderWidth-x1m60m6i borderStyle-x1y0btm7 borderColor-x1hydj5d borderBottomColor-xslp3sd borderRadius-x1nklt0o borderRadius-xd22jv inset-x1los6se" data-style-src="tests/fixture/page-tsx/input.stylex.js:136">
           Get started by editing&nbsp;
-          <code className="fontWeight-x1xlr1w8 fontFamily-xh1z4oz" data-style-src="tests/fixture/page-tsx/input.stylex.js:176">app/page.tsx</code>
+          <code className="input__style.code fontWeight-x1xlr1w8 fontFamily-xh1z4oz" data-style-src="tests/fixture/page-tsx/input.stylex.js:176">app/page.tsx</code>
         </p>
       </div>
-      <div className="flexGrow-x1iyjqo2 display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-xl56j7k gap-x1irrqrq" data-style-src="tests/fixture/page-tsx/input.stylex.js:85">
-        <h1 className="fontSize-x1u631ky lineHeight-xo5v014 fontFamily-x1o4itb0 fontWeight-xo1l8bm textAlign-x2b8uid display-x78zum5 gap-x643tzn whiteSpace-xuxw1ft flexDirection-x1q0g3np flexDirection-xwlf911" data-style-src="tests/fixture/page-tsx/input.stylex.js:93">
-          Next.js App Dir<span className="position-x1n2onr6 fontFamily-x6icuqf top-x13vifvy top-x1dgnge0 animationName-xjjucxr animationDuration-x1c74tu6 animationIterationCount-xa4qsjk animationTimingFunction-x1esw782" data-style-src="tests/fixture/page-tsx/input.stylex.js:107">♥️</span>️StyleX
+      <div className="input__style.hero flexGrow-x1iyjqo2 display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-xl56j7k gap-x1irrqrq" data-style-src="tests/fixture/page-tsx/input.stylex.js:85">
+        <h1 className="input__style.h1 fontSize-x1u631ky lineHeight-xo5v014 fontFamily-x1o4itb0 fontWeight-xo1l8bm textAlign-x2b8uid display-x78zum5 gap-x643tzn whiteSpace-xuxw1ft flexDirection-x1q0g3np flexDirection-xwlf911" data-style-src="tests/fixture/page-tsx/input.stylex.js:93">
+          Next.js App Dir<span className="input__style.emoji position-x1n2onr6 fontFamily-x6icuqf top-x13vifvy top-x1dgnge0 animationName-xjjucxr animationDuration-x1c74tu6 animationIterationCount-xa4qsjk animationTimingFunction-x1esw782" data-style-src="tests/fixture/page-tsx/input.stylex.js:107">♥️</span>️StyleX
         </h1>
           <Counter/>
       </div>
 
-      <div className="display-xrvj5dj gridTemplateColumns-xtp8ymz gridTemplateColumns-xx3cr9d gridTemplateColumns-xtffbmy width-xcqkx85 maxWidth-x193iq5w maxWidth-xl858mc textAlign-x15hltav" data-style-src="tests/fixture/page-tsx/input.stylex.js:180">
+      <div className="input__style.grid display-xrvj5dj gridTemplateColumns-xtp8ymz gridTemplateColumns-xx3cr9d gridTemplateColumns-xtffbmy width-xcqkx85 maxWidth-x193iq5w maxWidth-xl858mc textAlign-x15hltav" data-style-src="tests/fixture/page-tsx/input.stylex.js:180">
         <Card body="Learn how to use StyleX to build UIs" href={`${HOMEPAGE}/docs/learn/`} title="Docs"/>
         <Card body="Browse through the StyleX API reference" href={`${HOMEPAGE}/docs/api/`} title="API"/>
         <Card body="Play with StyleX and look at the compile outputs" href={`${HOMEPAGE}/playground/`} title="Playground"/>

--- a/crates/stylex-transform/tests/fixture/page-tsx/output.js
+++ b/crates/stylex-transform/tests/fixture/page-tsx/output.js
@@ -11,21 +11,21 @@ interface Props {
 }
 export default function Home(_props: Props) {
     return(// @ts-expect-error - sx is not correctly typed
-    <main className="display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 paddingTop-x1llwu7x paddingBottom-xjfnvzm paddingBottom-x191vjuz" data-style-src="tests/fixture/page-tsx/input.stylex.js:58">
-      <div className="display-x1jfb8zj justifyContent-xarpa2k alignItems-x1h91t0o fontSize-xmit1kp maxWidth-xmrzitl width-xh8yej3 zIndex-xhtitgo fontFamily-xh1z4oz" data-style-src="tests/fixture/page-tsx/input.stylex.js:104">
-        <p className="display-xjg0vao position-x1n2onr6 position-x15f3dyk justifyContent-xo5s888 alignItems-xu8adaz width-x1v68ji2 margin-x1ghz6dp paddingInline-x1fvqwet paddingTop-x1eq7djj paddingTop-xrmelco paddingBottom-x1hsyo9t paddingBottom-x191vjuz backgroundColor-x1lz9bv1 backgroundImage-x1n7lvf9 borderWidth-xmkeg23 borderWidth-x1m60m6i borderStyle-x1y0btm7 borderColor-x1hydj5d borderBottomColor-xslp3sd borderRadius-x1nklt0o borderRadius-xd22jv inset-x1los6se" data-style-src="tests/fixture/page-tsx/input.stylex.js:123">
+    <main className="display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 paddingTop-x1llwu7x paddingBottom-xjfnvzm paddingBottom-x191vjuz" data-style-src="tests/fixture/page-tsx/input.stylex.js:73">
+      <div className="display-x1jfb8zj justifyContent-xarpa2k alignItems-x1h91t0o fontSize-xmit1kp maxWidth-xmrzitl width-xh8yej3 zIndex-xhtitgo fontFamily-xh1z4oz" data-style-src="tests/fixture/page-tsx/input.stylex.js:119">
+        <p className="display-xjg0vao position-x1n2onr6 position-x15f3dyk justifyContent-xo5s888 alignItems-xu8adaz width-x1v68ji2 margin-x1ghz6dp paddingInline-x1fvqwet paddingTop-x1eq7djj paddingTop-xrmelco paddingBottom-x1hsyo9t paddingBottom-x191vjuz backgroundColor-x1lz9bv1 backgroundImage-x1n7lvf9 borderWidth-xmkeg23 borderWidth-x1m60m6i borderStyle-x1y0btm7 borderColor-x1hydj5d borderBottomColor-xslp3sd borderRadius-x1nklt0o borderRadius-xd22jv inset-x1los6se" data-style-src="tests/fixture/page-tsx/input.stylex.js:136">
           Get started by editing&nbsp;
-          <code className="fontWeight-x1xlr1w8 fontFamily-xh1z4oz" data-style-src="tests/fixture/page-tsx/input.stylex.js:173">app/page.tsx</code>
+          <code className="fontWeight-x1xlr1w8 fontFamily-xh1z4oz" data-style-src="tests/fixture/page-tsx/input.stylex.js:176">app/page.tsx</code>
         </p>
       </div>
-      <div className="flexGrow-x1iyjqo2 display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-xl56j7k gap-x1irrqrq" data-style-src="tests/fixture/page-tsx/input.stylex.js:70">
-        <h1 className="fontSize-x1u631ky lineHeight-xo5v014 fontFamily-x1o4itb0 fontWeight-xo1l8bm textAlign-x2b8uid display-x78zum5 gap-x643tzn whiteSpace-xuxw1ft flexDirection-x1q0g3np flexDirection-xwlf911" data-style-src="tests/fixture/page-tsx/input.stylex.js:78">
-          Next.js App Dir<span className="position-x1n2onr6 fontFamily-x6icuqf top-x13vifvy top-x1dgnge0 animationName-xjjucxr animationDuration-x1c74tu6 animationIterationCount-xa4qsjk animationTimingFunction-x1esw782" data-style-src="tests/fixture/page-tsx/input.stylex.js:92">♥️</span>️StyleX
+      <div className="flexGrow-x1iyjqo2 display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-xl56j7k gap-x1irrqrq" data-style-src="tests/fixture/page-tsx/input.stylex.js:85">
+        <h1 className="fontSize-x1u631ky lineHeight-xo5v014 fontFamily-x1o4itb0 fontWeight-xo1l8bm textAlign-x2b8uid display-x78zum5 gap-x643tzn whiteSpace-xuxw1ft flexDirection-x1q0g3np flexDirection-xwlf911" data-style-src="tests/fixture/page-tsx/input.stylex.js:93">
+          Next.js App Dir<span className="position-x1n2onr6 fontFamily-x6icuqf top-x13vifvy top-x1dgnge0 animationName-xjjucxr animationDuration-x1c74tu6 animationIterationCount-xa4qsjk animationTimingFunction-x1esw782" data-style-src="tests/fixture/page-tsx/input.stylex.js:107">♥️</span>️StyleX
         </h1>
           <Counter/>
       </div>
 
-      <div className="display-xrvj5dj gridTemplateColumns-xtp8ymz gridTemplateColumns-xx3cr9d gridTemplateColumns-xtffbmy width-xcqkx85 maxWidth-x193iq5w maxWidth-xl858mc textAlign-x15hltav" data-style-src="tests/fixture/page-tsx/input.stylex.js:177">
+      <div className="display-xrvj5dj gridTemplateColumns-xtp8ymz gridTemplateColumns-xx3cr9d gridTemplateColumns-xtffbmy width-xcqkx85 maxWidth-x193iq5w maxWidth-xl858mc textAlign-x15hltav" data-style-src="tests/fixture/page-tsx/input.stylex.js:180">
         <Card body="Learn how to use StyleX to build UIs" href={`${HOMEPAGE}/docs/learn/`} title="Docs"/>
         <Card body="Browse through the StyleX API reference" href={`${HOMEPAGE}/docs/api/`} title="API"/>
         <Card body="Play with StyleX and look at the compile outputs" href={`${HOMEPAGE}/playground/`} title="Playground"/>

--- a/crates/stylex-transform/tests/fixture/page-with-keyframes/output.js
+++ b/crates/stylex-transform/tests/fixture/page-with-keyframes/output.js
@@ -11,21 +11,21 @@ import Counter from './Counter';
 const HOMEPAGE = 'https://stylexjs.com';
 export default function Home() {
     return(// @ts-expect-error - sx is not correctly typed
-    <main className="display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 paddingTop-x1llwu7x paddingBottom-xjfnvzm paddingBottom-x191vjuz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:75">
-      <div className="display-x1jfb8zj justifyContent-xarpa2k alignItems-x1h91t0o maxWidth-xmrzitl width-xh8yej3 zIndex-xhtitgo fontFamily-xh1z4oz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:121">
-        <p className="display-xjg0vao position-x1n2onr6 position-x15f3dyk justifyContent-xo5s888 alignItems-xu8adaz width-x1v68ji2 margin-x1ghz6dp paddingInline-x1fvqwet paddingTop-x1eq7djj paddingTop-xrmelco paddingBottom-x1hsyo9t paddingBottom-x191vjuz backgroundColor-x1lz9bv1 backgroundImage-x1n7lvf9 borderWidth-xmkeg23 borderWidth-x1m60m6i borderStyle-x1y0btm7 borderColor-x1hydj5d borderBottomColor-xslp3sd borderRadius-x1nklt0o borderRadius-xd22jv inset-x1los6se" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:138">
+    <main className="input__style.main display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 paddingTop-x1llwu7x paddingBottom-xjfnvzm paddingBottom-x191vjuz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:75">
+      <div className="input__style.description display-x1jfb8zj justifyContent-xarpa2k alignItems-x1h91t0o maxWidth-xmrzitl width-xh8yej3 zIndex-xhtitgo fontFamily-xh1z4oz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:121">
+        <p className="input__style.descP display-xjg0vao position-x1n2onr6 position-x15f3dyk justifyContent-xo5s888 alignItems-xu8adaz width-x1v68ji2 margin-x1ghz6dp paddingInline-x1fvqwet paddingTop-x1eq7djj paddingTop-xrmelco paddingBottom-x1hsyo9t paddingBottom-x191vjuz backgroundColor-x1lz9bv1 backgroundImage-x1n7lvf9 borderWidth-xmkeg23 borderWidth-x1m60m6i borderStyle-x1y0btm7 borderColor-x1hydj5d borderBottomColor-xslp3sd borderRadius-x1nklt0o borderRadius-xd22jv inset-x1los6se" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:138">
           Get started by editing&nbsp;
-          <code className="fontWeight-x1xlr1w8 fontFamily-xh1z4oz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:178">app/page.tsx</code>
+          <code className="input__style.code fontWeight-x1xlr1w8 fontFamily-xh1z4oz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:178">app/page.tsx</code>
         </p>
       </div>
-      <div className="flexGrow-x1iyjqo2 display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-xl56j7k gap-x1irrqrq" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:87">
-        <h1 className="fontSize-x1u631ky lineHeight-xo5v014 fontFamily-x1o4itb0 fontWeight-xo1l8bm textAlign-x2b8uid display-x78zum5 gap-x643tzn whiteSpace-xuxw1ft flexDirection-x1q0g3np flexDirection-xwlf911" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:95">
-          Next.js App Dir<span className="position-x1n2onr6 fontFamily-x6icuqf top-x13vifvy top-x1dgnge0 animationDuration-x1c74tu6 animationIterationCount-xa4qsjk animationTimingFunction-x1esw782" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:109">♥️</span>️StyleX
+      <div className="input__style.hero flexGrow-x1iyjqo2 display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-xl56j7k gap-x1irrqrq" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:87">
+        <h1 className="input__style.h1 fontSize-x1u631ky lineHeight-xo5v014 fontFamily-x1o4itb0 fontWeight-xo1l8bm textAlign-x2b8uid display-x78zum5 gap-x643tzn whiteSpace-xuxw1ft flexDirection-x1q0g3np flexDirection-xwlf911" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:95">
+          Next.js App Dir<span className="input__style.emoji position-x1n2onr6 fontFamily-x6icuqf top-x13vifvy top-x1dgnge0 animationDuration-x1c74tu6 animationIterationCount-xa4qsjk animationTimingFunction-x1esw782" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:109">♥️</span>️StyleX
         </h1>
         <Counter/>
       </div>
 
-      <div className="display-xrvj5dj gridTemplateColumns-xtp8ymz gridTemplateColumns-xx3cr9d gridTemplateColumns-xtffbmy width-xcqkx85 maxWidth-x193iq5w maxWidth-xl858mc textAlign-x15hltav" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:182">
+      <div className="input__style.grid display-xrvj5dj gridTemplateColumns-xtp8ymz gridTemplateColumns-xx3cr9d gridTemplateColumns-xtffbmy width-xcqkx85 maxWidth-x193iq5w maxWidth-xl858mc textAlign-x15hltav" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:182">
         <Card body="Learn how to use StyleX to build UIs" href={`${HOMEPAGE}/docs/learn/`} title="Docs"/>
         <Card body="Browse through the StyleX API reference" href={`${HOMEPAGE}/docs/api/`} title="API"/>
         <Card body="Play with StyleX and look at the compile outputs" href={`${HOMEPAGE}/playground/`} title="Playground"/>

--- a/crates/stylex-transform/tests/fixture/page-with-keyframes/output.js
+++ b/crates/stylex-transform/tests/fixture/page-with-keyframes/output.js
@@ -11,21 +11,21 @@ import Counter from './Counter';
 const HOMEPAGE = 'https://stylexjs.com';
 export default function Home() {
     return(// @ts-expect-error - sx is not correctly typed
-    <main className="display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 paddingTop-x1llwu7x paddingBottom-xjfnvzm paddingBottom-x191vjuz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:56">
-      <div className="display-x1jfb8zj justifyContent-xarpa2k alignItems-x1h91t0o maxWidth-xmrzitl width-xh8yej3 zIndex-xhtitgo fontFamily-xh1z4oz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:101">
-        <p className="display-xjg0vao position-x1n2onr6 position-x15f3dyk justifyContent-xo5s888 alignItems-xu8adaz width-x1v68ji2 margin-x1ghz6dp paddingInline-x1fvqwet paddingTop-x1eq7djj paddingTop-xrmelco paddingBottom-x1hsyo9t paddingBottom-x191vjuz backgroundColor-x1lz9bv1 backgroundImage-x1n7lvf9 borderWidth-xmkeg23 borderWidth-x1m60m6i borderStyle-x1y0btm7 borderColor-x1hydj5d borderBottomColor-xslp3sd borderRadius-x1nklt0o borderRadius-xd22jv inset-x1los6se" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:119">
+    <main className="display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 paddingTop-x1llwu7x paddingBottom-xjfnvzm paddingBottom-x191vjuz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:75">
+      <div className="display-x1jfb8zj justifyContent-xarpa2k alignItems-x1h91t0o maxWidth-xmrzitl width-xh8yej3 zIndex-xhtitgo fontFamily-xh1z4oz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:121">
+        <p className="display-xjg0vao position-x1n2onr6 position-x15f3dyk justifyContent-xo5s888 alignItems-xu8adaz width-x1v68ji2 margin-x1ghz6dp paddingInline-x1fvqwet paddingTop-x1eq7djj paddingTop-xrmelco paddingBottom-x1hsyo9t paddingBottom-x191vjuz backgroundColor-x1lz9bv1 backgroundImage-x1n7lvf9 borderWidth-xmkeg23 borderWidth-x1m60m6i borderStyle-x1y0btm7 borderColor-x1hydj5d borderBottomColor-xslp3sd borderRadius-x1nklt0o borderRadius-xd22jv inset-x1los6se" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:138">
           Get started by editing&nbsp;
-          <code className="fontWeight-x1xlr1w8 fontFamily-xh1z4oz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:169">app/page.tsx</code>
+          <code className="fontWeight-x1xlr1w8 fontFamily-xh1z4oz" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:178">app/page.tsx</code>
         </p>
       </div>
-      <div className="flexGrow-x1iyjqo2 display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-xl56j7k gap-x1irrqrq" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:68">
-        <h1 className="fontSize-x1u631ky lineHeight-xo5v014 fontFamily-x1o4itb0 fontWeight-xo1l8bm textAlign-x2b8uid display-x78zum5 gap-x643tzn whiteSpace-xuxw1ft flexDirection-x1q0g3np flexDirection-xwlf911" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:76">
-          Next.js App Dir<span className="position-x1n2onr6 fontFamily-x6icuqf top-x13vifvy top-x1dgnge0 animationDuration-x1c74tu6 animationIterationCount-xa4qsjk animationTimingFunction-x1esw782" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:90">♥️</span>️StyleX
+      <div className="flexGrow-x1iyjqo2 display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-xl56j7k gap-x1irrqrq" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:87">
+        <h1 className="fontSize-x1u631ky lineHeight-xo5v014 fontFamily-x1o4itb0 fontWeight-xo1l8bm textAlign-x2b8uid display-x78zum5 gap-x643tzn whiteSpace-xuxw1ft flexDirection-x1q0g3np flexDirection-xwlf911" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:95">
+          Next.js App Dir<span className="position-x1n2onr6 fontFamily-x6icuqf top-x13vifvy top-x1dgnge0 animationDuration-x1c74tu6 animationIterationCount-xa4qsjk animationTimingFunction-x1esw782" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:109">♥️</span>️StyleX
         </h1>
         <Counter/>
       </div>
 
-      <div className="display-xrvj5dj gridTemplateColumns-xtp8ymz gridTemplateColumns-xx3cr9d gridTemplateColumns-xtffbmy width-xcqkx85 maxWidth-x193iq5w maxWidth-xl858mc textAlign-x15hltav" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:173">
+      <div className="display-xrvj5dj gridTemplateColumns-xtp8ymz gridTemplateColumns-xx3cr9d gridTemplateColumns-xtffbmy width-xcqkx85 maxWidth-x193iq5w maxWidth-xl858mc textAlign-x15hltav" data-style-src="tests/fixture/page-with-keyframes/input.stylex.js:182">
         <Card body="Learn how to use StyleX to build UIs" href={`${HOMEPAGE}/docs/learn/`} title="Docs"/>
         <Card body="Browse through the StyleX API reference" href={`${HOMEPAGE}/docs/api/`} title="API"/>
         <Card body="Play with StyleX and look at the compile outputs" href={`${HOMEPAGE}/playground/`} title="Playground"/>

--- a/crates/stylex-transform/tests/fixture/page/output.js
+++ b/crates/stylex-transform/tests/fixture/page/output.js
@@ -49,7 +49,7 @@ const { foo, ...a } = {
 };
 export default function Home() {
     const { className, style } = {
-        className: "color-x1e2nbdu display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 padding-x1lmef92 lineHeight-x1swossr fontSize-xif65rj",
+        className: "input__s.main color-x1e2nbdu display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 padding-x1lmef92 input__s.title lineHeight-x1swossr fontSize-xif65rj",
         "data-style-src": "tests/fixture/page/input.stylex.js:5; tests/fixture/page/input.stylex.js:19"
     };
     return <main className={className} style={style}>

--- a/crates/stylex-transform/tests/fixture/page/output.js
+++ b/crates/stylex-transform/tests/fixture/page/output.js
@@ -50,7 +50,7 @@ const { foo, ...a } = {
 export default function Home() {
     const { className, style } = {
         className: "color-x1e2nbdu display-x78zum5 flexDirection-xdt5ytf alignItems-x6s0dn4 justifyContent-x1qughib minHeight-xg6iff7 padding-x1lmef92 lineHeight-x1swossr fontSize-xif65rj",
-        "data-style-src": "tests/fixture/page/input.stylex.js:4; tests/fixture/page/input.stylex.js:13"
+        "data-style-src": "tests/fixture/page/input.stylex.js:5; tests/fixture/page/input.stylex.js:19"
     };
     return <main className={className} style={style}>
       Main

--- a/crates/stylex-transform/tests/fixture/spot-loader/output.js
+++ b/crates/stylex-transform/tests/fixture/spot-loader/output.js
@@ -116,6 +116,7 @@ _inject2({
 });
 const styles = {
     root: {
+        "input__styles.root": "input__styles.root",
         display: "display-xrvj5dj",
         gridAutoFlow: "gridAutoFlow-x1mt1orb",
         gridTemplateColumns: "gridTemplateColumns-xernuvs",
@@ -125,6 +126,7 @@ const styles = {
         $$css: "tests/fixture/spot-loader/input.stylex.js:15"
     },
     rect: {
+        "input__styles.rect": "input__styles.rect",
         backgroundColor: "backgroundColor-x1mdjlir",
         borderRadius: "borderRadius-x12oqio5",
         zIndex: "zIndex-x11uqc5h",
@@ -135,46 +137,55 @@ const styles = {
         $$css: "tests/fixture/spot-loader/input.stylex.js:23"
     },
     rect1: {
+        "input__styles.rect1": "input__styles.rect1",
         height: "height-x10buj8t",
         $$css: "tests/fixture/spot-loader/input.stylex.js:32"
     },
     rect2: {
+        "input__styles.rect2": "input__styles.rect2",
         animationDelay: "animationDelay-x1qdon1m",
         height: "height-x1lnynta",
         $$css: "tests/fixture/spot-loader/input.stylex.js:35"
     },
     rect3: {
+        "input__styles.rect3": "input__styles.rect3",
         animationDelay: "animationDelay-x123bg45",
         height: "height-x5yr21d",
         $$css: "tests/fixture/spot-loader/input.stylex.js:39"
     },
     rect4: {
+        "input__styles.rect4": "input__styles.rect4",
         animationDelay: "animationDelay-x1ba7lo8",
         backgroundColor: "backgroundColor-xb4ade6",
         height: "height-x1lnynta",
         $$css: "tests/fixture/spot-loader/input.stylex.js:43"
     },
     rect5: {
+        "input__styles.rect5": "input__styles.rect5",
         animationDelay: "animationDelay-xdwblqi",
         height: "height-x10buj8t",
         $$css: "tests/fixture/spot-loader/input.stylex.js:48"
     },
     sizeSmall: {
+        "input__styles.sizeSmall": "input__styles.sizeSmall",
         height: "height-xettwda",
         width: "width-xs5h3dt",
         $$css: "tests/fixture/spot-loader/input.stylex.js:52"
     },
     size_small: {
+        "input__styles.size_small": "input__styles.size_small",
         height: "height-xettwda",
         width: "width-xs5h3dt",
         $$css: "tests/fixture/spot-loader/input.stylex.js:56"
     },
     size_normal: {
+        "input__styles.size_normal": "input__styles.size_normal",
         height: "height-x1sh0tsm",
         width: "width-xekueh",
         $$css: "tests/fixture/spot-loader/input.stylex.js:60"
     },
     size_large: {
+        "input__styles.size_large": "input__styles.size_large",
         height: "height-x17frcva",
         width: "width-xdvn7xf",
         $$css: "tests/fixture/spot-loader/input.stylex.js:64"
@@ -183,7 +194,7 @@ const styles = {
 const SpotLoader = ({ isLoading = true, style, size = COMMON_SIZES.normal })=>{
     return isLoading && <>
         <div {...stylex.props(styles[size])}>{size}</div>
-        <div className="display-xrvj5dj gridAutoFlow-x1mt1orb gridTemplateColumns-xernuvs alignItems-x6s0dn4 justifyContent-xl56j7k gap-xmjcfx9 height-xettwda width-xs5h3dt" data-style-src="tests/fixture/spot-loader/input.stylex.js:15; tests/fixture/spot-loader/input.stylex.js:52">styles.sizeSmall</div>
+        <div className="input__styles.root display-xrvj5dj gridAutoFlow-x1mt1orb gridTemplateColumns-xernuvs alignItems-x6s0dn4 justifyContent-xl56j7k gap-xmjcfx9 input__styles.sizeSmall height-xettwda width-xs5h3dt" data-style-src="tests/fixture/spot-loader/input.stylex.js:15; tests/fixture/spot-loader/input.stylex.js:52">styles.sizeSmall</div>
         <div {...stylex.props(styles.root, styles.sizeSmall, style)}>styles.sizeSmall with styles</div>
       </>;
 };

--- a/crates/stylex-transform/tests/fixture/spot-loader/output.js
+++ b/crates/stylex-transform/tests/fixture/spot-loader/output.js
@@ -122,7 +122,7 @@ const styles = {
         alignItems: "alignItems-x6s0dn4",
         justifyContent: "justifyContent-xl56j7k",
         gap: "gap-xmjcfx9",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:12"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:15"
     },
     rect: {
         backgroundColor: "backgroundColor-x1mdjlir",
@@ -132,58 +132,58 @@ const styles = {
         animationDuration: "animationDuration-x1m9vv7p",
         animationIterationCount: "animationIterationCount-xa4qsjk",
         animationTimingFunction: "animationTimingFunction-x4hg4is",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:20"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:23"
     },
     rect1: {
         height: "height-x10buj8t",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:29"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:32"
     },
     rect2: {
         animationDelay: "animationDelay-x1qdon1m",
         height: "height-x1lnynta",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:32"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:35"
     },
     rect3: {
         animationDelay: "animationDelay-x123bg45",
         height: "height-x5yr21d",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:36"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:39"
     },
     rect4: {
         animationDelay: "animationDelay-x1ba7lo8",
         backgroundColor: "backgroundColor-xb4ade6",
         height: "height-x1lnynta",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:40"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:43"
     },
     rect5: {
         animationDelay: "animationDelay-xdwblqi",
         height: "height-x10buj8t",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:45"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:48"
     },
     sizeSmall: {
         height: "height-xettwda",
         width: "width-xs5h3dt",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:49"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:52"
     },
     size_small: {
         height: "height-xettwda",
         width: "width-xs5h3dt",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:53"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:56"
     },
     size_normal: {
         height: "height-x1sh0tsm",
         width: "width-xekueh",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:57"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:60"
     },
     size_large: {
         height: "height-x17frcva",
         width: "width-xdvn7xf",
-        $$css: "tests/fixture/spot-loader/input.stylex.js:61"
+        $$css: "tests/fixture/spot-loader/input.stylex.js:64"
     }
 };
 const SpotLoader = ({ isLoading = true, style, size = COMMON_SIZES.normal })=>{
     return isLoading && <>
         <div {...stylex.props(styles[size])}>{size}</div>
-        <div className="display-xrvj5dj gridAutoFlow-x1mt1orb gridTemplateColumns-xernuvs alignItems-x6s0dn4 justifyContent-xl56j7k gap-xmjcfx9 height-xettwda width-xs5h3dt" data-style-src="tests/fixture/spot-loader/input.stylex.js:12; tests/fixture/spot-loader/input.stylex.js:49">styles.sizeSmall</div>
+        <div className="display-xrvj5dj gridAutoFlow-x1mt1orb gridTemplateColumns-xernuvs alignItems-x6s0dn4 justifyContent-xl56j7k gap-xmjcfx9 height-xettwda width-xs5h3dt" data-style-src="tests/fixture/spot-loader/input.stylex.js:15; tests/fixture/spot-loader/input.stylex.js:52">styles.sizeSmall</div>
         <div {...stylex.props(styles.root, styles.sizeSmall, style)}>styles.sizeSmall with styles</div>
       </>;
 };

--- a/crates/stylex-transform/tests/fixture/typography/output.js
+++ b/crates/stylex-transform/tests/fixture/typography/output.js
@@ -123,114 +123,114 @@ const styles = {
         margin: "margin-x1ghz6dp",
         overflowWrap: "overflowWrap-xj0a0fe",
         fontFamily: "fontFamily-xbwy7e6",
-        $$css: "tests/fixture/typography/input.stylex.js:6"
+        $$css: "tests/fixture/typography/input.stylex.js:8"
     },
     textXxxl: {
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-x193ocya",
-        $$css: "tests/fixture/typography/input.stylex.js:11"
+        $$css: "tests/fixture/typography/input.stylex.js:13"
     },
     textXxl: {
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-xlj8byu",
-        $$css: "tests/fixture/typography/input.stylex.js:15"
+        $$css: "tests/fixture/typography/input.stylex.js:17"
     },
     textXl: {
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-xgc4vk5",
-        $$css: "tests/fixture/typography/input.stylex.js:19"
+        $$css: "tests/fixture/typography/input.stylex.js:21"
     },
     textLg: {
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-x17gblq1",
-        $$css: "tests/fixture/typography/input.stylex.js:23"
+        $$css: "tests/fixture/typography/input.stylex.js:25"
     },
     textMd: {
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-xm7bc5f",
-        $$css: "tests/fixture/typography/input.stylex.js:27"
+        $$css: "tests/fixture/typography/input.stylex.js:29"
     },
     textSm: {
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-x9bx2mk",
-        $$css: "tests/fixture/typography/input.stylex.js:31"
+        $$css: "tests/fixture/typography/input.stylex.js:33"
     },
     body: {
         fontSize: "fontSize-xr14wxu",
         lineHeight: "lineHeight-x1sjzer8",
-        $$css: "tests/fixture/typography/input.stylex.js:35"
+        $$css: "tests/fixture/typography/input.stylex.js:37"
     },
     bodySm: {
         fontSize: "fontSize-x9bx2mk",
         lineHeight: "lineHeight-x1sjzer8",
-        $$css: "tests/fixture/typography/input.stylex.js:39"
+        $$css: "tests/fixture/typography/input.stylex.js:41"
     },
     bodyMd: {
         fontSize: "fontSize-xm7bc5f",
         lineHeight: "lineHeight-x1sjzer8",
-        $$css: "tests/fixture/typography/input.stylex.js:43"
+        $$css: "tests/fixture/typography/input.stylex.js:45"
     },
     truncate: {
         whiteSpace: "whiteSpace-xuxw1ft",
         textOverflow: "textOverflow-xlyipyv",
         overflow: "overflow-xb3r6kr",
-        $$css: "tests/fixture/typography/input.stylex.js:47"
+        $$css: "tests/fixture/typography/input.stylex.js:49"
     },
     bold: {
         fontWeight: "fontWeight-x117nqv4",
-        $$css: "tests/fixture/typography/input.stylex.js:52"
+        $$css: "tests/fixture/typography/input.stylex.js:54"
     },
     italic: {
         fontStyle: "fontStyle-x1k4tb9n",
-        $$css: "tests/fixture/typography/input.stylex.js:55"
+        $$css: "tests/fixture/typography/input.stylex.js:57"
     },
     textTransform_unset: {
         textTransform: "textTransform-x1gdvv3m",
-        $$css: "tests/fixture/typography/input.stylex.js:58"
+        $$css: "tests/fixture/typography/input.stylex.js:60"
     },
     textTransform_uppercase: {
         textTransform: "textTransform-xtvhhri",
-        $$css: "tests/fixture/typography/input.stylex.js:61"
+        $$css: "tests/fixture/typography/input.stylex.js:63"
     },
     textTransform_lowercase: {
         textTransform: "textTransform-x1kyqaxf",
-        $$css: "tests/fixture/typography/input.stylex.js:64"
+        $$css: "tests/fixture/typography/input.stylex.js:66"
     },
     textTransform_capitalize: {
         textTransform: "textTransform-xn80e1m",
-        $$css: "tests/fixture/typography/input.stylex.js:67"
+        $$css: "tests/fixture/typography/input.stylex.js:69"
     },
     underline: {
         textDecoration: "textDecoration-x1bvjpef",
-        $$css: "tests/fixture/typography/input.stylex.js:70"
+        $$css: "tests/fixture/typography/input.stylex.js:72"
     },
     colorSuccess: {
         color: "color-x2i9qa9",
-        $$css: "tests/fixture/typography/input.stylex.js:73"
+        $$css: "tests/fixture/typography/input.stylex.js:75"
     },
     colorError: {
         color: "color-x1wptp0d",
-        $$css: "tests/fixture/typography/input.stylex.js:76"
+        $$css: "tests/fixture/typography/input.stylex.js:78"
     },
     colorInfo: {
         color: "color-xt2mot5",
-        $$css: "tests/fixture/typography/input.stylex.js:79"
+        $$css: "tests/fixture/typography/input.stylex.js:81"
     },
     colorWarning: {
         color: "color-xe5xflh",
-        $$css: "tests/fixture/typography/input.stylex.js:82"
+        $$css: "tests/fixture/typography/input.stylex.js:84"
     },
     colorPrimary: {
         color: "color-xw3ogp8",
-        $$css: "tests/fixture/typography/input.stylex.js:85"
+        $$css: "tests/fixture/typography/input.stylex.js:87"
     },
     color_primary: {
         color: "color-xw3ogp8",
-        $$css: "tests/fixture/typography/input.stylex.js:88"
+        $$css: "tests/fixture/typography/input.stylex.js:90"
     },
     colorSecondary: {
         color: "color-x10gd8tk",
-        $$css: "tests/fixture/typography/input.stylex.js:91"
+        $$css: "tests/fixture/typography/input.stylex.js:93"
     }
 };
 const DEFAULT_VARIANT_MAPPING = {

--- a/crates/stylex-transform/tests/fixture/typography/output.js
+++ b/crates/stylex-transform/tests/fixture/typography/output.js
@@ -120,115 +120,140 @@ _inject2({
 });
 const styles = {
     text: {
+        "input__styles.text": "input__styles.text",
         margin: "margin-x1ghz6dp",
         overflowWrap: "overflowWrap-xj0a0fe",
         fontFamily: "fontFamily-xbwy7e6",
         $$css: "tests/fixture/typography/input.stylex.js:8"
     },
     textXxxl: {
+        "input__styles.textXxxl": "input__styles.textXxxl",
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-x193ocya",
         $$css: "tests/fixture/typography/input.stylex.js:13"
     },
     textXxl: {
+        "input__styles.textXxl": "input__styles.textXxl",
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-xlj8byu",
         $$css: "tests/fixture/typography/input.stylex.js:17"
     },
     textXl: {
+        "input__styles.textXl": "input__styles.textXl",
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-xgc4vk5",
         $$css: "tests/fixture/typography/input.stylex.js:21"
     },
     textLg: {
+        "input__styles.textLg": "input__styles.textLg",
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-x17gblq1",
         $$css: "tests/fixture/typography/input.stylex.js:25"
     },
     textMd: {
+        "input__styles.textMd": "input__styles.textMd",
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-xm7bc5f",
         $$css: "tests/fixture/typography/input.stylex.js:29"
     },
     textSm: {
+        "input__styles.textSm": "input__styles.textSm",
         lineHeight: "lineHeight-x48q9rv",
         fontSize: "fontSize-x9bx2mk",
         $$css: "tests/fixture/typography/input.stylex.js:33"
     },
     body: {
+        "input__styles.body": "input__styles.body",
         fontSize: "fontSize-xr14wxu",
         lineHeight: "lineHeight-x1sjzer8",
         $$css: "tests/fixture/typography/input.stylex.js:37"
     },
     bodySm: {
+        "input__styles.bodySm": "input__styles.bodySm",
         fontSize: "fontSize-x9bx2mk",
         lineHeight: "lineHeight-x1sjzer8",
         $$css: "tests/fixture/typography/input.stylex.js:41"
     },
     bodyMd: {
+        "input__styles.bodyMd": "input__styles.bodyMd",
         fontSize: "fontSize-xm7bc5f",
         lineHeight: "lineHeight-x1sjzer8",
         $$css: "tests/fixture/typography/input.stylex.js:45"
     },
     truncate: {
+        "input__styles.truncate": "input__styles.truncate",
         whiteSpace: "whiteSpace-xuxw1ft",
         textOverflow: "textOverflow-xlyipyv",
         overflow: "overflow-xb3r6kr",
         $$css: "tests/fixture/typography/input.stylex.js:49"
     },
     bold: {
+        "input__styles.bold": "input__styles.bold",
         fontWeight: "fontWeight-x117nqv4",
         $$css: "tests/fixture/typography/input.stylex.js:54"
     },
     italic: {
+        "input__styles.italic": "input__styles.italic",
         fontStyle: "fontStyle-x1k4tb9n",
         $$css: "tests/fixture/typography/input.stylex.js:57"
     },
     textTransform_unset: {
+        "input__styles.textTransform_unset": "input__styles.textTransform_unset",
         textTransform: "textTransform-x1gdvv3m",
         $$css: "tests/fixture/typography/input.stylex.js:60"
     },
     textTransform_uppercase: {
+        "input__styles.textTransform_uppercase": "input__styles.textTransform_uppercase",
         textTransform: "textTransform-xtvhhri",
         $$css: "tests/fixture/typography/input.stylex.js:63"
     },
     textTransform_lowercase: {
+        "input__styles.textTransform_lowercase": "input__styles.textTransform_lowercase",
         textTransform: "textTransform-x1kyqaxf",
         $$css: "tests/fixture/typography/input.stylex.js:66"
     },
     textTransform_capitalize: {
+        "input__styles.textTransform_capitalize": "input__styles.textTransform_capitalize",
         textTransform: "textTransform-xn80e1m",
         $$css: "tests/fixture/typography/input.stylex.js:69"
     },
     underline: {
+        "input__styles.underline": "input__styles.underline",
         textDecoration: "textDecoration-x1bvjpef",
         $$css: "tests/fixture/typography/input.stylex.js:72"
     },
     colorSuccess: {
+        "input__styles.colorSuccess": "input__styles.colorSuccess",
         color: "color-x2i9qa9",
         $$css: "tests/fixture/typography/input.stylex.js:75"
     },
     colorError: {
+        "input__styles.colorError": "input__styles.colorError",
         color: "color-x1wptp0d",
         $$css: "tests/fixture/typography/input.stylex.js:78"
     },
     colorInfo: {
+        "input__styles.colorInfo": "input__styles.colorInfo",
         color: "color-xt2mot5",
         $$css: "tests/fixture/typography/input.stylex.js:81"
     },
     colorWarning: {
+        "input__styles.colorWarning": "input__styles.colorWarning",
         color: "color-xe5xflh",
         $$css: "tests/fixture/typography/input.stylex.js:84"
     },
     colorPrimary: {
+        "input__styles.colorPrimary": "input__styles.colorPrimary",
         color: "color-xw3ogp8",
         $$css: "tests/fixture/typography/input.stylex.js:87"
     },
     color_primary: {
+        "input__styles.color_primary": "input__styles.color_primary",
         color: "color-xw3ogp8",
         $$css: "tests/fixture/typography/input.stylex.js:90"
     },
     colorSecondary: {
+        "input__styles.colorSecondary": "input__styles.colorSecondary",
         color: "color-x10gd8tk",
         $$css: "tests/fixture/typography/input.stylex.js:93"
     }

--- a/crates/stylex-transform/tests/fixture/use-memo/output.js
+++ b/crates/stylex-transform/tests/fixture/use-memo/output.js
@@ -64,11 +64,13 @@ _inject2({
 });
 const styles = {
     primary: {
+        "input__styles.primary": "input__styles.primary",
         backgroundColor: "backgroundColor-xrkmrrc",
         color: "color-x1awj2ng",
         $$css: "tests/fixture/use-memo/input.stylex.js:33"
     },
     root: {
+        "input__styles.root": "input__styles.root",
         display: "display-x1lliihq",
         fontSize: "fontSize-x1j61zf2",
         paddingBottom: "paddingBottom-xsag5q8",

--- a/crates/stylex-transform/tests/fixture/use-memo/output.js
+++ b/crates/stylex-transform/tests/fixture/use-memo/output.js
@@ -66,7 +66,7 @@ const styles = {
     primary: {
         backgroundColor: "backgroundColor-xrkmrrc",
         color: "color-x1awj2ng",
-        $$css: "tests/fixture/use-memo/input.stylex.js:32"
+        $$css: "tests/fixture/use-memo/input.stylex.js:33"
     },
     root: {
         display: "display-x1lliihq",
@@ -75,7 +75,7 @@ const styles = {
         paddingLeft: "paddingLeft-x5tiur9",
         paddingRight: "paddingRight-x1s7jvk7",
         paddingTop: "paddingTop-xz9dl7a",
-        $$css: "tests/fixture/use-memo/input.stylex.js:36"
+        $$css: "tests/fixture/use-memo/input.stylex.js:37"
     }
 };
 var _c;

--- a/crates/stylex-transform/tests/transform_stylex_create_test/debug_options.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/debug_options.rs
@@ -115,3 +115,58 @@ stylex_test!(
     });
   "#
 );
+
+// ──────────────────────────────────────────────
+// Dev class names follow `dev`
+//
+// `enableDevClassNames` defaults to the value of `dev`, so a dev build names
+// each namespace after its file and variable unless the option turns it off.
+// A dynamic entry keeps its name too, in the static fragment the compiler
+// hoists for it.
+// ──────────────────────────────────────────────
+
+/// A dev build with no debug options set, reading the authored text so the
+/// debug lines are the ones the author sees. Tree-shake compensation is on
+/// because the reference output these snapshots were checked against keeps the
+/// import. The tester's fields come by value, so the pass does not borrow the
+/// tester it outlives.
+fn dev_transform(
+  comments: TestComments,
+  source_map: std::sync::Arc<swc_core::common::SourceMap>,
+  customize: impl FnOnce(TestBuilder) -> TestBuilder,
+) -> impl Pass {
+  build_test_transform(comments, move |b| {
+    customize(
+      b.with_source_map(source_map)
+        .with_dev(true)
+        .with_treeshake_compensation(true)
+        .with_filename(swc_core::common::FileName::Real("MyComponent.js".into())),
+    )
+  })
+}
+
+stylex_test!(
+  a_dev_build_names_each_namespace_by_default,
+  |tr| dev_transform(tr.comments.clone(), tr.cm.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const styles = stylex.create({
+      root: { color: 'red' },
+      dyn: (width) => ({ width }),
+    });
+  "#
+);
+
+stylex_test!(
+  a_dev_build_names_no_namespace_when_the_option_is_off,
+  |tr| dev_transform(tr.comments.clone(), tr.cm.clone(), |b| {
+    b.with_enable_dev_class_names(false)
+  }),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const styles = stylex.create({
+      root: { color: 'red' },
+      dyn: (width) => ({ width }),
+    });
+  "#
+);

--- a/crates/stylex-transform/tests/transform_stylex_create_test/dynamic_styles.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/dynamic_styles.rs
@@ -900,12 +900,19 @@ stylex_test!(
 // order of the hoisted declarations and the injection calls is visible.
 stylex_test!(
   a_dynamic_entry_inside_a_namespace_in_dev_with_runtime_injection,
-  |tr| stylex_transform(tr.comments.clone(), |b| {
-    b.with_dev(true)
-      .with_enable_dev_class_names(true)
-      .with_filename(swc_core::common::FileName::Real("MyComponent.tsx".into()))
-      .with_runtime_injection()
-  }),
+  |tr| {
+    // Cloned here rather than in the builder closure, which must not borrow the
+    // tester: the pass it builds outlives the call.
+    let source_map = tr.cm.clone();
+
+    stylex_transform(tr.comments.clone(), move |b| {
+      b.with_source_map(source_map)
+        .with_dev(true)
+        .with_enable_dev_class_names(true)
+        .with_filename(swc_core::common::FileName::Real("MyComponent.tsx".into()))
+        .with_runtime_injection()
+    })
+  },
   r#"
     import * as stylex from '@stylexjs/stylex';
     export namespace Demo {

--- a/crates/stylex-transform/tests/transform_stylex_create_test/dynamic_styles.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/dynamic_styles.rs
@@ -926,3 +926,41 @@ stylex_test!(
     }
   "#
 );
+
+// A dynamic entry can name a constant of the scope it was written in. The
+// compiler cannot fold that name, so it keeps it as it is written and the hoist
+// carries it to the module level, where it is not declared. The module loads,
+// because the body of the entry runs only when it is called; the call is what
+// fails. This snapshot records the output as it is, so the day the behaviour
+// changes the change is visible here.
+stylex_test!(
+  a_nested_dynamic_entry_keeps_a_reference_to_the_scope_it_left,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export function render(gap) {
+      const styles = stylex.create({
+        box: (value) => ({ width: value, margin: gap }),
+      });
+      return stylex.props(styles.box(1));
+    }
+  "#
+);
+
+// The hoisted declaration sits beside the author's own declarations, so its
+// name has to be one the module does not already use. A module that declares
+// `_styles` itself gets the next free name.
+stylex_test!(
+  a_hoisted_styles_object_passes_over_a_name_the_module_already_uses,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const _styles = 1;
+    export function render(value) {
+      const styles = stylex.create({
+        color: (v) => ({ color: v }),
+      });
+      return stylex.props(styles.color(value));
+    }
+  "#
+);

--- a/crates/stylex-transform/tests/transform_stylex_create_test/dynamic_styles.rs
+++ b/crates/stylex-transform/tests/transform_stylex_create_test/dynamic_styles.rs
@@ -819,3 +819,103 @@ stylex_test!(
     });
   "#
 );
+
+// ──────────────────────────────────────────────
+// A dynamic entry declared in a nested scope (#1303)
+//
+// A `stylex.create` call that is not a module-level statement is hoisted to a
+// module-level `const` and the call site becomes a reference to it. The dynamic
+// rewrite has to see the compiled object before that hoist. Otherwise the entry
+// it would turn into an arrow function is already an identifier and it keeps
+// its static shape, and the call site fails at run time with
+// `styles.color is not a function`. Each case below keeps a static sibling so
+// the snapshot also shows that the sibling is left as it was.
+// ──────────────────────────────────────────────
+stylex_test!(
+  a_dynamic_entry_inside_a_namespace_stays_callable,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export namespace Demo {
+      const styles = stylex.create({
+        color: (value: string) => ({ color: value }),
+        base: { display: 'flex' },
+      });
+      export function render() {
+        return stylex.props(styles.base, styles.color('red'));
+      }
+    }
+  "#
+);
+
+stylex_test!(
+  a_dynamic_entry_inside_a_function_body_stays_callable,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export function render(value) {
+      const styles = stylex.create({
+        color: (value) => ({ color: value }),
+        base: { display: 'flex' },
+      });
+      return stylex.props(styles.base, styles.color(value));
+    }
+  "#
+);
+
+stylex_test!(
+  a_dynamic_entry_inside_an_iife_stays_callable,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export const render = (() => {
+      const styles = stylex.create({
+        color: (value) => ({ color: value }),
+        base: { display: 'flex' },
+      });
+      return (value) => stylex.props(styles.base, styles.color(value));
+    })();
+  "#
+);
+
+stylex_test!(
+  a_dynamic_entry_inside_a_block_stays_callable,
+  |tr| stylex_transform(tr.comments.clone(), |b| b),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export let render;
+    {
+      const styles = stylex.create({
+        color: (value) => ({ color: value }),
+        base: { display: 'flex' },
+      });
+      render = (value) => stylex.props(styles.base, styles.color(value));
+    }
+  "#
+);
+
+// Dev mode gives the dynamic entry a static fragment -- the debug class name --
+// that is hoisted from inside the rewrite, and runtime injection adds the
+// `_inject2` calls. Both are anchored at module level, so this is where the
+// order of the hoisted declarations and the injection calls is visible.
+stylex_test!(
+  a_dynamic_entry_inside_a_namespace_in_dev_with_runtime_injection,
+  |tr| stylex_transform(tr.comments.clone(), |b| {
+    b.with_dev(true)
+      .with_enable_dev_class_names(true)
+      .with_filename(swc_core::common::FileName::Real("MyComponent.tsx".into()))
+      .with_runtime_injection()
+  }),
+  r#"
+    import * as stylex from '@stylexjs/stylex';
+    export namespace Demo {
+      const styles = stylex.create({
+        color: (value: string) => ({ color: value }),
+        base: { display: 'flex' },
+      });
+      export function render() {
+        return stylex.props(styles.base, styles.color('red'));
+      }
+    }
+  "#
+);

--- a/crates/stylex-transform/tests/utils/macros.rs
+++ b/crates/stylex-transform/tests/utils/macros.rs
@@ -10,6 +10,7 @@ macro_rules! stylex_test {
     test!(
       $crate::utils::transform::ts_syntax(),
       |tr| StyleXTransform::test(tr.comments.clone())
+        .with_source_map(tr.cm.clone())
         .with_runtime_injection()
         .into_pass(),
       $name,
@@ -32,6 +33,7 @@ macro_rules! stylex_test {
     test!(
       $crate::utils::transform::ts_syntax(),
       |tr| StyleXTransform::test(tr.comments.clone())
+        .with_source_map(tr.cm.clone())
         .with_options($options)
         .with_runtime_injection()
         .into_pass(),

--- a/crates/stylex-transform/tests/utils/macros.rs
+++ b/crates/stylex-transform/tests/utils/macros.rs
@@ -65,6 +65,7 @@ macro_rules! stylex_test_transform {
         Option::None,
         |tr| {
           StyleXTransform::test(tr.comments.clone())
+            .with_source_map(tr.cm.clone())
             .with_runtime_injection()
             .into_pass()
         },
@@ -98,6 +99,7 @@ macro_rules! stylex_test_transform {
         Option::None,
         |tr| {
           StyleXTransform::test(tr.comments.clone())
+            .with_source_map(tr.cm.clone())
             .with_options($options)
             .with_runtime_injection()
             .into_pass()
@@ -141,6 +143,7 @@ macro_rules! stylex_test_panic {
         Option::None,
         |tr| {
           StyleXTransform::test(tr.comments.clone())
+            .with_source_map(tr.cm.clone())
             .with_runtime_injection()
             .into_pass()
         },
@@ -176,6 +179,7 @@ macro_rules! stylex_test_panic {
         Option::None,
         |tr| {
           StyleXTransform::test(tr.comments.clone())
+            .with_source_map(tr.cm.clone())
             .with_options($options)
             .with_runtime_injection()
             .into_pass()

--- a/guidelines/SCRIPTS.md
+++ b/guidelines/SCRIPTS.md
@@ -291,6 +291,13 @@ scripts/coverage-missing.sh                     # whole workspace
 scripts/coverage-missing.sh stylex_css          # one crate (or -p stylex_css)
 scripts/coverage-missing.sh stylex_css --html   # add an HTML report
 scripts/coverage-missing.sh stylex_css --open   # ...and open it
+scripts/coverage-missing.sh --skip-toolchain-check  # do not look for a newer nightly
 ```
 
 Requires nightly plus `cargo install cargo-llvm-cov cargo-nextest --locked`.
+
+The script names the nightly it measured with, and warns when a newer one is
+available. Region counting is a property of the compiler and continuous
+integration installs the newest nightly every run, so an old local nightly can
+report full coverage against a gate that fails there. Run `rustup update
+nightly` before you trust a clean report.

--- a/scripts/coverage-missing.sh
+++ b/scripts/coverage-missing.sh
@@ -24,7 +24,13 @@
 #      counts as uncovered even though the source line *is* exercised by another
 #      instantiation. A region is reported only when no instantiation runs it;
 #      the delta from llvm-cov's raw count is explained in a note.
-#   3. Scope filtering — cargo-llvm-cov's target dir is stateful: a `-p <crate>`
+#   3. Toolchain drift — the nightly compiler decides how regions are counted,
+#      and continuous integration installs the newest nightly on every run. An
+#      older local nightly measures fewer regions, so this report can read clean
+#      while the same gate fails in continuous integration. The version in use is
+#      printed, and an available update is a warning (`--skip-toolchain-check`
+#      turns the network lookup off).
+#   4. Scope filtering — cargo-llvm-cov's target dir is stateful: a `-p <crate>`
 #      run can fold in leftover instrumented object files from an earlier
 #      full-workspace run (e.g. dependency crates), producing a noisy,
 #      non-deterministic file list. The report is filtered to the requested
@@ -41,6 +47,7 @@
 #   scripts/coverage-missing.sh -p stylex_css   # same, explicit flag
 #   scripts/coverage-missing.sh --show-phantoms # also print generic per-instantiation gaps
 #   scripts/coverage-missing.sh --strict-phantoms # deprecated alias for --show-phantoms
+#   scripts/coverage-missing.sh --skip-toolchain-check # do not look for a newer nightly
 #   scripts/coverage-missing.sh --html          # also write an HTML report (second run)
 #   scripts/coverage-missing.sh --open          # write + open the HTML report in a browser
 #   scripts/coverage-missing.sh -h | --help
@@ -87,6 +94,7 @@ USAGE
   scripts/coverage-missing.sh -p stylex_css   # same, explicit flag
   scripts/coverage-missing.sh --show-phantoms # also print generic per-instantiation gaps
   scripts/coverage-missing.sh --strict-phantoms # deprecated alias for --show-phantoms
+  scripts/coverage-missing.sh --skip-toolchain-check # do not look for a newer nightly
   scripts/coverage-missing.sh --html          # also write an HTML report (second run)
   scripts/coverage-missing.sh --open          # write + open the HTML report in a browser
   scripts/coverage-missing.sh -h | --help
@@ -103,12 +111,14 @@ package=""
 html=0
 open=0
 show_phantoms=0
+toolchain_check=1
 
 while [ $# -gt 0 ]; do
   case "$1" in
     -h | --help) usage 0 ;;
     --show-phantoms) show_phantoms=1 ;;
     --strict-phantoms) show_phantoms=1 ;;
+    --skip-toolchain-check) toolchain_check=0 ;;
     --html) html=1 ;;
     --open)
       html=1
@@ -130,6 +140,42 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+# Name the compiler that measures this run, and say when a newer one exists.
+#
+# Region counting is a property of the nightly compiler, and continuous
+# integration installs the newest nightly every time. An older local nightly can
+# merge regions that the newer one counts apart, which reads here as full
+# coverage while the same gate fails in continuous integration. The version is
+# always printed, so a report can be compared with the one in the job log.
+report_toolchain() {
+  local version
+  version="$(rustc +nightly --version 2>/dev/null || true)"
+
+  if [ -z "$version" ]; then
+    echo "warning: no nightly toolchain found -- run 'rustup toolchain install nightly'" >&2
+    return 0
+  fi
+
+  echo "==> Toolchain: $version"
+
+  # The lookup needs the network, so it is skippable and never fatal.
+  [ "$toolchain_check" -eq 1 ] || return 0
+
+  local status
+  status="$(rustup check 2>/dev/null | grep '^nightly' || true)"
+
+  case "$status" in
+    *"update available"*)
+      echo "warning: a newer nightly is available -- $status" >&2
+      echo "         Continuous integration builds with the newest nightly, and the" >&2
+      echo "         region count depends on the compiler, so this report can disagree" >&2
+      echo "         with it. Run 'rustup update nightly' to compare like with like." >&2
+      ;;
+  esac
+}
+
+report_toolchain
 
 # Select scope: a single crate (fast) or the whole workspace (CI parity).
 # `scope_*` is handed to the Python reporter so its file list matches exactly the

--- a/scripts/git/coverage-missing.test.mjs
+++ b/scripts/git/coverage-missing.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * The uncovered-region reporter, `scripts/coverage-missing.sh`.
+ *
+ * The script measures with whatever nightly the machine holds, while continuous
+ * integration installs the newest nightly on every run. The region count is a
+ * property of that compiler, so an old local nightly makes the script report
+ * full coverage against a gate that fails in continuous integration -- which is
+ * exactly how fourteen uncovered regions reached a pull request. The script
+ * therefore names the compiler it used and warns when a newer one exists, and
+ * this suite holds that behaviour still.
+ *
+ * The real script runs against stubbed `rustc`, `rustup` and `cargo`, so what is
+ * asserted is what the script does, not what the machine happens to have.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  createWorkspace,
+  hermeticEnvironment,
+  missing,
+  pathVariable,
+  readLog,
+  repoRoot,
+  stubPath,
+  writeStubs,
+} from './lib/test-harness.mjs';
+
+const script = path.join(repoRoot, 'scripts/coverage-missing.sh');
+
+/** The script is bash, and the report it renders is python. */
+const NEEDS_BASH = missing('bash', 'python3');
+
+/** A `rustup check` line for a nightly that has nothing newer behind it. */
+const UP_TO_DATE =
+  'nightly-aarch64-apple-darwin - up to date: 1.100.0-nightly (cea272fa3 2026-09-07)';
+
+/** The same line for a nightly that is behind the one continuous integration installs. */
+const BEHIND =
+  'nightly-aarch64-apple-darwin - update available: 1.100.0-nightly (f248f4038 2026-09-05) -> 1.100.0-nightly (cea272fa3 2026-09-07)';
+
+/** A coverage export holding no measured file, which is the shortest clean run. */
+const EMPTY_EXPORT = '{"data":[{"files":[],"functions":[]}]}';
+
+/**
+ * Runs the real script with stubs for the three commands it starts.
+ *
+ * `rustcVersion` empty stands for a machine with no nightly installed, so the
+ * stub fails the way `rustc +nightly` fails there. `rustupCheck` is the line the
+ * script reads to decide whether the nightly is behind.
+ */
+function runScript({
+  rustcVersion = 'rustc 1.100.0-nightly (cea272fa3 2026-09-07)',
+  rustupCheck = UP_TO_DATE,
+  args = [],
+} = {}) {
+  const workspace = createWorkspace('stylex-coverage-missing-');
+
+  // The stub writes the export where the script asked for it, so the report
+  // renders from a real file rather than from a missing one.
+  const cargoBody = [
+    'output=""',
+    'previous=""',
+    'for argument in "$@"; do',
+    '  if [ "$previous" = "--output-path" ]; then output="$argument"; fi',
+    '  previous="$argument"',
+    'done',
+    `[ -n "$output" ] && printf '%s' '${EMPTY_EXPORT}' > "$output"`,
+    'exit 0',
+  ].join('\n');
+
+  writeStubs(workspace.bin, {
+    cargo: { body: cargoBody },
+    rustc: rustcVersion === '' ? { body: 'exit 1' } : { body: `printf '%s\\n' '${rustcVersion}'` },
+    rustup: { body: `printf '%s\\n' '${rustupCheck}'` },
+  });
+
+  const result = spawnSync('bash', [script, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: hermeticEnvironment({
+      [pathVariable]: stubPath(workspace.bin),
+      FAKE_COMMAND_LOG: workspace.log,
+    }),
+  });
+
+  return { result, log: readLog(workspace.log) };
+}
+
+void test('the run names the compiler that measured it', { skip: NEEDS_BASH }, () => {
+  const { result } = runScript();
+
+  assert.match(result.stdout, /[=]=> Toolchain: rustc 1\.100\.0-nightly \(cea272fa3 2026-09-07\)/);
+  assert.equal(result.status, 0);
+});
+
+void test('a nightly behind the newest one is a warning', { skip: NEEDS_BASH }, () => {
+  const { result } = runScript({ rustupCheck: BEHIND });
+
+  assert.match(result.stderr, /a newer nightly is available/);
+  assert.match(result.stderr, /rustup update nightly/);
+  // A warning only: the report still runs and still answers for the run it made.
+  assert.equal(result.status, 0);
+});
+
+void test('a nightly that is up to date says nothing', { skip: NEEDS_BASH }, () => {
+  const { result } = runScript({ rustupCheck: UP_TO_DATE });
+
+  assert.doesNotMatch(result.stderr, /newer nightly/);
+  assert.equal(result.status, 0);
+});
+
+void test('--skip-toolchain-check asks the network nothing', { skip: NEEDS_BASH }, () => {
+  const { result, log } = runScript({ rustupCheck: BEHIND, args: ['--skip-toolchain-check'] });
+
+  assert.doesNotMatch(log, /^rustup check/m, 'the lookup ran although it was turned off');
+  assert.doesNotMatch(result.stderr, /newer nightly/);
+  assert.match(result.stdout, /[=]=> Toolchain: /, 'the version is named even so');
+  assert.equal(result.status, 0);
+});
+
+void test(
+  'a machine with no nightly is told which command installs one',
+  { skip: NEEDS_BASH },
+  () => {
+    const { result } = runScript({ rustcVersion: '' });
+
+    assert.match(result.stderr, /no nightly toolchain found/);
+    assert.match(result.stderr, /rustup toolchain install nightly/);
+  }
+);

--- a/scripts/packages/build/rust.sh
+++ b/scripts/packages/build/rust.sh
@@ -19,7 +19,28 @@ if [ "$build_rust" = true ]; then
     verbose_flag=""
   fi
 
-  cargo_name=$(grep '^name' Cargo.toml | sed 's/name = "\(.*\)"/\1/')
+  # The `name` key of one manifest section. Both `[package]` and `[[bin]]` hold
+  # one, so each is read inside its own section: a plain `grep '^name'` would
+  # match either, and both where a manifest declares both.
+  manifest_name() {
+    awk -v want="$1" '
+      /^\[/ { section = $0 }
+      section == want && /^name[[:space:]]*=/ {
+        sub(/^name[[:space:]]*=[[:space:]]*"/, "")
+        sub(/".*$/, "")
+        print
+        exit
+      }
+    ' Cargo.toml
+  }
+
+  cargo_name=$(manifest_name "[package]")
+
+  # Cargo names a binary after its `[[bin]]` entry when the manifest declares
+  # one, and after the package otherwise. A library always uses the package
+  # name, so only the binary branch below consults this.
+  bin_name=$(manifest_name "[[bin]]")
+  : "${bin_name:=$cargo_name}"
 
   mkdir -p ./dist || handle_error "Failed to create the dist directory"
 
@@ -28,7 +49,7 @@ if [ "$build_rust" = true ]; then
     # Build the Rust application if there is no src/lib.rs file
     cargo build --release $verbose_flag || handle_error "Failed to build the Rust project"
 
-    built_path="$(find ../../target/release/"${cargo_name}" -type f | tail -1)"
+    built_path="$(find ../../target/release/"${bin_name}" -type f | tail -1)"
 
     if [ -z "$built_path" ]; then
       handle_error "Could not find a built file"


### PR DESCRIPTION
## Description

This pull request introduces several improvements and fixes to the handling of source code frames, diagnostic state, and test infrastructure in the StyleX Rust compiler and its test suites. The most significant changes clarify the logic for sourcing code for diagnostics, expand test coverage for key scenarios (including dynamic styles in nested scopes), and improve test utilities for running Node.js scripts. Additionally, documentation and code comments have been enhanced for clarity.

**Source code selection and diagnostics improvements:**

* The logic for determining which source code is quoted in diagnostics now prioritizes the file on disk when `useRealFileForSource` is enabled, falls back to the input text given to the compiler if the file is missing, and only prints the module from the AST as a last resort. This is reflected in both code and updated documentation/comments. [[1]](diffhunk://#diff-2a1a8db44c754e0b44101bd3920f21ae94fad534a0bd53e0764629f901c82f1dL687-R696) [[2]](diffhunk://#diff-2a1a8db44c754e0b44101bd3920f21ae94fad534a0bd53e0764629f901c82f1dL699-R716) [[3]](diffhunk://#diff-2a1a8db44c754e0b44101bd3920f21ae94fad534a0bd53e0764629f901c82f1dL715-L718) [[4]](diffhunk://#diff-dc7c30b4f9a4c9c61e67ff2a569bf1eccf0a6621727a9d4e25ca62c0133f88d8L446-R447)
* The `DiagnosticState` trait and its test double (`StateDouble`) now support retrieving the input source text and toggling disk reads, enabling more precise and configurable diagnostics in both production and tests. [[1]](diffhunk://#diff-ceb21a4c861abbcecd3824dd3ab1b52f9396100f79c77ee165167e86b22570e9R36-R48) [[2]](diffhunk://#diff-07fffd3fb2f2bfb146515551ca3a2b0ebe85d90858f111c6f2bf3a7e061fff08R21-R24) [[3]](diffhunk://#diff-07fffd3fb2f2bfb146515551ca3a2b0ebe85d90858f111c6f2bf3a7e061fff08R41-R56) [[4]](diffhunk://#diff-07fffd3fb2f2bfb146515551ca3a2b0ebe85d90858f111c6f2bf3a7e061fff08R96-R103)

**Testing infrastructure and coverage:**

* New and expanded tests ensure correct line resolution and quoting behavior in various scenarios, including when modules are memoized without text, when files are/aren't on disk, and for dynamic entries in nested scopes. This includes a major new test suite for dynamic stylex entries inside namespaces and IIFEs, verifying runtime behavior and regression coverage for #1303. [[1]](diffhunk://#diff-5e4a461cf1403b3b70bb4271c986a4e16624110db31744522119507987f31797R876-R978) [[2]](diffhunk://#diff-a46eea1b19faac9f7323178e9489f855d0aee957c757e867f57d0d89b29abe79R1-R179) [[3]](diffhunk://#diff-1b8def1afb8207b1664b7f165ad5bb780eef0a084938bd80cfaac45ded0cd0e1R159-R179)
* The test utility for running Node.js scripts now includes a `runNodeScriptOrThrow` helper that throws on failure and is used in relevant test suites for clearer error handling and assertions. [[1]](diffhunk://#diff-80cdf3d2e25a7596052cffb133f0e48f50e6f3b1f75e5d781a261a0ea2f0c22eL6-R13) [[2]](diffhunk://#diff-67d43941689778030158dd0d27ec4fbd41e575fbeeb59d131b1f4a8bc68939c6L9-R9) [[3]](diffhunk://#diff-67d43941689778030158dd0d27ec4fbd41e575fbeeb59d131b1f4a8bc68939c6R117-R131) [[4]](diffhunk://#diff-a9e9d0c7c2b96ea6fff1732a498039c9d7f5e014027e1a9f3a7be85d4947510dR87-R115)

**Documentation and code clarity:**

* Comments and documentation have been improved throughout, especially around how source code is selected for diagnostics and the defaulting behavior of certain options. [[1]](diffhunk://#diff-2a1a8db44c754e0b44101bd3920f21ae94fad534a0bd53e0764629f901c82f1dL687-R696) [[2]](diffhunk://#diff-bad1020fe866aeea92a50072cc9292dbd48d2a509404c16cf9834f8b61b4020dR46)

**Internal code improvements:**

* The state manager now computes AST hashes once per injection batch, improving efficiency when adding styles to inject.

**References:**
- Source code selection and diagnostics: [[1]](diffhunk://#diff-2a1a8db44c754e0b44101bd3920f21ae94fad534a0bd53e0764629f901c82f1dL687-R696) [[2]](diffhunk://#diff-2a1a8db44c754e0b44101bd3920f21ae94fad534a0bd53e0764629f901c82f1dL699-R716) [[3]](diffhunk://#diff-2a1a8db44c754e0b44101bd3920f21ae94fad534a0bd53e0764629f901c82f1dL715-L718) [[4]](diffhunk://#diff-ceb21a4c861abbcecd3824dd3ab1b52f9396100f79c77ee165167e86b22570e9R36-R48) [[5]](diffhunk://#diff-07fffd3fb2f2bfb146515551ca3a2b0ebe85d90858f111c6f2bf3a7e061fff08R21-R24) [[6]](diffhunk://#diff-07fffd3fb2f2bfb146515551ca3a2b0ebe85d90858f111c6f2bf3a7e061fff08R41-R56) [[7]](diffhunk://#diff-07fffd3fb2f2bfb146515551ca3a2b0ebe85d90858f111c6f2bf3a7e061fff08R96-R103) [[8]](diffhunk://#diff-dc7c30b4f9a4c9c61e67ff2a569bf1eccf0a6621727a9d4e25ca62c0133f88d8L446-R447)
- Testing infrastructure and coverage: [[1]](diffhunk://#diff-5e4a461cf1403b3b70bb4271c986a4e16624110db31744522119507987f31797R876-R978) [[2]](diffhunk://#diff-a46eea1b19faac9f7323178e9489f855d0aee957c757e867f57d0d89b29abe79R1-R179) [[3]](diffhunk://#diff-1b8def1afb8207b1664b7f165ad5bb780eef0a084938bd80cfaac45ded0cd0e1R159-R179) [[4]](diffhunk://#diff-80cdf3d2e25a7596052cffb133f0e48f50e6f3b1f75e5d781a261a0ea2f0c22eL6-R13) [[5]](diffhunk://#diff-67d43941689778030158dd0d27ec4fbd41e575fbeeb59d131b1f4a8bc68939c6L9-R9) [[6]](diffhunk://#diff-67d43941689778030158dd0d27ec4fbd41e575fbeeb59d131b1f4a8bc68939c6R117-R131) [[7]](diffhunk://#diff-a9e9d0c7c2b96ea6fff1732a498039c9d7f5e014027e1a9f3a7be85d4947510dR87-R115)
- Documentation and code clarity: [[1]](diffhunk://#diff-2a1a8db44c754e0b44101bd3920f21ae94fad534a0bd53e0764629f901c82f1dL687-R696) [[2]](diffhunk://#diff-bad1020fe866aeea92a50072cc9292dbd48d2a509404c16cf9834f8b61b4020dR46)
- Internal code improvements:

## Fixes

Fixes #1303

## Type of change

Please select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
