### PR TITLE
Enhance evaluator test coverage and refactor for clarity

### DIFF
--- a/crates/stylex-css-parser/CONTEXT.md
+++ b/crates/stylex-css-parser/CONTEXT.md
@@ -5,9 +5,9 @@ right of a colon, and the prelude of an at-rule such as `@media` — never a
 stylesheet, a selector or a whole rule.
 
 Only one item is reachable from the rest of the workspace:
-`last_media_query_wins_transform`. Every CSS type and property parser here is a
-port with no caller outside the crate, which is what
-**unreachable port** below is about.
+`last_media_query_wins_transform`. No plugin run enters any other parser here,
+so nothing the plugin emits is evidence about one, which is what
+**unwitnessed parser** below is about.
 
 ## Language
 
@@ -58,16 +58,23 @@ crate over, on the shorthand expansion path, where the unit is a
 formatter _there_ causes a divergence; reaching for it here closes one.
 _Avoid_: passthrough, verbatim, raw
 
-**Unreachable port**:
-A type in this crate whose reference counterpart the plugin never runs, so its
-behaviour cannot be settled by comparing output. The rule is about evidence: a
-claim that some colour grammar matches the reference compiler cannot be checked,
-because the plugin normalizes a colour as _text_ and never rebuilds it from
-parsed channels — `lch(50 50% 180)` comes out unchanged, the percentage echoed
-rather than scaled. Where a colour _does_ reach emitted text — the comma
-spelling, an unbounded alpha, a fractional `rgb()` channel — the plugin can be
-run end to end, and was.
-_Avoid_: dead code, unused type, aspirational port
+**Unwitnessed parser**:
+A parser that no plugin run enters — a CSS type, a property parser, or a reader
+one of them is built from. No output is evidence about it, so its behaviour
+cannot be settled by comparing output. The colour types are the case that
+matters, for two reasons. The plugin normalizes a colour as _text_ and never
+rebuilds it from parsed channels — `lch(50 50% 180)` comes out unchanged, the
+percentage echoed rather than scaled. The reference compiler's
+`Oklch.parser`/`Oklab.parser` also refuse every input: an optional whitespace
+separator consumes the space that the same sequence then demands as an element.
+A claim that some colour grammar here matches the reference compiler is
+therefore uncheckable.
+
+The rule is about evidence, not about reach. Some colour behaviour _does_ show
+in emitted text, because the text path carries it — the comma spelling, an
+unbounded alpha, a fractional `rgb()` channel. Those claims were settled end to
+end, and are parity. The parsers below them stay unwitnessed.
+_Avoid_: dead code, unused type, unreachable port, aspirational port
 
 **Precision suite**:
 A test file named for what it pins rather than for an upstream test file, with

--- a/crates/stylex-css-parser/src/css_types/alpha_value.rs
+++ b/crates/stylex-css-parser/src/css_types/alpha_value.rs
@@ -104,12 +104,12 @@ pub fn alpha_as_number() -> TokenParser<f64> {
 /// the source: `-0.5` arrives as `value: -0.5` *and* `signCharacter: '-'`, so
 /// the parser answers `+0.5`, and `-50%` likewise answers `+0.5`.
 ///
-/// This reader keeps a negative alpha negative. Nothing in the plugin reaches it
-/// -- see the *Unreachable port* entry in `CONTEXT.md` -- so no emitted CSS
-/// differs, and reproducing a sign bug in a type with no caller would be the
-/// wrong way to close the gap. What is fixed here is the claim: this is a
-/// divergence, and the next person to add a caller needs to know that rather
-/// than trust a comment that said "parity".
+/// This reader keeps a negative alpha negative. No plugin run enters it, so no
+/// emitted CSS differs and no output is evidence about it -- see the
+/// *Unwitnessed parser* entry in `CONTEXT.md`. Reproducing a sign bug in a
+/// reader with no caller would be the wrong way to close the gap. What is fixed
+/// here is the claim: this is a divergence, and the next person to add a caller
+/// needs to know that rather than trust a comment that said "parity".
 ///
 /// [`crate::css_types::common_types::NumberOrPercentage`] inherits the same gap
 /// through its number arm, and says so.

--- a/crates/stylex-css-parser/src/tests/css_types/color_test.rs
+++ b/crates/stylex-css-parser/src/tests/css_types/color_test.rs
@@ -870,8 +870,8 @@ mod the_optional_alpha_rewind {
     }
   }
   /// The reference compiler's own `lch(50% 100 270deg)` case, ported -- but as
-  /// characterization rather than parity, because this type is an
-  /// [unreachable port](../../CONTEXT.md).
+  /// characterization rather than parity, because this is an
+  /// [unwitnessed parser](../../../CONTEXT.md).
   ///
   /// Two different answers, and neither is a defect in the other:
   ///


### PR DESCRIPTION
The glossary defined a domain term called `Unreachable port`: a type whose behaviour cannot be settled by comparing output. The definition was sound and the term was used, but the name described the type by a relationship to another implementation rather than by what the type is.

The term is now `Unwitnessed parser`. What makes such a parser unsettleable is that no plugin run enters it, so nothing the plugin emits is evidence about it. That statement holds inside this crate and needs no second implementation to be read. `parser` rather than `type` for the head noun, because the crate already defines `CSS type` for a grammar production and this set is wider: a CSS type, a property parser, or a hand-written reader one of them is built from. The old name goes on the entry's avoid list, so a reader who searches for it arrives at the new one.

The crate header moved with the term. It said every CSS type and property parser has no caller outside the crate, "which is what unreachable port below is about" -- true of the old name, but callerlessness is the mechanism and not the rule. The header now states the chain, and the entry closes on the same point: some colour behaviour does show in emitted text through the text path and was settled end to end, while the parsers below it stay unwitnessed.

The definition carries both of its worked reasons again. The second one, that the reference compiler's oklch and oklab parsers refuse every input, was lost to the glossary shortening in 72e0ce69a and is confirmed against the reference source. Its cause is corrected as well: the entry used to blame the lightness reader's own optional whitespace prefix, but the enclosing sequence carries an optional whitespace separator between elements, and that separator consumes the space before the reader's prefix is consulted. The sequence then demands whitespace as an element and finds none. Either step alone gives the same refusal, so only the named cause changes.

Three use sites agree with the new name. The characterization note on the lch(50% 100 270deg) case also linked one directory too shallow, so the reader could not reach the definition; the depth is corrected.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
