### PR TITLE
fix(stylexswc/rs-compiler): keep a base refusal out of the comparison only

### DIFF
--- a/crates/stylex-rs-compiler/benchmark/__tests__/bench-budget.test.ts
+++ b/crates/stylex-rs-compiler/benchmark/__tests__/bench-budget.test.ts
@@ -21,6 +21,7 @@ import {
   type RawStatsFile,
   type SubjectDescriptor,
 } from '../lib/types.js';
+import { fixtureMeasuredByOne } from './helpers/raw-fixtures.js';
 
 const BASE: SubjectDescriptor = { label: 'base', version: '0.18.2', resolvedFrom: '/base' };
 const CANDIDATE: SubjectDescriptor = {
@@ -77,6 +78,19 @@ function fixture(name: string, candidateP95PerRound: readonly number[]): Fixture
       confidence: { point: 0.5, lower: 0.45, upper: 0.55 },
     },
   };
+}
+
+/** The same fixture, measured by the candidate alone. */
+function candidateOnlyFixture(
+  name: string,
+  candidateP95PerRound: readonly number[]
+): FixtureRawStats {
+  return fixtureMeasuredByOne({
+    name,
+    label: CANDIDATE.label,
+    perRound: candidateP95PerRound,
+    samplesOf: samples,
+  });
 }
 
 function rawStats(
@@ -194,6 +208,55 @@ describe('evaluateBudget — coverage', () => {
     expect(report.problems).toContainEqual({
       kind: 'extra-entry',
       message: 'budget entry "removed" was not measured in this run',
+      severity: 'failure',
+    });
+  });
+
+  // The release leg compares against the last published version, which cannot
+  // compile a fixture that prices a feature it does not carry. That fixture is
+  // measured for the candidate alone, and the ceilings describe the candidate,
+  // so it is checked like any other.
+  test('a fixture only the candidate measured is held to its ceiling', () => {
+    const report = evaluateBudget(
+      rawStats([fixture('card', [1]), candidateOnlyFixture('engine-fold', [1])]),
+      budget([entry('card', 2), entry('engine-fold', 2)])
+    );
+
+    expect(report.problems).toStrictEqual([]);
+    expect(report.status).toBe('pass');
+    expect(report.fixtures[1]?.name).toBe('engine-fold');
+    expect(report.fixtures[1]?.status).toBe('pass');
+  });
+
+  test('the same fixture breaches its ceiling like any other', () => {
+    const report = evaluateBudget(
+      rawStats([fixture('card', [1]), candidateOnlyFixture('engine-fold', [9])]),
+      budget([entry('card', 2), entry('engine-fold', 2)])
+    );
+
+    expect(report.status).toBe('failed');
+    expect(report.problems).toContainEqual({
+      kind: 'breach',
+      message: 'engine-fold: p95 9.0000 ms exceeds ceiling 2.0000 ms',
+      severity: 'failure',
+    });
+  });
+
+  // Ceilings that describe the base cannot be checked against a fixture the
+  // base did not measure. The entry is reported as one nothing measured, which
+  // is the reading that stops the release rather than one that reads a number
+  // off the wrong subject.
+  test('a base budget reports a candidate-only fixture as unmeasured', () => {
+    const report = evaluateBudget(
+      rawStats([fixture('card', [1]), candidateOnlyFixture('engine-fold', [1])]),
+      { ...budget([entry('card', 4), entry('engine-fold', 4)]), subject: 'base' }
+    );
+
+    expect(report.subject.label).toBe(BASE.label);
+    expect(report.fixtures.map(measured => measured.name)).toStrictEqual(['card']);
+    expect(report.problems).toContainEqual({
+      kind: 'extra-entry',
+      message: 'budget entry "engine-fold" was not measured in this run',
       severity: 'failure',
     });
   });

--- a/crates/stylex-rs-compiler/benchmark/__tests__/helpers/count-rules-probe.mjs
+++ b/crates/stylex-rs-compiler/benchmark/__tests__/helpers/count-rules-probe.mjs
@@ -1,0 +1,58 @@
+/**
+ * Asks for one subject's rule count, one way or the other, and prints it.
+ *
+ * Run as a process of its own by `subject-process.test.ts`, because what the
+ * case is about is the stderr of the process that asks. The compiler writes to
+ * that file descriptor itself, so nothing inside the test process can see it.
+ *
+ * Usage: node <this file> <packageDir> <child|in-process> <code>
+ * `code` is the module the subject is asked to compile.
+ */
+
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [, , packageDir, mode, code] = process.argv;
+
+// A URL and not a path: an absolute path is not a module specifier on Windows.
+const lib = name => pathToFileURL(path.join(packageDir, 'benchmark', 'lib', name)).href;
+
+const { countRulesInChild } = await import(lib('subject-process.ts'));
+const { countRulesInProcess } = await import(lib('runner.ts'));
+const { loadSubject } = await import(lib('subjects.ts'));
+
+const fixture = {
+  name: 'probe',
+  filePath: path.join(packageDir, 'benchmark', 'perf_fixtures', 'create-basic.js'),
+  code,
+  weight: 'standard',
+  category: 'perf',
+  batchSize: 1,
+};
+
+const stylexOptions = {
+  dev: false,
+  treeshakeCompensation: true,
+  unstable_moduleResolution: { type: 'haste', rootDir: packageDir },
+};
+
+if (mode === 'child') {
+  const counts = countRulesInChild({
+    subject: { label: 'subject', packageDir },
+    fixtures: [fixture],
+    stylexOptions,
+    timeBudgetMs: 10,
+  });
+
+  console.log(JSON.stringify(counts.probe));
+} else {
+  const subject = await loadSubject({ label: 'subject', packageDir });
+
+  try {
+    console.log(JSON.stringify(countRulesInProcess(stylexOptions)(subject, fixture)));
+  } catch (error) {
+    // The same shape a refusal has when a child reports it, so the case can
+    // hold both answers to one assertion.
+    console.log(JSON.stringify({ refusal: error.message.split('\n')[0] }));
+  }
+}

--- a/crates/stylex-rs-compiler/benchmark/__tests__/helpers/raw-fixtures.ts
+++ b/crates/stylex-rs-compiler/benchmark/__tests__/helpers/raw-fixtures.ts
@@ -1,0 +1,37 @@
+/**
+ * Builders for the raw-stats shapes a test states by hand.
+ */
+
+import type { FixtureRawStats, RawLatencySamples } from '../../lib/types.js';
+
+export interface OneSubjectFixture {
+  name: string;
+  /** The subject that measured it. No other subject appears in its rounds. */
+  label: string;
+  /** One value per round, in the order the rounds carry. */
+  perRound: readonly number[];
+  /** How a value becomes samples. Each suite states latency its own way. */
+  samplesOf: (value: number) => RawLatencySamples;
+}
+
+/**
+ * A fixture only one subject measured.
+ *
+ * What the release leg writes for a fixture the published base cannot compile:
+ * samples for one subject, and no paired block, because there is no pair. The
+ * budget suite and the verdict suite both read such a fixture, so the shape is
+ * stated one time here.
+ */
+export function fixtureMeasuredByOne(input: OneSubjectFixture): FixtureRawStats {
+  return {
+    name: input.name,
+    weight: 'standard',
+    category: 'transform',
+    batchSize: 1,
+    rounds: input.perRound.map((value, index) => ({
+      round: index,
+      subjectOrder: [input.label],
+      perSubject: { [input.label]: input.samplesOf(value) },
+    })),
+  };
+}

--- a/crates/stylex-rs-compiler/benchmark/__tests__/release-leg.test.ts
+++ b/crates/stylex-rs-compiler/benchmark/__tests__/release-leg.test.ts
@@ -1,0 +1,169 @@
+/**
+ * The release leg, from the producer to the two gates that read it.
+ *
+ * The release benchmark compares the candidate against the last published
+ * version, which is behind by whole features, so `--allow-base-refusals` lets
+ * a fixture the published version cannot compile leave the comparison. The
+ * absolute p95 budget is about the candidate alone and has a committed ceiling
+ * for every fixture in the manifest, so a fixture that left the comparison and
+ * the run together reached the budget as an entry nothing measured.
+ *
+ * These assertions run the real producer and hand what it wrote to the real
+ * consumers, which is the only place the two readings meet.
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  BUDGET_SCHEMA_VERSION,
+  evaluateBudget,
+  type BudgetEntry,
+  type BudgetFile,
+} from '../lib/budget.js';
+import { runRounds, type UncomparedFixture } from '../lib/runner.js';
+import { createSubject } from '../lib/subjects.js';
+import {
+  RAW_STATS_SCHEMA_VERSION,
+  type BootstrapConfig,
+  type FixtureDescriptor,
+  type RawStatsEnvironment,
+  type RawStatsFile,
+} from '../lib/types.js';
+import { evaluateRawStats, renderVerdictMarkdown } from '../lib/verdict.js';
+
+const SHARED: FixtureDescriptor = {
+  name: 'card',
+  filePath: '/fixtures/card.js',
+  code: 'const styles = 1;',
+  weight: 'standard',
+  category: 'transform',
+  batchSize: 1,
+};
+
+/** A fixture that prices a feature the published base does not carry. */
+const NEW_FEATURE: FixtureDescriptor = { ...SHARED, name: 'Feature - engine fold' };
+
+const BENCH = { retainSamples: true, warmup: false, time: 0, iterations: 1 } as const;
+
+const ENVIRONMENT: RawStatsEnvironment = {
+  timestamp: '2026-09-12T00:00:00.000Z',
+  node: 'v24.18.0',
+  os: { type: 'Linux', release: '6.11.0', arch: 'x64', platform: 'linux' },
+  cpu: { model: 'AMD EPYC 7763', cores: 4 },
+  memoryGB: 16,
+  packageVersion: '0.19.0-rc.3',
+  target: 'x86_64-unknown-linux-gnu',
+  toolchain: {},
+  runnerImage: 'ubuntu24',
+  runnerImageVersion: '20260803.1.0',
+};
+
+function entry(name: string): BudgetEntry {
+  return {
+    name,
+    ceilingMs: 1000,
+    observedUpperMs: 800,
+    headroom: 1.25,
+    runs: 5,
+    reviewedAt: '2026-09-10',
+    evidence: 'runs 1-5 of workflow 34710120184',
+  };
+}
+
+const BUDGET: BudgetFile = {
+  schemaVersion: BUDGET_SCHEMA_VERSION,
+  state: 'enforced',
+  subject: 'candidate',
+  statistic: 'median-of-round-p95',
+  canonical: {
+    target: 'x86_64-unknown-linux-gnu',
+    node: 'v24.18.0',
+    runner: 'ubuntu-latest',
+    runnerImages: ['ubuntu24'],
+    runnerImageVersions: ['20260803.1.0'],
+  },
+  policy: {
+    seeding: 'seed from repeated clean runs',
+    increases: 'reviewed change with evidence',
+    decreases: 'ratchet proven improvements',
+    automation: 'never written by a task',
+    environment: 'canonical target, Node, and image only',
+  },
+  entries: [entry(SHARED.name), entry(NEW_FEATURE.name)],
+};
+
+const BOOTSTRAP: BootstrapConfig = { seed: 42, resamples: 200, confidence: 0.95 };
+
+interface ReleaseRun {
+  rawStats: RawStatsFile;
+  uncompared: readonly UncomparedFixture[];
+}
+
+/** The release leg's own run: a published base that refuses the new fixture. */
+async function releaseRun(): Promise<ReleaseRun> {
+  const base = createSubject(
+    { label: 'npm@0.18.6', version: '0.18.6', resolvedFrom: '/npm' },
+    fixture => {
+      if (fixture.name === NEW_FEATURE.name) {
+        throw new Error("[StyleX] The method 'trim' is not yet supported in static evaluation.");
+      }
+      return 1;
+    }
+  );
+  const candidate = createSubject(
+    { label: 'candidate@0.19.0-rc.3', version: '0.19.0-rc.3', resolvedFrom: '/candidate' },
+    () => 1
+  );
+
+  const result = await runRounds({
+    subjects: [base, candidate],
+    fixtures: [SHARED, NEW_FEATURE],
+    stylexOptions: {},
+    rounds: 2,
+    seed: 1,
+    standardBench: BENCH,
+    heavyBench: BENCH,
+    requiredSubject: candidate.descriptor.label,
+  });
+
+  return {
+    rawStats: {
+      schemaVersion: RAW_STATS_SCHEMA_VERSION,
+      environment: ENVIRONMENT,
+      subjects: [base.descriptor, candidate.descriptor],
+      fixtures: result.fixtures,
+    },
+    uncompared: result.uncompared,
+  };
+}
+
+describe('release leg — a base that refuses a fixture', () => {
+  test('the candidate is still measured for the absolute budget', async () => {
+    const report = evaluateBudget((await releaseRun()).rawStats, BUDGET);
+
+    expect(report.problems).toEqual([]);
+    expect(report.status).toBe('pass');
+    expect(report.fixtures.map(fixture => fixture.name)).toContain(NEW_FEATURE.name);
+  });
+
+  test('the run says which fixture lost its comparison, and why', async () => {
+    expect((await releaseRun()).uncompared).toEqual([
+      {
+        fixture: NEW_FEATURE.name,
+        subject: 'npm@0.18.6',
+        reason: "[StyleX] The method 'trim' is not yet supported in static evaluation.",
+      },
+    ]);
+  });
+
+  test('the verdict scores what it can compare and names what it cannot', async () => {
+    const report = evaluateRawStats((await releaseRun()).rawStats, { bootstrap: BOOTSTRAP });
+
+    expect(report.suiteStatus).toBe('pass');
+    expect(report.fixtures.map(fixture => fixture.name)).toStrictEqual([SHARED.name]);
+    expect(report.uncompared).toStrictEqual([NEW_FEATURE.name]);
+    expect(renderVerdictMarkdown(report)).toContain(
+      `Not compared (measured for candidate@0.19.0-rc.3 only): ${NEW_FEATURE.name}`
+    );
+  });
+});

--- a/crates/stylex-rs-compiler/benchmark/__tests__/release-leg.test.ts
+++ b/crates/stylex-rs-compiler/benchmark/__tests__/release-leg.test.ts
@@ -26,6 +26,7 @@ import {
   RAW_STATS_SCHEMA_VERSION,
   type BootstrapConfig,
   type FixtureDescriptor,
+  type RawLatencySamples,
   type RawStatsEnvironment,
   type RawStatsFile,
 } from '../lib/types.js';
@@ -94,6 +95,26 @@ const BUDGET: BudgetFile = {
 
 const BOOTSTRAP: BootstrapConfig = { seed: 42, resamples: 200, confidence: 0.95 };
 
+/**
+ * Latency samples that all read `value`.
+ *
+ * The rounds below are handed in rather than timed. What this file is about is
+ * which fixtures a run plans, and for which subjects -- not how fast they are.
+ * A real timing of two subjects that both answer `1` is the noise of the clock,
+ * so a ratio taken from it crosses the fail threshold on some machines and not
+ * on others, and the suite status would say nothing about this code.
+ */
+function samplesOf(value: number): RawLatencySamples {
+  return {
+    samples: [value, value, value],
+    p50: value,
+    p95: value,
+    rme: 0,
+    samplesCount: 3,
+    opsPerSec: 1000 / value,
+  };
+}
+
 interface ReleaseRun {
   rawStats: RawStatsFile;
   uncompared: readonly UncomparedFixture[];
@@ -124,6 +145,13 @@ async function releaseRun(): Promise<ReleaseRun> {
     standardBench: BENCH,
     heavyBench: BENCH,
     requiredSubject: candidate.descriptor.label,
+    // The rule counts stay real, because the refusal they carry is what this
+    // file is about. Only the timing is stated, so every number below is the
+    // same on every machine.
+    measureRound: (fixture, order) =>
+      Promise.resolve(
+        Object.fromEntries(order.map(subject => [subject.descriptor.label, samplesOf(0.5)]))
+      ),
   });
 
   return {

--- a/crates/stylex-rs-compiler/benchmark/__tests__/runner.test.ts
+++ b/crates/stylex-rs-compiler/benchmark/__tests__/runner.test.ts
@@ -157,6 +157,16 @@ async function refused(subjectRun: SubjectRun): Promise<Error> {
   return failure;
 }
 
+describe('runRounds preconditions', () => {
+  // Stated by the runner rather than left to the plan, whose own failure is
+  // about a base that refuses every fixture and would name none here.
+  test('refuses a run with no fixture to measure', async () => {
+    await expect(run([subject('base')], 1, 1, { fixtures: [] })).rejects.toThrow(
+      'runRounds requires at least one fixture'
+    );
+  });
+});
+
 describe('runRounds strategies', () => {
   // The two steps that touch a subject are handed in, so the split runner can
   // measure in another process while everything else stays this code.
@@ -326,26 +336,31 @@ describe('runRounds paired roles', () => {
  * other measurement -- which is what one `.trim()` in `engine-fold.js` did to
  * the whole publish benchmark. The gate that matters is the candidate: a
  * fixture *it* refuses is a regression in the code under measurement.
+ *
+ * What the fixture loses is the comparison, not the run. The absolute p95
+ * budget holds a ceiling for every fixture in the manifest and reads the
+ * candidate alone, so a fixture dropped from the run reached that check as an
+ * entry nothing measured and failed the release a second way.
  */
 describe('runRounds fixture exclusion', () => {
-  test('a healthy run excludes nothing', async () => {
-    const { fixtures, excluded } = await pairedRun(subject('base'));
+  test('a healthy run compares every fixture', async () => {
+    const { fixtures, uncompared } = await pairedRun(subject('base'));
 
-    expect(excluded).toEqual([]);
+    expect(uncompared).toEqual([]);
     expect(fixtures.map(fixture => fixture.name)).toEqual(['card', 'counter']);
   });
 
-  test('drops a fixture the base cannot compile and keeps the rest', async () => {
+  test('keeps a fixture the base cannot compile, for the candidate alone', async () => {
     const base = subjectRefusing(
       'base',
       'card',
       refusingWith("[StyleX] The method 'trim' is not yet supported in static evaluation.")
     );
 
-    const { fixtures, excluded } = await pairedRun(base);
+    const { fixtures, uncompared } = await pairedRun(base);
 
-    expect(fixtures.map(fixture => fixture.name)).toEqual(['counter']);
-    expect(excluded).toEqual([
+    expect(fixtures.map(fixture => fixture.name)).toEqual(['card', 'counter']);
+    expect(uncompared).toEqual([
       {
         fixture: 'card',
         subject: 'base',
@@ -354,9 +369,25 @@ describe('runRounds fixture exclusion', () => {
     ]);
   });
 
-  // A compiler refusal carries a code frame under its sentence. Beside a
-  // dropped fixture the sentence is the whole of what a reader needs, and the
-  // frame would bury the fixture names the report is made of.
+  // The candidate's samples are what the absolute budget reads, and the absent
+  // base is what tells the verdict engine there is no ratio to take.
+  test('records the candidate and nothing else for a fixture the base refused', async () => {
+    const base = subjectRefusing('base', 'card', refusingWith('refused'));
+
+    const { fixtures } = await pairedRun(base);
+    const card = fixtures.find(fixture => fixture.name === 'card');
+
+    expect(card?.rounds[0]?.subjectOrder).toEqual(['candidate']);
+    expect(card?.rounds[0]?.perSubject.candidate).toBeDefined();
+    expect(card?.rounds[0]?.perSubject.base).toBeUndefined();
+    // No roles, because there is no pair. The budget resolves its subject from
+    // the fixtures that do carry them.
+    expect(card?.paired).toBeUndefined();
+  });
+
+  // A compiler refusal carries a code frame under its sentence. Beside an
+  // uncompared fixture the sentence is the whole of what a reader needs, and
+  // the frame would bury the fixture names the report is made of.
   test('reports only the first line of what the base said', async () => {
     const base = subjectRefusing(
       'base',
@@ -364,41 +395,41 @@ describe('runRounds fixture exclusion', () => {
       refusingWith('  refused\n  --> file.js:1:1\n   |\n 1 | code\n')
     );
 
-    const { excluded } = await pairedRun(base);
+    const { uncompared } = await pairedRun(base);
 
-    expect(excluded[0]?.reason).toBe('refused');
+    expect(uncompared[0]?.reason).toBe('refused');
   });
 
   test('names the refusal when the base threw something that is not an Error', async () => {
     const base = subjectRefusing('base', 'card', () => raise('plain string'));
 
-    const { excluded } = await pairedRun(base);
+    const { uncompared } = await pairedRun(base);
 
-    expect(excluded[0]?.reason).toBe('plain string');
+    expect(uncompared[0]?.reason).toBe('plain string');
   });
 
   test('stands in for a refusal that carries no message at all', async () => {
     const base = subjectRefusing('base', 'card', refusingWith(''));
 
-    const { excluded } = await pairedRun(base);
+    const { uncompared } = await pairedRun(base);
 
-    expect(excluded[0]?.reason).toBe('refused without a message');
+    expect(uncompared[0]?.reason).toBe('refused without a message');
   });
 
   // A base that compiles a fixture to nothing cannot measure it either: the
   // zero-rule guard reads the same either way, and reporting the count keeps
   // the two apart for whoever has to read the line.
-  test('drops a fixture the base compiles to no rules', async () => {
-    const { fixtures, excluded } = await pairedRun(subjectRefusing('base', 'card', () => 0));
+  test('leaves the comparison of a fixture the base compiles to no rules', async () => {
+    const { fixtures, uncompared } = await pairedRun(subjectRefusing('base', 'card', () => 0));
 
-    expect(fixtures.map(fixture => fixture.name)).toEqual(['counter']);
-    expect(excluded[0]?.reason).toBe('emitted 0 StyleX rules');
+    expect(fixtures.map(fixture => fixture.name)).toEqual(['card', 'counter']);
+    expect(uncompared[0]?.reason).toBe('emitted 0 StyleX rules');
   });
 
-  test('drops a fixture whose base rule count is not a number at all', async () => {
-    const { excluded } = await pairedRun(subjectRefusing('base', 'card', () => Number.NaN));
+  test('leaves the comparison when the base rule count is not a number at all', async () => {
+    const { uncompared } = await pairedRun(subjectRefusing('base', 'card', () => Number.NaN));
 
-    expect(excluded[0]?.reason).toBe('emitted NaN StyleX rules');
+    expect(uncompared[0]?.reason).toBe('emitted NaN StyleX rules');
   });
 
   // The one refusal that must still stop the run. Reported against the
@@ -459,8 +490,8 @@ describe('runRounds fixture exclusion', () => {
     );
   });
 
-  // A large manifest where one entry leaves: the report must name that entry
-  // and nothing else, and the surviving fixtures must keep manifest order.
+  // A large manifest where one entry loses its base: the report must name that
+  // entry and nothing else, and every fixture must keep manifest order.
   test('keeps manifest order across a large manifest with one exclusion', async () => {
     const many = Array.from({ length: 60 }, (_index, position) => ({
       ...FIXTURE,
@@ -468,29 +499,31 @@ describe('runRounds fixture exclusion', () => {
     }));
     const base = subjectRefusing('base', 'fixture-31', refusingWith('refused'));
 
-    const { fixtures, excluded } = await run([base, subject('candidate')], 1, 1, {
+    const { fixtures, uncompared } = await run([base, subject('candidate')], 1, 1, {
       fixtures: many,
       requiredSubject: 'candidate',
     });
 
-    expect(excluded).toHaveLength(1);
-    expect(excluded[0]?.fixture).toBe('fixture-31');
-    expect(fixtures).toHaveLength(59);
-    expect(fixtures.map(fixture => fixture.name)).toEqual(
-      many.map(fixture => fixture.name).filter(name => name !== 'fixture-31')
-    );
+    expect(uncompared).toHaveLength(1);
+    expect(uncompared[0]?.fixture).toBe('fixture-31');
+    expect(fixtures).toHaveLength(60);
+    expect(fixtures.map(fixture => fixture.name)).toEqual(many.map(fixture => fixture.name));
   });
 
-  // Two subjects refusing the same fixture is one exclusion. A second line
-  // saying the same thing adds no information, and the fixture is gone either
-  // way -- so the count is what a reader can trust.
+  // Two subjects refusing the same fixture is one report. A second line saying
+  // the same thing adds no information, and the fixture loses its comparison
+  // either way -- so the count is what a reader can trust. Both refusing
+  // subjects still leave the fixture, which is what the round names.
   test('reports one exclusion when every non-gate subject refuses the same fixture', async () => {
     const refuse = refusingWith('refused');
-    const { excluded } = await pairedRun(
+    const { fixtures, uncompared } = await pairedRun(
       subjectRefusing('base-a', 'card', refuse),
       subjectRefusing('base-b', 'card', refuse)
     );
 
-    expect(excluded).toEqual([{ fixture: 'card', subject: 'base-a', reason: 'refused' }]);
+    expect(uncompared).toEqual([{ fixture: 'card', subject: 'base-a', reason: 'refused' }]);
+    expect(fixtures.find(fixture => fixture.name === 'card')?.rounds[0]?.subjectOrder).toEqual([
+      'candidate',
+    ]);
   });
 });

--- a/crates/stylex-rs-compiler/benchmark/__tests__/subject-process.test.ts
+++ b/crates/stylex-rs-compiler/benchmark/__tests__/subject-process.test.ts
@@ -255,6 +255,58 @@ describe('callWorker', () => {
   });
 });
 
+/**
+ * Where the compiler error beside a refusal goes.
+ *
+ * The addon draws a code frame on the process stderr before it refuses, and
+ * that stream is the release log. A leg that expects the refusal -- the base is
+ * a published version behind this build -- printed a compiler error for a
+ * fixture it went on to report under `Not compared`, so a run that did nothing
+ * wrong read as a failed one.
+ *
+ * Measured from a process of this suite's own, because the addon writes to the
+ * file descriptor and not through anything this process can replace.
+ */
+describe('countRulesInChild', () => {
+  /** The module the compiler refuses, and the sentence it refuses it with. */
+  const REFUSED_CODE =
+    "import * as stylex from '@stylexjs/stylex';\n" +
+    'export const s = stylex.create({ a: { width: someUnknown.value } });\n';
+  const REFUSAL = '[StyleX] a > width > Referenced constant is not defined.';
+
+  const PROBE = path.join(import.meta.dirname, 'helpers', 'count-rules-probe.mjs');
+
+  function askForTheCount(mode: 'child' | 'in-process'): { count: unknown; stderr: string } {
+    const result = spawnSync(
+      process.execPath,
+      [...workerExecArgv(), PROBE, packageDir, mode, REFUSED_CODE],
+      { encoding: 'utf8' }
+    );
+
+    if (result.stdout.trim() === '') {
+      throw new Error(`the probe printed no answer:\n${result.stderr}`);
+    }
+
+    return { count: JSON.parse(result.stdout) as unknown, stderr: result.stderr };
+  }
+
+  // The control. Without it a probe that answered nothing at all would pass the
+  // case below, because it too writes no compiler error.
+  test.runIf(built)('the same count taken in this process prints the error', () => {
+    const asked = askForTheCount('in-process');
+
+    expect(asked.count).toStrictEqual({ refusal: REFUSAL });
+    expect(asked.stderr).toContain('error: [StyleX]');
+  });
+
+  test.runIf(built)('answers the refusal and writes nothing to the caller stderr', () => {
+    const asked = askForTheCount('child');
+
+    expect(asked.count).toStrictEqual({ refusal: REFUSAL });
+    expect(asked.stderr).toBe('');
+  });
+});
+
 describe('bench-worker', () => {
   /** The modules the reader child below loads, in the order it loads them. */
   const readerModules = ['lib/subject-process.js', 'lib/native-bindings.js'];

--- a/crates/stylex-rs-compiler/benchmark/__tests__/verdict.test.ts
+++ b/crates/stylex-rs-compiler/benchmark/__tests__/verdict.test.ts
@@ -24,6 +24,7 @@ import {
   reproducedFailures,
   type VerdictThresholds,
 } from '../lib/verdict.js';
+import { fixtureMeasuredByOne } from './helpers/raw-fixtures.js';
 
 const BASE: SubjectDescriptor = { label: 'base', version: '1.0.0', resolvedFrom: '/base' };
 const CANDIDATE: SubjectDescriptor = {
@@ -89,6 +90,16 @@ function rawStats(
     subjects,
     fixtures,
   };
+}
+
+/** The same fixture as `fixture`, measured by the candidate alone. */
+function candidateOnlyFixture(name: string, candidatePerRound: readonly number[]): FixtureRawStats {
+  return fixtureMeasuredByOne({
+    name,
+    label: CANDIDATE.label,
+    perRound: candidatePerRound,
+    samplesOf: samplesFor,
+  });
 }
 
 const tightThresholds: VerdictThresholds = {
@@ -429,6 +440,82 @@ describe('evaluateRawStats — validation', () => {
     ).toThrow(/perSubject\["candidate"\] must be an object/);
   });
 
+  // The round names who was measured, so these are the ways it can lie about
+  // that: a name the file never declared, a name given two times, and no name
+  // at all. Each would leave a reader unable to say what the samples describe.
+  test('rejects a round that names a subject the file does not declare', () => {
+    const valid = fixture('x', [1], [1]);
+    const file = rawStats([
+      {
+        ...valid,
+        rounds: [
+          {
+            round: 0,
+            subjectOrder: [BASE.label, 'ghost'],
+            perSubject: valid.rounds[0]!.perSubject,
+          },
+        ],
+      },
+    ]);
+
+    expect(() => evaluateRawStats(file, { bootstrap: BOOTSTRAP })).toThrow(
+      /names "ghost", which is not a subject of this file/
+    );
+  });
+
+  test('rejects a round that names one subject two times', () => {
+    const valid = fixture('x', [1], [1]);
+    const file = rawStats([
+      {
+        ...valid,
+        rounds: [
+          {
+            round: 0,
+            subjectOrder: [BASE.label, BASE.label],
+            perSubject: valid.rounds[0]!.perSubject,
+          },
+        ],
+      },
+    ]);
+
+    expect(() => evaluateRawStats(file, { bootstrap: BOOTSTRAP })).toThrow(
+      /subjectOrder must name each subject at most one time/
+    );
+  });
+
+  test('rejects a round that names no subject at all', () => {
+    const valid = fixture('x', [1], [1]);
+    const file = rawStats([{ ...valid, rounds: [{ round: 0, subjectOrder: [], perSubject: {} }] }]);
+
+    expect(() => evaluateRawStats(file, { bootstrap: BOOTSTRAP })).toThrow(
+      /subjectOrder must name at least one subject/
+    );
+  });
+
+  // A fixture half of which was measured against something else. No reader of
+  // the file could say which half, so the file is refused rather than read.
+  test('rejects a fixture whose rounds name different subjects', () => {
+    const valid = fixture('x', [1, 1], [1, 1]);
+    const file = rawStats([
+      fixture('paired', [1, 1], [1, 1]),
+      {
+        ...valid,
+        rounds: [
+          valid.rounds[0]!,
+          {
+            round: 1,
+            subjectOrder: [CANDIDATE.label],
+            perSubject: { [CANDIDATE.label]: samplesFor(1) },
+          },
+        ],
+      },
+    ]);
+
+    expect(() => evaluateRawStats(file, { bootstrap: BOOTSTRAP })).toThrow(
+      /rounds must name the same subjects in every round/
+    );
+  });
+
   test('rejects malformed nested latency values', () => {
     const validFixture = fixture('x', [1], [1]);
     const firstRound = validFixture.rounds[0];
@@ -473,6 +560,39 @@ describe('evaluateRawStats — validation', () => {
   });
 });
 
+/**
+ * A fixture the base could not compile.
+ *
+ * The release leg measures it for the candidate alone, so the absolute p95
+ * budget keeps the number it holds a ceiling for. A ratio has no second side
+ * to take, so the fixture is named here rather than scored.
+ */
+describe('evaluateRawStats — a fixture measured by one subject', () => {
+  test('names the fixture and scores the rest', () => {
+    const rounds = Array.from({ length: 10 }, () => 1);
+    const report = evaluateRawStats(
+      rawStats([fixture('flat', rounds, rounds), candidateOnlyFixture('engine-fold', rounds)]),
+      { thresholds: tightThresholds, bootstrap: BOOTSTRAP }
+    );
+
+    expect(report.suiteStatus).toBe('pass');
+    expect(report.fixtures.map(entry => entry.name)).toStrictEqual(['flat']);
+    expect(report.uncompared).toStrictEqual(['engine-fold']);
+  });
+
+  // A run where no fixture has two sides compared nothing, whatever its
+  // fixtures say. Reported here rather than as a clean pass over zero rows.
+  test('refuses a file where no fixture has both subjects', () => {
+    const rounds = Array.from({ length: 10 }, () => 1);
+
+    expect(() =>
+      evaluateRawStats(rawStats([candidateOnlyFixture('engine-fold', rounds)]), {
+        bootstrap: BOOTSTRAP,
+      })
+    ).toThrow('Raw stats has no fixture both subjects measured');
+  });
+});
+
 describe('evaluateRawStats — determinism', () => {
   test('same inputs yield identical bootstrap intervals', () => {
     const base = Array.from({ length: 12 }, () => 1);
@@ -506,6 +626,30 @@ describe('renderVerdictMarkdown', () => {
 
   test('escapeMarkdownCell handles backslashes before pipes', () => {
     expect(escapeMarkdownCell('a\\|b')).toBe('a\\\\\\|b');
+  });
+
+  // A reader who counts the rows must be able to see that the suite compared
+  // fewer fixtures than the manifest holds, and which ones it could not.
+  test('names the fixtures it could not compare under the table', () => {
+    const rounds = Array.from({ length: 8 }, () => 1);
+    const report = evaluateRawStats(
+      rawStats([fixture('flat', rounds, rounds), candidateOnlyFixture('engine-fold', rounds)]),
+      { thresholds: tightThresholds, bootstrap: BOOTSTRAP }
+    );
+
+    expect(renderVerdictMarkdown(report)).toContain(
+      'Not compared (measured for candidate only): engine-fold'
+    );
+  });
+
+  test('says nothing about comparisons a run made in full', () => {
+    const rounds = Array.from({ length: 8 }, () => 1);
+    const report = evaluateRawStats(rawStats([fixture('flat', rounds, rounds)]), {
+      thresholds: tightThresholds,
+      bootstrap: BOOTSTRAP,
+    });
+
+    expect(renderVerdictMarkdown(report)).not.toContain('Not compared');
   });
 });
 

--- a/crates/stylex-rs-compiler/benchmark/bench-revisions.ts
+++ b/crates/stylex-rs-compiler/benchmark/bench-revisions.ts
@@ -20,11 +20,19 @@
  * pull-request leg builds the merge base, and the release leg installs the last
  * published version. So they need different readings of a base that refuses a
  * fixture, and `--allow-base-refusals` is which one the caller wants. Under the
- * flag such a fixture is reported under `Not compared` and left out of the run,
- * because stopping the whole leg for a fixture that prices a feature the
- * published version does not carry gave up every other measurement for a fact
- * the manifest already states. Without it every refusal stops the run, which is
- * what keeps a fixture only this branch compiles out of the manifest.
+ * flag such a fixture is reported under `Not compared` and measured for the
+ * candidate alone.
+ *
+ * It leaves the comparison, not the run. Stopping the whole leg gave up every
+ * other measurement for a fact the manifest already states. Dropping the
+ * fixture gave up the candidate's own number, and the absolute p95 budget holds
+ * a ceiling for it. Without the flag every refusal stops the run, which is what
+ * keeps a fixture only this branch compiles out of the manifest.
+ *
+ * Under the flag the base is asked for its rule counts in a child process. The
+ * addon draws a compiler error on stderr before it refuses, and that stream is
+ * the release log, so a refusal this leg expects made a good run read as a
+ * failed one. Only the sanity check moves; the base is timed here.
  *
  * Usage:
  *   pnpm bench:revisions --base <base-pkg-dir> --candidate <candidate-pkg-dir>
@@ -52,8 +60,13 @@ import { captureEnvironment } from './lib/env.js';
 import { loadAllFixtures } from './lib/fixtures.js';
 import { formatLatency } from './lib/format.js';
 import { findNativeBindings, subjectsCanShareProcess } from './lib/native-bindings.js';
-import { runRounds, type RunOptions, type RunResult } from './lib/runner.js';
-import { startSplitRun, type SplitRun } from './lib/subject-process.js';
+import { countRulesInProcess, runRounds, type RunOptions, type RunResult } from './lib/runner.js';
+import {
+  countRulesInChild,
+  readReportedCount,
+  startSplitRun,
+  type SplitRun,
+} from './lib/subject-process.js';
 import { loadSubject, type LoadedSubject } from './lib/subjects.js';
 import {
   RAW_STATS_SCHEMA_VERSION,
@@ -73,11 +86,12 @@ interface PairedRunOptions {
   base: RevisionInput;
   candidate: RevisionInput;
   /**
-   * Whether a fixture the base subject cannot measure leaves the run instead of
-   * stopping it. Off by default, so the strict reading is what a caller gets
-   * without asking: the pull-request leg builds its base from the merge base,
-   * where a fixture only this branch compiles is a manifest question and the
-   * refusal is the guard that catches it.
+   * Whether a fixture the base subject cannot measure leaves the comparison
+   * instead of stopping the run. The candidate is still timed for it, so the
+   * absolute budget keeps its number. Off by default, so the strict reading is
+   * what a caller gets without asking: the pull-request leg builds its base
+   * from the merge base, where a fixture only this branch compiles is a
+   * manifest question and the refusal is the guard that catches it.
    */
   allowBaseRefusals: boolean;
   /**
@@ -186,7 +200,8 @@ async function main(): Promise<void> {
       ...placement.strategies,
       // Under `--allow-base-refusals` the candidate is the only gate: it is the
       // code the numbers are about, so a fixture it refuses still stops the leg,
-      // while one only the base refuses leaves the run with a line saying so.
+      // while one only the base refuses leaves the comparison with a line saying
+      // so, and is measured for the candidate alone.
       // Without the flag no subject is privileged and any refusal stops the run,
       // which is the reading the merge-base leg needs.
       ...(options.allowBaseRefusals ? { requiredSubject: options.candidate.label } : {}),
@@ -194,11 +209,14 @@ async function main(): Promise<void> {
   } finally {
     placement.close();
   }
-  const { fixtures: rawFixtures, excluded } = result;
+  const { fixtures: rawFixtures, uncompared } = result;
 
-  if (excluded.length > 0) {
+  if (uncompared.length > 0) {
     console.log(chalk.yellow.bold('Not compared'));
-    for (const entry of excluded) {
+    // Says what this run did, and no more. Whether the number then meets a
+    // ceiling is the budget step, which only one leg of the release runs.
+    console.log(chalk.dim(`  measured for ${options.candidate.label} alone`));
+    for (const entry of uncompared) {
       console.log(`  ${entry.fixture} — ${entry.subject}: ${entry.reason}`);
     }
     console.log('');
@@ -225,10 +243,10 @@ async function main(): Promise<void> {
     subjects: placement.subjects.map(subject => subject.descriptor),
     fixtures: rawFixtures,
     // Written beside the numbers rather than only to the log, so a comparison
-    // that measured fewer fixtures than the manifest holds says so in the file
+    // that compared fewer fixtures than the manifest holds says so in the file
     // a reviewer downloads. Read by nobody: the schema does not carry it, and
     // the parser keeps the keys it knows.
-    ...(excluded.length > 0 ? { excluded } : {}),
+    ...(uncompared.length > 0 ? { uncompared } : {}),
   };
 
   const resultsDir = path.join(benchmarkDir, 'results');
@@ -247,6 +265,10 @@ interface SubjectPlacement {
 
 /**
  * Loads both subjects, or arranges for each to be measured on its own.
+ *
+ * Where the base may refuse, its rule counts are read in a child process even
+ * though both subjects share this one. The answer is the same; what changes is
+ * that the compiler error beside it does not reach this run's stderr.
  *
  * The single process is the path every platform but macOS takes, and the one
  * every release has gated on. The split path exists because two bindings that
@@ -282,7 +304,35 @@ async function placeSubjects(input: {
     subjects.push(await loadSubject({ label: revision.label, packageDir: revision.packageDir }));
   }
 
-  return { subjects, strategies: {}, close: () => undefined };
+  if (!input.options.allowBaseRefusals) {
+    return { subjects, strategies: {}, close: () => undefined };
+  }
+
+  // The base is a published version that is behind this build, so a fixture it
+  // cannot compile is expected and is reported under `Not compared`. Asked in
+  // this process, the addon draws a compiler error on this run's stderr before
+  // it refuses, and a leg that did nothing wrong reads as a failed one. Asked
+  // in a child, the same refusal arrives as a value. Only the sanity check
+  // moves: the base is timed here, for the fixtures it accepted.
+  const base = input.options.base;
+  const reported = countRulesInChild({
+    subject: { label: base.label, packageDir: base.packageDir },
+    fixtures: input.fixtures,
+    stylexOptions: input.stylexOptions,
+    timeBudgetMs: input.options.timeBudgetMs,
+  });
+  const inProcess = countRulesInProcess(input.stylexOptions);
+
+  return {
+    subjects,
+    strategies: {
+      countRules: (subject, fixture) =>
+        subject.descriptor.label === base.label
+          ? readReportedCount(reported, base.label, fixture)
+          : inProcess(subject, fixture),
+    },
+    close: () => undefined,
+  };
 }
 
 function parseCli(argv: readonly string[]): PairedRunOptions {

--- a/crates/stylex-rs-compiler/benchmark/lib/budget.ts
+++ b/crates/stylex-rs-compiler/benchmark/lib/budget.ts
@@ -38,7 +38,7 @@ import {
   requireRecord,
   requireString,
 } from './json.js';
-import { parseRawStats } from './raw-stats.js';
+import { measuredBy, parseRawStats } from './raw-stats.js';
 import { median } from './stats.js';
 import type {
   FixtureRawStats,
@@ -229,13 +229,25 @@ export function evaluateBudget(rawStatsInput: unknown, budgetInput: unknown): Bu
   const budget = parseBudget(budgetInput, 'budget');
   const subject = selectSubject(raw, budget);
 
+  // A paired run can hold a fixture only one of its subjects measured, because
+  // the release leg compares against a published version that is behind by
+  // whole features. The ceilings describe one subject, so the fixtures this
+  // check is about are the ones that subject measured.
+  //
+  // Coverage keeps both of its questions over that set. A ceiling for a fixture
+  // the subject did not measure is still reported as an entry nothing measured,
+  // because nothing held it. A fixture the subject did not measure and has no
+  // ceiling for asks nothing: a ceiling can only describe a number, and there
+  // is none.
+  const measured = raw.fixtures.filter(fixture => measuredBy(fixture, subject.label));
+
   const problems: BudgetProblem[] = [
     ...checkEnvironment(raw.environment, budget.canonical),
-    ...(budget.state === 'enforced' ? checkCoverage(raw.fixtures, budget.entries) : []),
+    ...(budget.state === 'enforced' ? checkCoverage(measured, budget.entries) : []),
   ];
 
   const ceilings = new Map(budget.entries.map(entry => [entry.name, entry.ceilingMs]));
-  const fixtures = raw.fixtures.map(fixture => {
+  const fixtures = measured.map(fixture => {
     const report = measureFixture(fixture, subject.label, budget.state, ceilings.get(fixture.name));
     if (report.status === 'breach' && report.ceilingMs !== undefined) {
       problems.push(

--- a/crates/stylex-rs-compiler/benchmark/lib/raw-stats.ts
+++ b/crates/stylex-rs-compiler/benchmark/lib/raw-stats.ts
@@ -78,6 +78,19 @@ export function parseRawStats(
   };
 }
 
+/**
+ * Whether `label` measured every round of `fixture`.
+ *
+ * A paired run can hold a fixture only one of its subjects measured, because
+ * the release leg compares against a published version that is behind by whole
+ * features. Both readers of the file ask this question. The verdict engine asks
+ * it to find the fixtures it can take a ratio for, and the budget asks it to
+ * find the ones its ceilings describe. One answer, so the two cannot disagree.
+ */
+export function measuredBy(fixture: FixtureRawStats, label: string): boolean {
+  return fixture.rounds.every(round => round.perSubject[label] !== undefined);
+}
+
 function parseSubject(value: unknown, context: string): SubjectDescriptor {
   const subject = requireRecord(value, context);
   return {
@@ -158,6 +171,20 @@ function parseFixture(
       throw new Error(`${context}.rounds must use contiguous zero-based indices`);
     }
   }
+  // A fixture a subject refused is measured by the subjects that answered, and
+  // by those same subjects in every round of it. Rounds that disagree describe
+  // a fixture half of which was measured against something else, and no reader
+  // of this file could tell which half.
+  const firstOrder = [...rounds[0]!.subjectOrder].toSorted();
+  for (const round of rounds) {
+    const order = [...round.subjectOrder].toSorted();
+    if (
+      order.length !== firstOrder.length ||
+      order.some((label, index) => label !== firstOrder[index])
+    ) {
+      throw new Error(`${context}.rounds must name the same subjects in every round`);
+    }
+  }
 
   return {
     name: requireString(fixture.name, `${context}.name`),
@@ -180,20 +207,31 @@ function parseRound(
   const subjectOrder = requireArray(round.subjectOrder, `${context}.subjectOrder`).map(
     (label, index) => requireString(label, `${context}.subjectOrder[${index}]`)
   );
-  const expectedLabels = subjects.map(subject => subject.label).toSorted();
-  if (
-    subjectOrder.length !== expectedLabels.length ||
-    subjectOrder.toSorted().some((label, index) => label !== expectedLabels[index])
-  ) {
-    throw new Error(`${context}.subjectOrder must contain each subject label exactly once`);
+  // A subset rather than the whole set: the release leg compares against the
+  // last published version, and a fixture that prices a feature that version
+  // does not carry is measured by the candidate alone. What the round may not
+  // do is name a subject the file does not declare, or name one two times.
+  const declared = new Set(subjects.map(subject => subject.label));
+  if (subjectOrder.length === 0) {
+    throw new Error(`${context}.subjectOrder must name at least one subject`);
+  }
+  if (new Set(subjectOrder).size !== subjectOrder.length) {
+    throw new Error(`${context}.subjectOrder must name each subject at most one time`);
+  }
+  for (const label of subjectOrder) {
+    if (!declared.has(label)) {
+      throw new Error(
+        `${context}.subjectOrder names ${JSON.stringify(label)}, which is not a subject of this file`
+      );
+    }
   }
 
   const rawPerSubject = requireRecord(round.perSubject, `${context}.perSubject`);
   const perSubject: Record<string, RawLatencySamples> = {};
-  for (const subject of subjects) {
-    perSubject[subject.label] = parseSamples(
-      rawPerSubject[subject.label],
-      `${context}.perSubject[${JSON.stringify(subject.label)}]`
+  for (const label of subjectOrder) {
+    perSubject[label] = parseSamples(
+      rawPerSubject[label],
+      `${context}.perSubject[${JSON.stringify(label)}]`
     );
   }
 

--- a/crates/stylex-rs-compiler/benchmark/lib/runner.ts
+++ b/crates/stylex-rs-compiler/benchmark/lib/runner.ts
@@ -13,13 +13,26 @@
  * stops a broken no-op subject from appearing fast.
  *
  * `requiredSubject` names the one subject the check is a gate for — the
- * revision under measurement. A fixture the *other* subject cannot compile is
- * dropped from the run instead of stopping it, because a comparison needs both
- * sides and the release leg compares against the last published version, which
- * can be several features behind. A fixture the required subject refuses is
- * still a hard failure: that one is a regression in the code under test. A
- * caller that names no required subject keeps the older behaviour, where any
- * refusal stops the run.
+ * revision under measurement. A fixture the *other* subject cannot compile
+ * leaves the comparison instead of stopping the run, because a comparison
+ * needs both sides and the release leg compares against the last published
+ * version, which can be several features behind. It does not leave the run:
+ * the subjects that did answer for it are still timed, because the absolute
+ * budget is about one subject and a fixture that prices a new feature is
+ * exactly the one a published base cannot compile. A fixture the required
+ * subject refuses is still a hard failure: that one is a regression in the
+ * code under test. A caller that names no required subject keeps the older
+ * behaviour, where any refusal stops the run.
+ *
+ * A run where no fixture at all is comparable by every subject still fails.
+ * That is a broken base rather than a manifest question, and a release must
+ * not read as a clean comparison when it compared nothing.
+ *
+ * A fixture that kept one subject is timed alone, so its rounds do not
+ * alternate two bindings the way a compared fixture's rounds do. Read its
+ * number against an absolute ceiling, not against the paired fixtures around
+ * it: a subject that shares no cache with a second binding is, if anything,
+ * a little faster, so the ceiling keeps its margin.
  *
  * A fixture may override `dev` for itself (`FixtureDescriptor.dev`). The
  * override is resolved in one place, `fixtureStylexOptions`, and used by
@@ -49,6 +62,18 @@ import type {
  * @throws Error carrying what the subject said when it cannot compile it.
  */
 export type RuleCounter = (subject: LoadedSubject, fixture: FixtureDescriptor) => number;
+
+/**
+ * The counter a run uses unless the caller hands in another one: ask the
+ * subject in this process.
+ *
+ * Exported because a caller that answers for one subject in a child process
+ * must answer for the others the way the runner would, and two spellings of
+ * that would be two configurations a fixture could be validated under.
+ */
+export function countRulesInProcess(stylexOptions: StyleXOptions): RuleCounter {
+  return (subject, fixture) => subject.run(fixture, fixtureStylexOptions(fixture, stylexOptions));
+}
 
 /** How one round of one fixture is timed, for the subjects in the order given. */
 export type RoundMeasurer = (
@@ -93,8 +118,13 @@ export interface RunOptions {
   measureRound?: RoundMeasurer;
 }
 
-/** One fixture that left a run, and the subject whose answer removed it. */
-export interface ExcludedFixture {
+/**
+ * One fixture that lost a subject, and the answer that removed it.
+ *
+ * The fixture stays in the run and the remaining subjects are timed for it.
+ * What it lost is the comparison: a ratio needs both sides.
+ */
+export interface UncomparedFixture {
   readonly fixture: string;
   readonly subject: string;
   /** What that subject did: a refusal sentence, or the rule count it emitted. */
@@ -106,18 +136,18 @@ export interface ExcludedFixture {
  *
  * Both readings of the same answer, because which one is wanted depends on who
  * the subject is: the run stops with `failure` where the subject is the one
- * under measurement, and reports `excluded` where it is not.
+ * under measurement, and reports `uncompared` where it is not.
  */
 interface SubjectRefusal {
   readonly subject: string;
   readonly failure: Error;
-  readonly excluded: ExcludedFixture;
+  readonly uncompared: UncomparedFixture;
 }
 
 export interface RunResult {
   fixtures: FixtureRawStats[];
   /** Empty on a run where every subject measured every fixture. */
-  excluded: ExcludedFixture[];
+  uncompared: UncomparedFixture[];
 }
 
 export async function runRounds(options: RunOptions): Promise<RunResult> {
@@ -127,15 +157,20 @@ export async function runRounds(options: RunOptions): Promise<RunResult> {
   if (options.rounds < 1) {
     throw new Error('runRounds requires rounds >= 1');
   }
+  // Stated here rather than left to the plan below, whose own failure is about
+  // a base that refuses every fixture and would name none in that message.
+  if (options.fixtures.length === 0) {
+    throw new Error('runRounds requires at least one fixture');
+  }
 
-  const { measurable, excluded } = selectMeasurableFixtures(options);
+  const { planned, uncompared } = planFixtures(options);
 
   const rng = makeSeededRng(options.seed);
   const fixtures: FixtureRawStats[] = [];
 
-  for (const fixture of measurable) {
+  for (const { fixture, subjects } of planned) {
     const roundStats: FixtureRoundStats[] = [];
-    const schedule = createBalancedSchedule(options.subjects, options.rounds, rng);
+    const schedule = createBalancedSchedule(subjects, options.rounds, rng);
     const measure = options.measureRound ?? ((one, order) => runSingleRound(one, order, options));
     for (const [round, order] of schedule.entries()) {
       // Normalised here rather than in either measurer, so a fixture that
@@ -154,27 +189,36 @@ export async function runRounds(options: RunOptions): Promise<RunResult> {
       category: fixture.category,
       batchSize: fixture.batchSize,
       rounds: roundStats,
-      paired: computePairedStats(options.subjects, roundStats, options.bootstrap),
+      paired: computePairedStats(subjects, roundStats, options.bootstrap),
     });
   }
 
-  return { fixtures, excluded };
+  return { fixtures, uncompared };
 }
 
-interface FixtureSelection {
-  /** The fixtures every subject answered for, in manifest order. */
-  measurable: FixtureDescriptor[];
-  excluded: ExcludedFixture[];
+/** One fixture of a run, and the subjects that answered for it. */
+interface FixturePlan {
+  fixture: FixtureDescriptor;
+  /** A non-empty subset of the run's subjects, in the run's own order. */
+  subjects: readonly LoadedSubject[];
 }
 
-function selectMeasurableFixtures(options: RunOptions): FixtureSelection {
-  const measurable: FixtureDescriptor[] = [];
-  const excluded: ExcludedFixture[] = [];
+interface RunPlan {
+  /** Every fixture that at least one subject answered for, in manifest order. */
+  planned: FixturePlan[];
+  uncompared: UncomparedFixture[];
+}
+
+function planFixtures(options: RunOptions): RunPlan {
+  const planned: FixturePlan[] = [];
+  const uncompared: UncomparedFixture[] = [];
+  let anyCompared = false;
 
   for (const fixture of options.fixtures) {
     const refusals = subjectRefusals(fixture, options);
     if (refusals.length === 0) {
-      measurable.push(fixture);
+      planned.push({ fixture, subjects: options.subjects });
+      anyCompared = true;
       continue;
     }
     // A refusal by the subject under measurement stops the run: whatever the
@@ -184,31 +228,40 @@ function selectMeasurableFixtures(options: RunOptions): FixtureSelection {
     const gating =
       options.requiredSubject === undefined
         ? refusals[0]
-        : refusals.find(entry => entry.subject === options.requiredSubject);
+        : refusals.find(answer => answer.subject === options.requiredSubject);
     if (gating !== undefined) throw gating.failure;
     // Only the first refusal is reported. A second subject saying the same
     // thing about the same fixture adds a line and no information, and the
-    // fixture leaves the run either way.
-    excluded.push(refusals[0]!.excluded);
+    // fixture loses its comparison either way.
+    uncompared.push(refusals[0]!.uncompared);
+
+    // The subjects that did answer are still timed. The required subject is
+    // among them, because a refusal by that one threw above, so the absolute
+    // budget still receives a measurement for this fixture.
+    const refused = new Set(refusals.map(answer => answer.subject));
+    planned.push({
+      fixture,
+      subjects: options.subjects.filter(subject => !refused.has(subject.descriptor.label)),
+    });
   }
 
-  if (measurable.length === 0) {
+  if (!anyCompared) {
     throw new Error(
       'Sanity check failed: no fixture is measurable by every subject — ' +
-        excluded.map(entry => `"${entry.fixture}" (${entry.subject}: ${entry.reason})`).join(', ')
+        uncompared
+          .map(fixture => `"${fixture.fixture}" (${fixture.subject}: ${fixture.reason})`)
+          .join(', ')
     );
   }
 
-  return { measurable, excluded };
+  return { planned, uncompared };
 }
 
 /** What each subject that cannot measure `fixture` said, in subject order. */
 function subjectRefusals(fixture: FixtureDescriptor, options: RunOptions): SubjectRefusal[] {
   const refusals: SubjectRefusal[] = [];
 
-  const count =
-    options.countRules ??
-    ((subject, entry) => subject.run(entry, fixtureStylexOptions(entry, options.stylexOptions)));
+  const count = options.countRules ?? countRulesInProcess(options.stylexOptions);
 
   for (const subject of options.subjects) {
     const label = subject.descriptor.label;
@@ -224,7 +277,7 @@ function subjectRefusals(fixture: FixtureDescriptor, options: RunOptions): Subje
       refusals.push({
         subject: label,
         failure: new Error(refusal(label, fixture, 'could not compile'), { cause: error }),
-        excluded: { fixture: fixture.name, subject: label, reason: sentenceOf(error) },
+        uncompared: { fixture: fixture.name, subject: label, reason: sentenceOf(error) },
       });
       continue;
     }
@@ -233,7 +286,7 @@ function subjectRefusals(fixture: FixtureDescriptor, options: RunOptions): Subje
       refusals.push({
         subject: label,
         failure: new Error(refusal(label, fixture, predicate)),
-        excluded: {
+        uncompared: {
           fixture: fixture.name,
           subject: label,
           reason: `emitted ${String(rules)} StyleX rules`,
@@ -359,8 +412,11 @@ function createBalancedSchedule<T>(
 }
 
 /**
- * Roles are recorded for every two-subject run; the bootstrap statistics
- * only when a config asks for them.
+ * Roles are recorded for every fixture two subjects measured; the bootstrap
+ * statistics only when a config asks for them.
+ *
+ * A fixture one subject refused carries no roles, because it carries no
+ * comparison. The budget resolves its subject from the fixtures that do.
  *
  * The two are separable on purpose. `base`/`candidate` are identity — the
  * budget check resolves which subject its ceilings describe from them, and

--- a/crates/stylex-rs-compiler/benchmark/lib/subject-process.ts
+++ b/crates/stylex-rs-compiler/benchmark/lib/subject-process.ts
@@ -497,6 +497,64 @@ export interface SplitSubject {
   packageDir: string;
 }
 
+/**
+ * One subject's rule count for every fixture, read in a child process.
+ *
+ * A fixture the subject cannot compile is the reason this exists. In this
+ * process the addon draws a code frame on stderr before it throws. That stream
+ * is the release log. So a leg that expects the refusal printed a compiler
+ * error for a fixture it then reported under `Not compared`, and a good run
+ * read as a failed one. The child writes its report to a file, and its stderr
+ * is read only when it fails. The refusal then arrives as a value.
+ *
+ * @throws Error when the child stops without writing a report.
+ */
+export function countRulesInChild(input: {
+  subject: SplitSubject;
+  fixtures: readonly FixtureDescriptor[];
+  stylexOptions: StyleXOptions;
+  timeBudgetMs: number;
+}): Record<string, WorkerCount> {
+  const run = openWorkerRuns();
+  try {
+    const report = callWorker(run, {
+      protocol: WORKER_PROTOCOL_VERSION,
+      packageDir: input.subject.packageDir,
+      label: input.subject.label,
+      fixtures: input.fixtures,
+      stylexOptions: input.stylexOptions,
+      timeBudgetMs: input.timeBudgetMs,
+      task: { kind: 'count-rules' },
+    });
+
+    return report.counts ?? {};
+  } finally {
+    closeWorkerRuns(run);
+  }
+}
+
+/**
+ * What a child reported about one fixture, as the sanity check needs it.
+ *
+ * A refusal comes back as the sentence the subject said, thrown here, so the
+ * runner cannot tell a child's answer from an answer this process took.
+ *
+ * @throws Error when the subject refused the fixture, or said nothing about it.
+ */
+export function readReportedCount(
+  counts: Record<string, WorkerCount>,
+  label: string,
+  fixture: FixtureDescriptor
+): number {
+  const count = counts[fixture.name];
+  if (count === undefined) {
+    throw new Error(`Subject "${label}" said nothing about fixture "${fixture.name}"`);
+  }
+  if (isWorkerRefusal(count)) throw new Error(count.refusal);
+
+  return count;
+}
+
 export interface SplitRun {
   /** Descriptors for the runner. Their `run` is never called. */
   subjects: LoadedSubject[];
@@ -533,16 +591,15 @@ export function startSplitRun(input: {
   // refuses, because the caller has nothing to close until this returns.
   try {
     for (const subject of input.subjects) {
-      const report = callWorker(run, {
-        protocol: WORKER_PROTOCOL_VERSION,
-        packageDir: subject.packageDir,
-        label: subject.label,
-        fixtures: input.fixtures,
-        stylexOptions: input.stylexOptions,
-        timeBudgetMs: input.timeBudgetMs,
-        task: { kind: 'count-rules' },
-      });
-      counts.set(subject.label, report.counts ?? {});
+      counts.set(
+        subject.label,
+        countRulesInChild({
+          subject,
+          fixtures: input.fixtures,
+          stylexOptions: input.stylexOptions,
+          timeBudgetMs: input.timeBudgetMs,
+        })
+      );
     }
   } catch (error) {
     closeWorkerRuns(run);
@@ -568,13 +625,7 @@ export function startSplitRun(input: {
 
     countRules(subject, fixture) {
       const label = subject.descriptor.label;
-      const count = counts.get(label)?.[fixture.name];
-      if (count === undefined) {
-        throw new Error(`Subject "${label}" said nothing about fixture "${fixture.name}"`);
-      }
-      if (isWorkerRefusal(count)) throw new Error(count.refusal);
-
-      return count;
+      return readReportedCount(counts.get(label) ?? {}, label, fixture);
     },
 
     async measureRound(fixture, order) {

--- a/crates/stylex-rs-compiler/benchmark/lib/verdict.ts
+++ b/crates/stylex-rs-compiler/benchmark/lib/verdict.ts
@@ -15,7 +15,7 @@
  */
 
 import { escapeMarkdownCell, markdownTableRow } from './format.js';
-import { parseRawStats } from './raw-stats.js';
+import { measuredBy, parseRawStats } from './raw-stats.js';
 import { bootstrapMedianRatio, ensureFinitePositive, median, roundRatios } from './stats.js';
 import type {
   BootstrapConfig,
@@ -78,6 +78,14 @@ export interface VerdictReport {
     candidate: SubjectDescriptor;
   };
   fixtures: readonly FixtureVerdict[];
+  /**
+   * Fixtures the run measured for one subject only, in the order they appear.
+   *
+   * A ratio needs both sides, so these carry no verdict. They are named here
+   * because a reader who counts the rows must be able to see that the suite
+   * compared fewer fixtures than the manifest holds, and why.
+   */
+  uncompared: readonly string[];
   /** Fixture names flagged by the primary evaluation. */
   flagged: readonly string[];
   /** True when at least one flagged fixture reproduces the failure. */
@@ -108,13 +116,24 @@ export function evaluateRawStats(primaryInput: unknown, options: EvaluateOptions
   validateThresholds(thresholds);
   const fixtures: FixtureVerdict[] = [];
   const flagged: string[] = [];
+  const uncompared: string[] = [];
 
   for (const rawFixture of primary.fixtures) {
+    // A fixture the base could not compile is measured for the candidate alone,
+    // so the absolute budget still has a number for it. A ratio does not: there
+    // is no base side to divide by. It is named, not evaluated.
+    if (!measuredBy(rawFixture, base.label) || !measuredBy(rawFixture, candidate.label)) {
+      uncompared.push(rawFixture.name);
+      continue;
+    }
     const verdict = evaluateFixture(rawFixture, base, candidate, thresholds, options.bootstrap);
     if (verdict.status === 'flagged') {
       flagged.push(verdict.name);
     }
     fixtures.push(verdict);
+  }
+  if (fixtures.length === 0) {
+    throw new Error('Raw stats has no fixture both subjects measured');
   }
 
   let hasReproducedFailure = false;
@@ -168,6 +187,7 @@ export function evaluateRawStats(primaryInput: unknown, options: EvaluateOptions
     bootstrap: options.bootstrap,
     subjects: { base, candidate },
     fixtures,
+    uncompared,
     flagged,
     hasReproducedFailure,
   };
@@ -359,5 +379,16 @@ export function renderVerdictMarkdown(report: VerdictReport): string {
     ]);
   });
 
-  return [...header, ...rows, ''].join('\n');
+  // Named under the table rather than left out of it: a reader who counts the
+  // rows must be able to see which fixtures the suite could not compare.
+  const uncompared =
+    report.uncompared.length === 0
+      ? []
+      : [
+          '',
+          `Not compared (measured for ${candidate} only): ` +
+            report.uncompared.map(name => escapeMarkdownCell(name)).join(', '),
+        ];
+
+  return [...header, ...rows, ...uncompared, ''].join('\n');
 }

--- a/guidelines/PERFORMANCE.md
+++ b/guidelines/PERFORMANCE.md
@@ -169,7 +169,7 @@ before timing anything. A shape that only a fix makes compilable is a
 correctness question, so it belongs to `crates/stylex-transform/tests/fixture`
 and stays there; `perf_fixtures/dynamic-styles.js` states this rule in its own
 header and leaves that shape out while still pricing the inline-style path.
-`selectMeasurableFixtures` names the fixture and the subject that refused it.
+`planFixtures` names the fixture and the subject that refused it.
 
 **Only the release leg allows a base refusal, and it passes a flag to get
 it.** The pull-request leg builds the merge base, where the rule above holds
@@ -178,12 +178,26 @@ version_, which does not have the features that landed since. A fixture that
 prices one of those features then has no base to compare against. One `.trim()`
 in `perf_fixtures/engine-fold.js` stopped the whole publish benchmark that way.
 That leg passes `--allow-base-refusals`. The run then reports the fixture under
-`Not compared`, writes it into the raw stats beside the numbers, and leaves it
-out of the comparison. The fixture returns once the published baseline has the
-feature. The flag is off by default, and it never lifts the gate on the
-candidate: a fixture _it_ refuses, or compiles to no rules, is a regression and
-fails the leg. A run where no fixture survives also fails, because a base that
-refuses everything is a broken subject.
+`Not compared` and writes it into the raw stats as `uncompared`, beside the
+numbers.
+
+What the fixture loses is the comparison, not the run. The candidate is still
+timed for it, because the absolute budget describes the candidate alone and
+holds a ceiling for every fixture in the manifest. A fixture dropped from the
+run reached that check as an entry nothing measured, and failed the release a
+second way. The verdict engine names such a fixture under its table and takes
+no ratio for it, because a ratio needs both sides.
+
+The flag is off by default, and it never lifts the gate on the candidate: a
+fixture _it_ refuses, or compiles to no rules, is a regression and fails the
+leg. A run where no fixture at all is comparable by every subject also fails,
+because a base that refuses everything is a broken subject.
+
+Under the flag the base is asked for its rule counts in a child process. The
+compiler draws a code frame on stderr before it refuses, and that stream is the
+release log, so a refusal this leg expects made a good run read as a failed
+one. Only the sanity check moves; the base is timed in the process that holds
+it.
 
 **Register a feature fixture in pairs.** One number for a development shape says
 nothing about what the feature costs; the pair does. A `Feature - x` entry and a
@@ -199,8 +213,8 @@ reach.
 `benchmark/budget.json` is `enforced`. It holds one ceiling for each of the 65
 benchmark fixtures, seeded on 2026-09-10: the largest median-of-round p95 that
 any seeding run gave, times a headroom of 1.25. Sixty-one ceilings come from
-ten runs and four from three runs, because the four fold fixtures could not be
-measured until the published base could fold. A breach fails the leg and,
+ten runs and four from three runs, because the four fold fixtures had no
+seeding run before the release leg could measure them. A breach fails the leg and,
 through the publish job, blocks the release. While the file is
 `pending-calibration` instead, it holds no ceilings, `bench:budget` reports
 `unseeded`, and the leg passes.


### PR DESCRIPTION
The release benchmark compares this build against the last published version, which is behind by whole features. A fixture that prices one of those features has no base to compare against, so `--allow-base-refusals` let it leave. It left the whole run, not only the comparison, and the candidate's own number left with it.

The absolute p95 budget reads the candidate alone and holds a ceiling for each of the 65 manifest fixtures. Four fixtures that price the engine fold then reached that check as entries nothing had measured, and release 0.19.0-rc.3 failed. The budget became `enforced` after 0.19.0-rc.2, so rc.3 is the first release to meet this.

A fixture a subject refuses now keeps the subjects that answered for it. The run reports it under `Not compared`, the verdict engine names it and takes no ratio, and the budget holds it to its ceiling like any other. A run where no fixture at all is comparable by every subject still fails, because a base that refuses everything is a broken subject.

The raw-stats reader accepts a round measured by some of the file's subjects, and requires every round of one fixture to name the same ones. A fixture that kept one subject carries no paired block, because it carries no pair.

The same job printed a compiler error for each refusal it expected. The addon draws a code frame on stderr before it throws, and that stream is the release log, so a leg that did nothing wrong read as a failed one. Under the flag the base is now asked for its rule counts in a child process, where the answer is a value. Only the sanity check moves; the base is timed in the process that holds it.

## Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Fixes

(Optional) Fixes # (issue)

## Additional Info

(Optional) Add any other relevant information about the pull request here.

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
